### PR TITLE
Example Documentation Fixes

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -172,6 +172,7 @@ See [examples/apps/heart_disease_eval](examples/apps/heart_disease_eval)
 - If you see the message
   `ModuleNotFoundError: No module named '...'`, you did not run
   `source _dev/bin/activate`
+  or you did not successfully build Avalon
 
 ## <a name="troubleshootingstandalone"></a>Troubleshooting: Standalone build
 - Verify your [environment variables](PREREQUISITES.md#environment)

--- a/examples/apps/echo/README.md
+++ b/examples/apps/echo/README.md
@@ -16,20 +16,25 @@ To use:
     information in `docker/Dockerfile.tcf-dev` and
     `examples/common/python/connectors/tcf_connector.toml`
 2.  Follow instructions in the "Docker-based Build and Execution" section of
-    the [build document](../../../BUILD.md#dockerbuild) through step 4
+    the [build document](../../../BUILD.md#dockerbuild) through step 5
     (activating a virtual environment)
-3.  Terminal 1 is running the TCF Enclave Manager and Listener with
+3.  Terminal 1 is running the Avalon Enclave Manager and Listener with
     `docker-compose` . Terminal 2 is running the Docker container shell
-    with the `(_dev)` prompt
 4.  In Terminal 2 run `cd $TCF_HOME/examples/apps/echo/client`
 5.  In Terminal 2, run `./echo_client.py -m "Hello world"` .
     Use the `-h` option to see other available options
 
-6.  You will see output showing:
+6.  You will see output showing the following:
     1. The client searches the registry for an "echo" worker
-    2. Sends a request to the worker
-    3. Waits for and receives a response.
-    4. The messages sent and received are encrypted with the key specified
+    2. The client sends a request to the worker
+    3. The client waits for and receives a response in JSON format
+    4. The decrypted response from the worker:
+       ```
+       [13:27:37 INFO    utility.utility]
+       Decryption result at client - RESULT: Hello World
+       ```
+    5. The worker receipt in JSON format
+    6. Messages sent and received are encrypted with the key specified
        in the JSON packet, then encoded in Base64.
-7.  In Terminal 1, press Ctrl-c to stop the TCF Enclave Manager and Listener
+7.  In Terminal 1, press Ctrl-c to stop the Avalon Enclave Manager and Listener
 

--- a/examples/apps/generic_client/README.md
+++ b/examples/apps/generic_client/README.md
@@ -5,9 +5,7 @@ workload application. The intention is to get up to speed quickly
 in application development by providing a generic client that works
 with any worker.
 
-## Using the Client
-
-The command line client, `generic_client.py` sends a message to the worker.
+The command line client, `generic_client.py`, sends a message to the worker.
 For command line options, type `./generic_client.py -h` from this directory.
 
 ```
@@ -49,8 +47,25 @@ worker details of first worker in the list, and submit work order.
 
 If `--uri` is passed, `--mode` is not used. It will fetch the worker details
 from the LMDB database and submit work order to the first available worker.
-The TCF Listener uses TCP port 1947, so the URI is usually
+The Avalon Listener uses TCP port 1947, so the default URI is
 `http://localhost:1947` .
+
+## Using the Generic Client
+
+The command line client `generic_client.py` allows you to submit
+worker requests on the command line.
+
+1. If needed, update the Ethereum account and direct registry contract
+   information in `docker/Dockerfile.tcf-dev` and
+   `examples/common/python/connectors/tcf_connector.toml`
+2. Follow the build instructions in the
+   [build document](../../../BUILD.md)
+3. Change to the Generic Client directory
+   ```bash
+   cd $TCF_HOME/examples/apps/generic_client
+   ```
+4. Run `./generic_client.py` using the appropriate command line options
+   documented here. For a list of options, type `./generic_client.py -h`
 
 ## Examples
 
@@ -58,6 +73,10 @@ The TCF Listener uses TCP port 1947, so the URI is usually
 ```
 ./generic_client.py --uri "http://localhost:1947" \
     --workload_id "echo-result" --in_data "Hello"
+```
+Or omit the URI if you use the default:
+```
+./generic_client.py --uri --workload_id "echo-result" --in_data "Hello"
 ```
 
 ### Heart disease eval workload using a URI

--- a/examples/apps/heart_disease_eval/README.md
+++ b/examples/apps/heart_disease_eval/README.md
@@ -1,10 +1,10 @@
-# Running the Heart Evaluation Demo
+# Running the Heart Disease Evaluation Demo
 
 This demo performs a heart disease evaluation based on input parameters.
 Three clients are available: batch command line client, interactive command line client, and GUI client.
 
 
-## Using the Heart Evaluation Batch Command Line Client
+## Using the Heart Disease Evaluation Batch Command Line Client
 
 The command line client, `Demo.py`, runs a set of pre-built JSON requests.
 To run, follow the instructions in the "Testing" section of the
@@ -12,7 +12,7 @@ To run, follow the instructions in the "Testing" section of the
 You may run the CLI demo in standalone mode or in a Docker container.
 
 
-## Using the Heart Evaluation Interactive Command Line Client
+## Using the Heart Disease Evaluation Interactive Command Line Client
 
 The command line client `generic_client.py` allows you to submit
 requests on the command line.
@@ -21,11 +21,10 @@ requests on the command line.
     information in `docker/Dockerfile.tcf-dev` and
     `examples/common/python/connectors/tcf_connector.toml`
 2.  Follow instructions in the "Docker-based Build and Execution" section of
-    the [build document](../../../BUILD.md#dockerbuild) through step 4
+    the [build document](../../../BUILD.md#dockerbuild) through step 5
     (activating a virtual environment)
-3.  Terminal 1 is running the TCF Enclave Manager and Listener with
+3.  Terminal 1 is running the Avalon Enclave Manager and Listener with
     `docker-compose` . Terminal 2 is running the Docker container shell
-    with the `(_dev)` prompt
 4.  In Terminal 2, set environment variable `WALLET_PRIVATE_KEY` if not set.
     This should match the value in file `docker/Dockerfile.tcf-dev`
     from step 3 above:
@@ -35,25 +34,24 @@ requests on the command line.
 5.  In Terminal 2 run `cd $TCF_HOME/examples/apps/generic_client`
 6.  In Terminal 2, run
     ``` bash
-    ./generic_client.py --uri "http://localhost:1947" \
-        --workload_id "heart-disease-eval" \
+    ./generic_client.py --workload_id "heart-disease-eval" \
         --in_data "Data: 25 10 1 67 102 125 1 95 5 10 1 11 36 1"
     ```
 7.  The data will be submitted to the worker and the results will appear shortly:
     ```
     [04:31:55 INFO    utility.utility] Decryption result at client -
-    You have a risk of 46% to have heart disease.
+    You have a 46% risk of heart disease.
     ```
 8.  Optionally submit another request.
     Use the `--help` option to see other available options
-9.  In Terminal 1, press Ctrl-c to stop the TCF Enclave Manager and Listener
+9.  In Terminal 1, press Ctrl-c to stop the Avalon Enclave Manager and Listener
 
-## Using the Heart Evaluation GUI Client
+## Using the Heart Disease Evaluation GUI Client
 
 The GUI client, `heart_gui.py` opens a X window on your display.
 You must run this on your graphical console or a terminal emulator that
 supports X Windows.
-The TCF Enclave Manager and TCF Listener run in a Docker container.
+The Avalon Enclave Manager and Avalon Listener run in a Docker container.
 
 1.  If needed, in file `docker/Dockerfile.tcf-dev` change `ENV DISPLAY`
     to the X Windows `$DISPLAY` value. By default, it is the console, `:0`
@@ -63,9 +61,8 @@ The TCF Enclave Manager and TCF Listener run in a Docker container.
 3.  Follow instructions in the "Docker-based Build and Execution" section of
     the [build document](../../../BUILD.md#dockerbuild) through step 4
     (activating a virtual environment)
-4.  Terminal 1 is running the TCF Enclave Manager and Listener with
+4.  Terminal 1 is running the Avalon Enclave Manager and Listener with
     `docker-compose` . Terminal 2 is running the Docker container shell
-    with the `(_dev)` prompt
 5.  In Terminal 2 run `cd $TCF_HOME/examples/apps/heart_disease_eval/client`
 6.  In Terminal 2 install Python3's TKInter GUI library with
     ```bash
@@ -92,19 +89,19 @@ The TCF Enclave Manager and TCF Listener run in a Docker container.
     Use the `--help` option to see other available options
 11. A new window will pop up with the GUI. See the screenshot below for an
     example.
-12. Input all the heart evaluation values.
+12. Input all the heart disease evaluation values.
     Alternatively, check the "Input variables as string" box to input the
     values as a string of 14 integers separated by spaces. For example,
     `25 10 1 67 102 125 1 95 5 10 1 11 36 1` or
     `32 1 1 156 132 125 1 95 1 0 1 1 3 1`
 13. Click the "Evaluate" button and a new window will appear with the
-    heart evaluation result.
+    heart disease evaluation result.
     The "View Request", "View Result", and "View Receipt" buttons will pop up
     windows displaying the raw JSON RPC files
 14. Close the GUI windows when done
 15. If you ran `xhost +` above, close access to your display with
     `xhost -` in Terminal 3
-16. In Terminal 1, press Ctrl-c to stop the TCF Enclave Manager and Listener
+16. In Terminal 1, press Ctrl-c to stop the Avalon Enclave Manager and Listener
 
 ![Screenshot of heart_gui.py]( heart_gui_screenshot.jpg "Screenshot of heart_gui.py")
 <br /> *Screenshot of heart_gui.py*


### PR DESCRIPTION
- Update references to `BUILD.md` instructions
- For the echo and generic clients,
  add BUILD and Python virtual environment steps
- For the heart disease client, remove `--uri` as it uses the default
- Expand the description of the echo client response

Signed-off-by: danintel <daniel.anderson@intel.com>