### PR TITLE
Add vim to dev container

### DIFF
--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -68,6 +68,7 @@ RUN apt-get update \
     liblmdb-dev \
     ocamlbuild \
     python3-tk \
+    vim \
  && apt-get -y -q upgrade \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add a basic editor to the dev container. Facilitates basic debug and
editing.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>