### PR TITLE
Fix TCF-Avalon in more readme's and add tutorial hint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/
 -->
-# Contributing to Trusted Compute Framework (TCF)
+# Contributing to Hyperledger Avalon
 
-TCF software is [Apache 2.0 licensed](LICENSE) and accepts contributions via
+Avalon software is [Apache 2.0 licensed](LICENSE) and accepts contributions via
 git pull requests.  Each commit must include a DCO line in the git commit message:
 
 `Signed-off-by: GitHub User Name <your.email@example.com>`
@@ -15,6 +15,5 @@ This sign-off means you agree the commit satisfies the
 For other ways to contribute, see
 [Get involved: How to Contribute to Hyperledger](https://www.hyperledger.org/blog/2018/07/11/get-involved-how-to-contribute-to-hyperledger)
 and our
-[community links](https://github.com/hyperledger-labs/trusted-compute-framework/tree/master/docs#community).
+[community links](https://github.com/hyperledger/avalon/tree/master/docs#community).
 
-© Copyright 2019, Intel Corporation.

--- a/docker/k8s/README.md
+++ b/docker/k8s/README.md
@@ -1,7 +1,7 @@
-# Kubernetes playground for trusted-compute-framework 
+# Kubernetes playground for Avalon 
 
 This serves as a playground for developing 
-[hyperledger-labs/trusted-compute-framework](https://github.com/hyperledger-labs/trusted-compute-framework)
+[hyperledger/avalon](https://github.com/hyperledger/avalon)
 in SGX-SIM mode.
 
 ## Prerequisites

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
-# Trusted Compute Framework (TCF) Documentation
+# Hyperledger Avalon Documentation
 
-## Introductory
-* [README](../README.md). Overview of TCF and TCF source code
-* [Trusted Compute Framework (TCF) Project](https://wiki.hyperledger.org/pages/viewpage.action?pageId=16324764). Overview of the TCF project, members, motivation, proposed solutions, current effort, and FAQ
-* [Ecosystem Support for EEA Trusted Compute Specification v1.0 Improves Blockchain Privacy and Scalability](https://software.intel.com/en-us/articles/ecosystem-support-for-eea-trusted-compute-specification-v10-improves-blockchain-privacy-and). Introductory TCF Blog, by Michael Reed (2019)
+## Introduction
+* [README](../README.md). Overview of Avalon and its source code
+* [Proposal](https://wiki.hyperledger.org/pages/viewpage.action?pageId=16324764). Proposal of the project, members, motivation, proposed solutions, and FAQ
+* [Ecosystem Support for EEA Trusted Compute Specification v1.0 Improves Blockchain Privacy and Scalability](https://software.intel.com/en-us/articles/ecosystem-support-for-eea-trusted-compute-specification-v10-improves-blockchain-privacy-and). Introductory Blog, by Michael Reed (2019)
 
 ## Community
 * [Project Wiki](https://wiki.hyperledger.org/display/avalon/Hyperledger+Avalon)
@@ -15,11 +15,11 @@
 * [Example Applications](../examples/apps/)
 
 ## Source Code
-* [TCF source code repository, https://github.com/hyperledger-labs/trusted-compute-framework](https://github.com/hyperledger-labs/trusted-compute-framework)
+* [TCF source code repository, https://github.com/hyperledger/avalon](https://github.com/hyperledger/avalon)
 * [Building source code](../BUILD.md)
 * [Example TCF applications](../examples/apps/)
 * [Contributing source code](../CONTRIBUTING.md)
 
 ## Reference
 * [ _Off-Chain Trusted Compute Specification_](https://entethalliance.github.io/trusted-computing/spec.html) defined by Enterprise Ethereum Alliance (EEA) Task Force (2019)
-* [TCF Cryptography](../tc/sgx/common/crypto/README.md). Cryptographic primitives used, libraries used, and implementation
+* [Cryptography](../tc/sgx/common/crypto/README.md). Cryptographic primitives used, libraries used, and implementation

--- a/docs/workload-tutorial/README.md
+++ b/docs/workload-tutorial/README.md
@@ -147,6 +147,11 @@ will be created next in [Phase 2](#phase2).
       --workload_id "hello-world" --in_data "Jane" "Dan"
   ```
 
+  > **_NOTE:_** If you are running Avalon in a container you can shell into the container like this:
+      ```bash
+      docker exec -it tcf bash
+      ```
+
 * The Hello World worker should return the string `Error: under construction`
   as the result (hard-coded placeholder string in `plug-in.cpp`):
   ```

--- a/docs/workload-tutorial/README.md
+++ b/docs/workload-tutorial/README.md
@@ -1,4 +1,4 @@
-# TCF Worker Application Development Tutorial
+# Avalon Worker Application Development Tutorial
 
 This tutorial describes how to build a trusted workload application.
 We begin by copying template files to a new directory.
@@ -73,10 +73,10 @@ Before beginning this tutorial, review the following items:
   * The Workload ID (`hello-world`) and input parameters (a name string)
     sent by the client must match the workload requirements for this worker
 
-* Review how to build TCF at [$TCF_HOME/BUILD.md](../../BUILD.md)
+* Review how to build Avalon at [$TCF_HOME/BUILD.md](../../BUILD.md)
 
 As a best practice, this tutorial separates the actual workload-specific logic
-from the the TCF plumbing required to link the workload to the TCF framework
+from the Avalon plumbing required to link the workload to the Avalon framework
 into separate files.
 
 ## Tutorial
@@ -85,13 +85,13 @@ This tutorial creates a workload application in two phases:
 1. [Create generic plug-in logic](#phase1)
 2. [Incrementally add workload-specific logic](#phase2)
 
-### <a name="phase1"></a>Phase 1: TCF Plug-in Code
+### <a name="phase1"></a>Phase 1: Avalon Plug-in Code
 
-For the first phase copy and modify template code to create TCF plug-in code.
-This code contains TCF framework code to invoke worker-specific logic that
+For the first phase copy and modify template code to create the plug-in code.
+This code contains Avalon framework code to invoke worker-specific logic that
 will be created next in [Phase 2](#phase2).
 
-* From the top-level TCF source repository directory, `$TCF_HOME`,
+* From the top-level Avalon source repository directory, `$TCF_HOME`,
   create a new workload directory and change into it:
   ```bash
   cd $TCF_HOME
@@ -136,7 +136,7 @@ will be created next in [Phase 2](#phase2).
   TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--whole-archive -lhello_world -Wl,--no-whole-archive)
   ```
 
-* Change to the top-level TCF source repository directory, `$TCF_HOME`,
+* Change to the top-level Avalon source repository directory, `$TCF_HOME`,
   and rebuild the framework (see [$TCF_HOME/BUILD.md](../../BUILD.md)).
   It should now include the new workload
 
@@ -167,10 +167,10 @@ directory
 
 ### <a name="phase2"></a>Phase 2: Worker-specific Code
 
-Now that we have TCF plug-in framework code, we incrementally add
+Now that we have Avalon plug-in framework code, we incrementally add
 worker-specific logic and call it from the plug-in code.
 As a best practice, we separate worker-specific logic from the
-TCF framework code that calls it into separate files.
+Avalon framework code that calls it into separate files.
 In this example we name the worker-specific function `ProcessHelloWorld()`.
 
 * Change back into the "Hello World" workload directory:
@@ -192,7 +192,7 @@ In this example we name the worker-specific function `ProcessHelloWorld()`.
 
   For this example, the worker-specific logic is trivial. Usually
   the logic is much more complex so it is in a separate file to
-  separate it from TCF-specific plug-in code
+  separate it from Avalon-specific plug-in code
 
 * Modify the `ProcessWorkOrder()` method in `plug-in.cpp`
   to call `ProcessHelloWorld()`.  That is, change:
@@ -221,7 +221,7 @@ In this example we name the worker-specific function `ProcessHelloWorld()`.
   item and will return each resulting string as a separate output data item.
 
 
-* Change to the top-level TCF source repository directory, `$TCF_HOME`,
+* Change to the top-level Avalon source repository directory, `$TCF_HOME`,
   and rebuild the framework (see [$TCF_HOME/BUILD.md](../../BUILD.md)).
   It should now include the new workload
 

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -1,7 +1,7 @@
-# TCF Example Applications
+# Avalon Example Applications
 
-The following TCF example applications are available.
-They are intended as introductions to the TCF API to learn how to
+The following Avalon example applications are available.
+They are intended as introductions to the Avalon API to learn how to
 create and write new applications.
 
 - [Echo](echo)

--- a/tc/sgx/common/crypto/README.md
+++ b/tc/sgx/common/crypto/README.md
@@ -11,7 +11,8 @@ trusted (SGX Enclave) code.
 
 This code is written in C++, but a Python wrapper is also available (see [../README.md](../README.md))
 
-TCF applications are free to use third-party cryptographic implementations (such as what a programming language binding may provide) or the cryptographic interfaces provided here.
+Avalon applications are free to use third-party cryptographic implementations (such as what a
+programming language binding may provide) or the cryptographic interfaces provided here.
 
 
 Software Components Required


### PR DESCRIPTION
Update name in READMEs and add a container shell hint for the tutorial.