### PR TITLE
Remove non-GitHub IDs from CODEOWNERS File

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @acmanjun @daniela1 @tjbarnes @sduraisa @manojgop @kmurthy2 @rsriniv3 @yyyarmos @manju956 @danintel @TomBarnes @srinathduraisamy @manojgop @Karthika @ram-srini @EugeneYYY
+* @manju956 @danintel @TomBarnes @srinathduraisamy @manojgop @Karthika @ram-srini @EugeneYYY


### PR DESCRIPTION
The non-GitHUB IDs are leftover from the previous
source repository host.

Signed-off-by: danintel <daniel.anderson@intel.com>