### PR TITLE
Remove virtual environment references in docker

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -53,16 +53,8 @@ Follow the instructions below to execute a Docker-based build and execution.
    followed by a repetitive message `Enclave manager sleeping for 10 secs`
 4. Open a Docker container shell using following command
    `sudo docker exec -it tcf bash`
-5. Activate a Python virtual environment in the Docker shell using following
-   command from the Docker working directory, `$TCF_HOME/tools/build`,
-   which is set in the `docker-compose.yaml` file:
-   ```
-   source _dev/bin/activate
-   ```
-   If the virtual environment for the current shell session is activated,
-   you will the see this prompt: `(_dev)`
-7. To execute test cases refer to [Testing](#testing) section below
-7. To exit the Avalon program, press `Ctrl-c`
+5. To execute test cases refer to [Testing](#testing) section below
+6. To exit the TCF program, press `Ctrl-c`
 
 
 # <a name="standalonebuild"></a>Standalone Build

--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -135,8 +135,7 @@ RUN OPENSSL_VER=1.1.1d \
 WORKDIR /project/TrustedComputeFramework
 
 RUN \
- echo "VIRTUAL_ENV=/project/TrustedComputeFramework/tools/build/_dev" >> /etc/environment \
- && echo "SOLC_BINARY=/root/.py-solc/solc-v0.4.25/bin/solc" >> /etc/environment \
+ echo "SOLC_BINARY=/root/.py-solc/solc-v0.4.25/bin/solc" >> /etc/environment \
  && echo "WALLET_PRIVATE_KEY=B413189C95B48737AE2D9AF4CAE97EB03F4DE40599DF8E6C89DCE4C2E2CBA8DE" >> /etc/environment \
  && echo "TCF_HOME=/project/TrustedComputeFramework/" >> /etc/environment \
  && if [ ! -z "$http_proxy"  ]; then \

--- a/scripts/enclave_manager.sh
+++ b/scripts/enclave_manager.sh
@@ -15,7 +15,5 @@
 
 enclave_manager="${TCF_HOME}/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py"
 
-source ${TCF_HOME}/tools/build/_dev/bin/activate
-
 echo "starting enclave manager ..."
 python3 $enclave_manager

--- a/scripts/lmdb.sh
+++ b/scripts/lmdb.sh
@@ -15,8 +15,6 @@
 
 lmdb_server="${TCF_HOME}/examples/common/python/shared_kv/remote_lmdb/lmdb_listener.py"
 
-source ${TCF_HOME}/tools/build/_dev/bin/activate
-
 echo "start the lmdb server ..."
 
 python3 ${lmdb_server}

--- a/scripts/propose_requests.sh
+++ b/scripts/propose_requests.sh
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
-source ${TCF_HOME}/tools/build/_dev/bin/activate
-
 testsDir=${TCF_HOME}/tests
 
 python3 ${testsDir}/Demo.py --input_dir ${testsDir}/json_requests/ \

--- a/scripts/tcs_listener.sh
+++ b/scripts/tcs_listener.sh
@@ -20,7 +20,5 @@ listener_port=`grep listener_port ${TCF_HOME}/config/tcs_config.toml | awk {'pri
 # config in env variables takes higher priority
 port=${TCF_TCS_LISTENER_PORT:-${listener_port}}
 
-source ${TCF_HOME}/tools/build/_dev/bin/activate
-
 echo "starting TCS listener ..."
 python3 $listener --bind_uri ${port}


### PR DESCRIPTION
The reason for having virtual environment is to provide isolation from TCF execution environment from the host system. Since, docker provides isolation from the host, we don't need virtual environment inside docker environment and hence the references are removed.

Signed-off-by: manju956 <manjunath.a.c@intel.com>