### PR TITLE
Build TCF code as part of docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,8 @@
 #Ignore Kv files
 config/Kv*
 
-#Ignore build directories
-workloads/build*
-tcs/core/common/build*
-tcs/core/tcs_trusted_worker_manager/enclave/build*
-tcs/core/common/python/build*
-common/build*
+#Ignore documentation files
+*.md
+docs/*
+CODEOWNERS
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,8 +63,7 @@ pipeline {
 
         stage('Build TCF') {
             steps {
-                sh 'docker-compose -f ci/docker-compose-build.yaml up'
-                sh 'docker-compose -f ci/docker-compose-build.yaml down'
+                sh 'docker-compose -f ci/docker-compose-build.yaml build'
             }
         }
 
@@ -89,7 +88,6 @@ pipeline {
 
     post {
         always {
-            sh 'docker-compose -f ci/docker-compose-build.yaml down'
             sh 'docker-compose -f ci/docker-compose-tests.yaml down'
         }
         success {

--- a/ci/docker-compose-build.yaml
+++ b/ci/docker-compose-build.yaml
@@ -19,16 +19,9 @@ services:
     image: tcf-ci-build:${ISOLATION_ID}
 
     build:
-      context: .
-      dockerfile: ../docker/Dockerfile.tcf-dev
+      context: ..
+      dockerfile: docker/Dockerfile.tcf-dev
       args:
         - http_proxy
         - https_proxy
         - no_proxy
-    volumes:
-      - ../:/project/TrustedComputeFramework
-    working_dir: "/project/TrustedComputeFramework/tools/build"
-    entrypoint: "bash -c \"\
-        if [ ${MAKECLEAN:-1} != 0 ]; then echo \\\"Clean build\\\" && make clean; fi \
-        && make \
-        && echo \\\"BUILD SUCCESS\\\" \""

--- a/ci/docker-compose-tests.yaml
+++ b/ci/docker-compose-tests.yaml
@@ -23,11 +23,8 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    volumes:
-      - ../:/project/TrustedComputeFramework
-    working_dir: "/project/TrustedComputeFramework/tools/build"
+    working_dir: "/project/TrustedComputeFramework/"
     entrypoint: "bash -c \"\
-        cd ../../scripts \
-        && source tcs_startup.sh -y \
+        source scripts/tcs_startup.sh -y \
         && sleep 5 \
-        && source ../tools/run_tests.sh \""
+        && source tools/run_tests.sh \""

--- a/docker-compose-sgx.yaml
+++ b/docker-compose-sgx.yaml
@@ -25,22 +25,18 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    environment:
+        - SGX_MODE=HW
         - TCF_DEBUG_BUILD=${TCF_DEBUG_BUILD:-}
         - DISPLAY=${DISPLAY:-}
+        - MAKECLEAN=${MAKECLEAN:-1}
     volumes:
-      - ./:/project/TrustedComputeFramework
+      # Below volume mappings are required for DISPLAY settings by heart disease GUI client
       - /tmp/.X11-unix:/tmp/.X11-unix
+      - ~/.Xauthority:/root/.Xauthority
     devices:
       - "/dev/isgx:/dev/isgx"
-    working_dir: "/project/TrustedComputeFramework/tools/build"
-    environment:
-      - SGX_MODE=HW
+    working_dir: "/project/TrustedComputeFramework"
     entrypoint: "bash -c \"\
-        if [ ${MAKECLEAN:-1} != 0 ]; then echo \\\"Clean build\\\" && make clean; fi \
-        && make \
-        && echo \\\"BUILD SUCCESS\\\" \
-        && cd ../../scripts \
-        && source tcs_startup.sh -y \
+        source scripts/tcs_startup.sh -y \
         && tail -f /dev/null \""
     stop_signal: SIGKILL

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,22 +25,16 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    environment:
+        - MAKECLEAN=${MAKECLEAN:-1}
         - TCF_DEBUG_BUILD=${TCF_DEBUG_BUILD:-}
         - DISPLAY=${DISPLAY:-}
         - XAUTHORITY=~/.Xauthority
     volumes:
-      - ./:/project/TrustedComputeFramework
+      # Below volume mappings are required for DISPLAY settings by heart disease GUI client
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ~/.Xauthority:/root/.Xauthority
-    working_dir: "/project/TrustedComputeFramework/tools/build"
-    environment:
-      - SGX_MODE=SIM
+    working_dir: "/project/TrustedComputeFramework"
     entrypoint: "bash -c \"\
-        if [ ${MAKECLEAN:-1} != 0 ]; then echo \\\"Clean build\\\" && make clean; fi \
-        && make \
-        && echo \\\"BUILD SUCCESS\\\" \
-        && cd ../../scripts \
-        && source tcs_startup.sh -y \
+        source scripts/tcs_startup.sh -y \
         && tail -f /dev/null \""
     stop_signal: SIGKILL

--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -131,11 +131,17 @@ RUN OPENSSL_VER=1.1.1d \
  && rm -rf /tmp/intel-sgx-ssl \
  && echo "SGX_SSL=/opt/intel/sgxssl" >> /etc/environment
 
-# Environment setup
-WORKDIR /project/TrustedComputeFramework
+COPY . /project/TrustedComputeFramework
 
-RUN \
- echo "SOLC_BINARY=/root/.py-solc/solc-v0.4.25/bin/solc" >> /etc/environment \
+ARG SGX_MODE
+ARG MAKECLEAN
+ARG TCF_DEBUG_BUILD
+ARG DISPLAY
+ARG XAUTHORITY
+
+# Environment setup
+
+RUN echo "SOLC_BINARY=/root/.py-solc/solc-v0.4.25/bin/solc" >> /etc/environment \
  && echo "WALLET_PRIVATE_KEY=B413189C95B48737AE2D9AF4CAE97EB03F4DE40599DF8E6C89DCE4C2E2CBA8DE" >> /etc/environment \
  && echo "TCF_HOME=/project/TrustedComputeFramework/" >> /etc/environment \
  && if [ ! -z "$http_proxy"  ]; then \
@@ -173,3 +179,6 @@ ENV DISPLAY=:0
 
 WORKDIR /project/TrustedComputeFramework/tools/build
 
+RUN if [ $MAKECLEAN != 0 ]; then echo "Clean build" && make clean; fi \
+ && make \
+ && echo "BUILD SUCCESS"


### PR DESCRIPTION
TCF code is built outside docker image. this leads to missing TCF packages or
libraries when build and bringing up TCF components/test case execution
does not happen in single docker process (this approach is being followed in CI).
Hence move building TCF components within docker image.

Signed-off-by: manju956 <manjunath.a.c@intel.com>