### PR TITLE
Work order receipt APIs implementation for direct model

### DIFF
--- a/examples/apps/echo/client/echo_client.py
+++ b/examples/apps/echo/client/echo_client.py
@@ -29,274 +29,339 @@ from utility.tcf_types import WorkerType
 import worker.worker_details as worker
 from work_order.work_order_params import WorkOrderParams
 from connectors.direct.direct_json_rpc_api_connector \
-	import DirectJsonRpcApiConnector
+    import DirectJsonRpcApiConnector
 import crypto.crypto as crypto
-from error_code.error_status import WorkOrderStatus
+from error_code.error_status import WorkOrderStatus, ReceiptCreateStatus
 import utility.signature as signature
 import utility.hex_utils as hex_utils
 from error_code.error_status import SignatureStatus
+from work_order_receipt.work_order_receipt_request import WorkOrderReceiptRequest
 
 # Remove duplicate loggers
 for handler in logging.root.handlers[:]:
     logging.root.removeHandler(handler)
 logger = logging.getLogger(__name__)
-TCFHOME = os.environ.get("TCF_HOME", "../../")
+TCFHOME = os.environ.get("TCF_HOME", "../../../../")
 
-def ParseCommandLine(args) :
+def ParseCommandLine(args):
+    global worker_obj
+    global worker_id
+    global message
+    global config
+    global off_chain
+    global requester_signature
+    global input_data_hash
 
-	global worker_obj
-	global worker_id
-	global message
-	global config
-	global off_chain
-	global requester_signature
-	global input_data_hash
+    parser = argparse.ArgumentParser()
+    use_service = parser.add_mutually_exclusive_group()
+    parser.add_argument("-c", "--config",
+                        help="the config file containing the Ethereum contract information",
+                        type=str)
+    use_service.add_argument("-r", "--registry-list",
+                             help="the Ethereum address of the registry list",
+                             type=str)
 
-	parser = argparse.ArgumentParser()
-	use_service = parser.add_mutually_exclusive_group()
-	parser.add_argument("-c", "--config", 
-		help="the config file containing the Ethereum contract information", 
-		type=str)
-	use_service.add_argument("-r", "--registry-list", 
-		help="the Ethereum address of the registry list", 
-		type=str)
-	use_service.add_argument("-s", "--service-uri", 
-		help="skip URI lookup and send to specified URI", 
-		type=str)
-	use_service.add_argument("-o", "--off-chain", 
-		help="skip URI lookup and use the registry in the config file", 
-		action="store_true")
-	parser.add_argument("-w", "--worker-id", 
-		help="skip worker lookup and retrieve specified worker", 
-		type=str)
-	parser.add_argument("-m", "--message", 
-		help='text message to be included in the JSON request payload', 
-		type=str)
-	parser.add_argument("-rs", "--requester-signature",
-		help="Enable requester signature for work order requests",
-		action="store_true")
-	parser.add_argument("-dh", "--data-hash",
-		help="Enable input data hash for work order requests",
-		action="store_true")
+    use_service.add_argument("-s", "--service-uri",
+                             help="skip URI lookup and send to specified URI",
+                             type=str)
 
-	options = parser.parse_args(args)
+    use_service.add_argument("-o", "--off-chain",
+                             help="skip URI lookup and use the registry in the config file",
+                             action="store_true")
 
-	if options.config:
-		conf_files = [options.config]
-	else:
-		conf_files = [ TCFHOME + \
-			"/examples/common/python/connectors/tcf_connector.toml" ]
-	confpaths = [ "." ]
-	try :
-		config = pconfig.parse_configuration_files(conf_files, confpaths)
-		json.dumps(config)
-	except pconfig.ConfigurationException as e :
-		logger.error(str(e))
-		sys.exit(-1)
+    parser.add_argument("-w", "--worker-id",
+                        help="skip worker lookup and retrieve specified worker",
+                        type=str)
+    parser.add_argument("-m", "--message",
+                        help='text message to be included in the JSON request payload',
+                        type=str)
+    parser.add_argument("-rs", "--requester-signature",
+                        help="Enable requester signature for work order requests",
+                        action="store_true")
+    parser.add_argument("-dh", "--data-hash",
+                        help="Enable input data hash for work order requests",
+                        action="store_true")
 
-	global direct_jrpc
-	direct_jrpc = DirectJsonRpcApiConnector(conf_files[0])
+    options = parser.parse_args(args)
+    if options.config:
+        conf_files = [options.config]
+    else:
+        conf_files = [TCFHOME +
+                      "/examples/common/python/connectors/tcf_connector.toml"]
+    confpaths = ["."]
+    try:
+        config = pconfig.parse_configuration_files(conf_files, confpaths)
+        config_json_str = json.dumps(config)
+    except pconfig.ConfigurationException as e:
+        logger.error(str(e))
+        sys.exit(-1)
 
-	# Whether or not to connect to the registry list on the blockchain
-	off_chain = False
+    global direct_jrpc
+    direct_jrpc = DirectJsonRpcApiConnector(conf_files[0])
 
-	if options.registry_list:
-		config["ethereum"]["direct_registry_contract_address"] = \
-			options.registry_list
+    # Whether or not to connect to the registry list on the blockchain
+    off_chain = False
 
-	if options.service_uri:
-		config["tcf"]["json_rpc_uri"] = options.service_uri
-		off_chain = True
+    if options.registry_list:
+        config["ethereum"]["direct_registry_contract_address"] = \
+            options.registry_list
 
-	if options.off_chain:
-		off_chain = True
+    if options.service_uri:
+        config["tcf"]["json_rpc_uri"] = options.service_uri
+        off_chain = True
 
-	requester_signature = options.requester_signature
-	input_data_hash = options.data_hash
-	worker_id = options.worker_id
-	message = options.message
-	if options.message is None or options.message == "":
-		message = "Test Message"
+    if options.off_chain:
+        off_chain = True
 
-	# Initializing Worker Object
-	worker_obj = worker.SGXWorkerDetails()
+    requester_signature = options.requester_signature
+    input_data_hash = options.data_hash
+    worker_id = options.worker_id
+    message = options.message
+    if options.message == None or options.message == "":
+        message = "Test Message"
+
+    # Initializing Worker Object
+    worker_obj = worker.SGXWorkerDetails()
+
 
 def Main(args=None):
-	ParseCommandLine(args)
+    ParseCommandLine(args)
 
-	config["Logging"] = {
-		"LogFile" : "__screen__",
-		"LogLevel" : "INFO"
-	}
-	
-	plogger.setup_loggers(config.get("Logging", {}))
-	sys.stdout = plogger.stream_to_logger(
-		logging.getLogger("STDOUT"), logging.DEBUG)
-	sys.stderr = plogger.stream_to_logger(
-		logging.getLogger("STDERR"), logging.WARN)
+    config["Logging"] = {
+        "LogFile": "__screen__",
+        "LogLevel": "INFO"
+    }
 
-	logger.info("***************** TRUSTED COMPUTE FRAMEWORK (TCF)" +
-		" *****************") 
+    plogger.setup_loggers(config.get("Logging", {}))
+    sys.stdout = plogger.stream_to_logger(
+        logging.getLogger("STDOUT"), logging.DEBUG)
+    sys.stderr = plogger.stream_to_logger(
+        logging.getLogger("STDERR"), logging.WARN)
 
-	# Connect to registry list and retrieve registry
-	if not off_chain:
-		registry_list_instance = direct_jrpc.create_worker_registry_list(
-			config
-		)
-		# Lookup returns tuple, first element is number of registries and
-		# second is element is lookup tag and third is list of organization ids.
-		registry_count, lookup_tag, registry_list = registry_list_instance.registry_lookup()
-		logger.info("\n Registry lookup response: registry count: {} lookup tag: {} registry list: {}\n".format(
-			registry_count, lookup_tag, registry_list
-		))
-		if (registry_count == 0):
-			logger.warn("No registries found")
-			sys.exit(1)
-		# Retrieve the fist registry details.
-		registry_retrieve_result = registry_list_instance.registry_retrieve(registry_list[0])
-		logger.info("\n Registry retrieve response: {}\n".format(
-			registry_retrieve_result
-		))
-		config["tcf"]["json_rpc_uri"] = registry_retrieve_result[0]
+    logger.info("***************** TRUSTED COMPUTE FRAMEWORK (TCF)" +
+                " *****************")
 
-	# Prepare worker
-	req_id = 31
-	global worker_id
-	worker_registry_instance = direct_jrpc.create_worker_registry(
-		config
-	)
-	if not worker_id:
-		worker_lookup_result = worker_registry_instance.worker_lookup(
-			worker_type=WorkerType.TEE_SGX, id=req_id
-		)
-		logger.info("\n Worker lookup response: {}\n".format(
-			json.dumps(worker_lookup_result, indent=4)
-		))
-		if "result" in worker_lookup_result and \
-			"ids" in worker_lookup_result["result"].keys():
-			if worker_lookup_result["result"]["totalCount"] != 0:
-				worker_id = worker_lookup_result["result"]["ids"][0]
-			else:
-				logger.error("ERROR: No workers found")
-				sys.exit(1)
-		else:
-			logger.error("ERROR: Failed to lookup worker")
-			sys.exit(1)
-	req_id += 1
-	worker_retrieve_result = worker_registry_instance.worker_retrieve(
-		worker_id,req_id
-	)
-	logger.info("\n Worker retrieve response: {}\n".format(
-		json.dumps(worker_retrieve_result, indent=4)
-	))
-	worker_obj.load_worker(worker_retrieve_result)
+    # Connect to registry list and retrieve registry
+    if not off_chain:
+        registry_list_instance = direct_jrpc.create_worker_registry_list(
+            config
+        )
+        # Lookup returns tuple, first element is number of registries and
+        # second is element is lookup tag and third is list of organization ids.
+        registry_count, lookup_tag, registry_list = registry_list_instance.registry_lookup()
+        logger.info("\n Registry lookup response: registry count: {} lookup tag: {} registry list: {}\n".format(
+            registry_count, lookup_tag, registry_list
+        ))
+        if (registry_count == 0):
+            logger.warn("No registries found")
+            sys.exit(1)
+        # Retrieve the fist registry details.
+        registry_retrieve_result = registry_list_instance.registry_retrieve(
+            registry_list[0])
+        logger.info("\n Registry retrieve response: {}\n".format(
+            registry_retrieve_result
+        ))
+        config["tcf"]["json_rpc_uri"] = registry_retrieve_result[0]
 
-	logger.info("**********Worker details Updated with Worker ID" + \
-		"*********\n%s\n", worker_id)
+    # Prepare worker
+    req_id = 31
+    global worker_id
+    worker_registry_instance = direct_jrpc.create_worker_registry(
+        config
+    )
+    if not worker_id:
+        worker_lookup_result = worker_registry_instance.worker_lookup(
+            worker_type=WorkerType.TEE_SGX, id=req_id
+        )
+        logger.info("\n Worker lookup response: {}\n".format(
+            json.dumps(worker_lookup_result, indent=4)
+        ))
+        if "result" in worker_lookup_result and \
+                "ids" in worker_lookup_result["result"].keys():
+            if worker_lookup_result["result"]["totalCount"] != 0:
+                worker_id = worker_lookup_result["result"]["ids"][0]
+            else:
+                logger.error("ERROR: No workers found")
+                sys.exit(1)
+        else:
+            logger.error("ERROR: Failed to lookup worker")
+            sys.exit(1)
+    req_id += 1
+    worker_retrieve_result = worker_registry_instance.worker_retrieve(
+        worker_id, req_id
+    )
+    logger.info("\n Worker retrieve response: {}\n".format(
+        json.dumps(worker_retrieve_result, indent=4)
+    ))
+    worker_obj.load_worker(worker_retrieve_result)
 
-	# Convert workloadId to hex
-	workload_id = "echo-result".encode("UTF-8").hex()
-	work_order_id = secrets.token_hex(32)
-	requester_id = secrets.token_hex(32)
-	session_iv = utility.generate_iv()
-	session_key = utility.generate_key()
-	requester_nonce = secrets.token_hex(16)
+    logger.info("**********Worker details Updated with Worker ID" +
+                "*********\n%s\n", worker_id)
 
-	# Create work order
-	wo_params = WorkOrderParams(
-		work_order_id, worker_id, workload_id, requester_id,
-		session_key, session_iv, requester_nonce,
-		result_uri=" ", notify_uri=" ",
-		worker_encryption_key=worker_obj.encryption_key,
-		data_encryption_algorithm="AES-GCM-256"
-	)
-	# Add worker input data
-	if input_data_hash:
-		# Compute data hash for data params inData
-		data_hash = utility.compute_data_hash(message)
-		# Convert data_hash to hex
-		data_hash = hex_utils.byte_array_to_hex_str(data_hash)
-		wo_params.add_in_data(message, data_hash)
-	else:
-		wo_params.add_in_data(message)
+    # Convert workloadId to hex
+    workload_id = "echo-result".encode("UTF-8").hex()
+    work_order_id = secrets.token_hex(32)
+    requester_id = secrets.token_hex(32)
+    session_iv = utility.generate_iv()
+    session_key = utility.generate_key()
+    requester_nonce = secrets.token_hex(16)
 
-	# Encrypt work order request hash
-	wo_params.add_encrypted_request_hash()
+    # Create work order
+    wo_params = WorkOrderParams(
+        work_order_id, worker_id, workload_id, requester_id,
+        session_key, session_iv, requester_nonce,
+        result_uri=" ", notify_uri=" ",
+        worker_encryption_key=worker_obj.encryption_key,
+        data_encryption_algorithm="AES-GCM-256"
+    )
+    # Add worker input data
+    if input_data_hash:
+        # Compute data hash for data params inData
+        data_hash = utility.compute_data_hash(message)
+        # Convert data_hash to hex
+        data_hash = hex_utils.byte_array_to_hex_str(data_hash)
+        wo_params.add_in_data(message, data_hash)
+    else:
+        wo_params.add_in_data(message)
 
-	if requester_signature:
-		private_key = utility.generate_signing_keys()
-		# Add requester signature and requester verifying_key
-		if wo_params.add_requester_signature(private_key) == False:
-			logger.info("Work order request signing failed")
-			exit(1)
+    # Encrypt work order request hash
+    wo_params.add_encrypted_request_hash()
 
-	# Submit work order
-	logger.info("Work order submit request : %s, \n \n ",
-        wo_params.to_string())
-	work_order_instance = direct_jrpc.create_work_order(
-		config
-	)
-	req_id += 1
-	response = work_order_instance.work_order_submit(
-		wo_params.get_params(),
-		wo_params.get_in_data(),
-		wo_params.get_out_data(),
-		id=req_id
-	)
-	logger.info("Work order submit response : {}\n ".format(
-		json.dumps(response, indent=4)
-	))
+    private_key = utility.generate_signing_keys()
+    if requester_signature:
+        # Add requester signature and requester verifying_key
+        if wo_params.add_requester_signature(private_key) == False:
+            logger.info("Work order request signing failed")
+            exit(1)
 
-	if "error" in response and response["error"]["code"] != WorkOrderStatus.PENDING:
-		sys.exit(1)
-	# Retrieve result
-	req_id += 1
-	res = work_order_instance.work_order_get_result(
-		work_order_id,
-		req_id
-	)
+    # Submit work order
+    logger.info("Work order submit request : %s, \n \n ",
+                wo_params.to_string(req_id))
+    work_order_instance = direct_jrpc.create_work_order(
+        config
+    )
+    req_id += 1
+    response = work_order_instance.work_order_submit(
+        wo_params.get_params(),
+        wo_params.get_in_data(),
+        wo_params.get_out_data(),
+        id=req_id
+    )
+    logger.info("Work order submit response : {}\n ".format(
+        json.dumps(response, indent=4)
+    ))
 
-	logger.info("Work order get result : {}\n ".format(
-		json.dumps(res, indent=4)
-	))
-	if "result" in res:
-		sig_obj = signature.ClientSignature()
-		status = sig_obj.verify_signature(res, worker_obj.verification_key)
-		try:
-			if status == SignatureStatus.PASSED:
-				logger.info("Signature verification Successful")
-				decrypted_res = utility.decrypted_response(
-					res, session_key, session_iv)
-				logger.info("\nDecrypted response:\n {}".format(decrypted_res))
-				if input_data_hash:
-					decrypted_data = decrypted_res[0]["data"]
-					data_hash_in_resp = (decrypted_res[0]["dataHash"]).upper()
-					# Verify data hash in response
-					if utility.verify_data_hash(decrypted_data, data_hash_in_resp) == False:
-						sys.exit(1)
-			else:
-				logger.info("Signature verification Failed")
-				sys.exit(1)
-		except:
-			logger.error("ERROR: Failed to decrypt response")
-			sys.exit(1)
-	else:
-		logger.info("\n Work order get result failed {}\n".format(
-			res
-		))
-		sys.exit(1)
+    if "error" in response and response["error"]["code"] != WorkOrderStatus.PENDING:
+        sys.exit(1)
 
-	# Retrieve receipt
-	wo_receipt_instance = direct_jrpc.create_work_order_receipt(
-		config
-	)
-	req_id += 1
-	receipt_res = wo_receipt_instance.work_order_receipt_retrieve(
-		work_order_id,
-		id=req_id
-	)
-	logger.info("\Retrieve receipt response:\n {}".format(
-		json.dumps(receipt_res, indent= 4)
-	))
-#------------------------------------------------------------------------------
+    # Create receipt
+    wo_receipt_instance = direct_jrpc.create_work_order_receipt(
+        config)
+    req_id += 1
+    # Create work order receipt object using WorkOrderReceiptRequest class
+    wo_request = json.loads(wo_params.to_string(req_id))
+    wo_receipt_obj = WorkOrderReceiptRequest()
+    wo_create_receipt = wo_receipt_obj.create_receipt(
+        wo_request,
+        ReceiptCreateStatus.PENDING.value,
+        private_key
+    )
+    logger.info("Work order create receipt request : {} \n \n ".format(
+        json.dumps(wo_create_receipt, indent=4)
+    ))
+    # Submit work order create receipt jrpc request
+    wo_receipt_resp = wo_receipt_instance.work_order_receipt_create(
+        wo_create_receipt["workOrderId"],
+        wo_create_receipt["workerServiceId"],
+        wo_create_receipt["workerId"],
+        wo_create_receipt["requesterId"],
+        wo_create_receipt["receiptCreateStatus"],
+        wo_create_receipt["workOrderRequestHash"],
+        wo_create_receipt["requesterGeneratedNonce"],
+        wo_create_receipt["requesterSignature"],
+        wo_create_receipt["signatureRules"],
+        wo_create_receipt["receiptVerificationKey"],
+        req_id
+    )
+    logger.info("Work order create receipt response : {} \n \n ".format(
+        wo_receipt_resp
+    ))
+    # Retrieve result
+    req_id += 1
+    res = work_order_instance.work_order_get_result(
+        work_order_id,
+        req_id
+    )
+
+    logger.info("Work order get result : {}\n ".format(
+        json.dumps(res, indent=4)
+    ))
+    sig_obj = signature.ClientSignature()
+    if "result" in res:
+        status = sig_obj.verify_signature(res, worker_obj.verification_key)
+        try:
+            if status == SignatureStatus.PASSED:
+                logger.info(
+                    "Work order response signature verification Successful")
+                decrypted_res = utility.decrypted_response(
+                    res, session_key, session_iv)
+                logger.info("\nDecrypted response:\n {}".format(decrypted_res))
+                if input_data_hash:
+                    decrypted_data = decrypted_res[0]["data"]
+                    data_hash_in_resp = (decrypted_res[0]["dataHash"]).upper()
+                    # Verify data hash in response
+                    if utility.verify_data_hash(decrypted_data, data_hash_in_resp) == False:
+                        sys.exit(1)
+            else:
+                logger.info("Signature verification Failed")
+                sys.exit(1)
+        except:
+            logger.error("ERROR: Failed to decrypt response")
+            sys.exit(1)
+    else:
+        logger.info("\n Work order get result failed {}\n".format(
+            res
+        ))
+        sys.exit(1)
+
+    # Retrieve receipt
+    receipt_res = wo_receipt_instance.work_order_receipt_retrieve(
+        work_order_id,
+        id=req_id
+    )
+
+    logger.info("\n Retrieve receipt response:\n {}".format(
+        json.dumps(receipt_res, indent=4)
+    ))
+    # Retrieve last update to receipt by passing 0xFFFFFFFF
+    req_id += 1
+    receipt_update_retrieve = wo_receipt_instance.work_order_receipt_update_retrieve(
+        work_order_id,
+        None,
+        1 << 32,
+        id=req_id
+    )
+    logger.info("\n Last update to receipt receipt is:\n {}".format(
+        json.dumps(receipt_update_retrieve, indent=4)
+    ))
+    status = sig_obj.verify_update_receipt_signature(receipt_update_retrieve)
+    if status == SignatureStatus.PASSED:
+        logger.info(
+            "Work order receipt retrieve signature verification Successful")
+    else:
+        logger.info(
+            "Work order receipt retrieve signature verification failed!!")
+        sys.exit(1)
+    # Receipt lookup based on requesterId
+    req_id += 1
+    receipt_lookup_res = wo_receipt_instance.work_order_receipt_lookup(
+        requester_id=requester_id,
+        id=req_id
+    )
+    logger.info("\n Work order receipt lookup response :\n {}".format(
+        json.dumps(receipt_lookup_res, indent=4)
+    ))
+
+
+# ------------------------------------------------------------------------------
 Main()

--- a/examples/apps/generic_client/generic_client.py
+++ b/examples/apps/generic_client/generic_client.py
@@ -28,10 +28,11 @@ from utility.tcf_types import WorkerType
 import worker.worker_details as worker_details
 from work_order.work_order_params import WorkOrderParams
 from connectors.direct.direct_json_rpc_api_connector \
-	import DirectJsonRpcApiConnector
-from error_code.error_status import WorkOrderStatus
+    import DirectJsonRpcApiConnector
+from error_code.error_status import WorkOrderStatus, ReceiptCreateStatus
 import utility.signature as signature
 from error_code.error_status import SignatureStatus
+from work_order_receipt.work_order_receipt_request import WorkOrderReceiptRequest
 
 # Remove duplicate loggers
 for handler in logging.root.handlers[:]:
@@ -41,284 +42,334 @@ TCFHOME = os.environ.get("TCF_HOME", "../../")
 
 def ParseCommandLine(args) :
 
-	global worker_obj
-	global worker_id
-	global workload_id
-	global in_data
-	global config
-	global mode
-	global uri
-	global address
-	global show_receipt
-	global show_decrypted_output
-	global requester_signature
+    global worker_obj
+    global worker_id
+    global workload_id
+    global in_data
+    global config
+    global mode
+    global uri
+    global address
+    global show_receipt
+    global show_decrypted_output
+    global requester_signature
 
-	parser = argparse.ArgumentParser()
-	mutually_excl_group = parser.add_mutually_exclusive_group()
-	parser.add_argument("-c", "--config",
-		help="The config file containing the Ethereum contract information",
-		type=str)
-	mutually_excl_group.add_argument("-u", "--uri",
-		help="Direct API listener endpoint, default is http://localhost:1947",
-		default="http://localhost:1947",		
-		type=str)
-	mutually_excl_group.add_argument("-a", "--address",
-		help="an address (hex string) of the smart contract (e.g. Worker registry listing)",
-		type=str)
-	parser.add_argument("-m", "--mode",
-		help="should be one of listing or registry (default)",
-		default="registry",		
-		choices={"registry", "listing"},
-		type=str)
-	parser.add_argument("-w", "--worker_id",
-		help="worker id (hex string) to use to submit a work order",
-		type=str)
-	parser.add_argument("-l", "--workload_id",
-		help='workload id (hex string) for a given worker',
-		type=str)
-	parser.add_argument("-i", "--in_data",
-		help='Input data',
-		nargs="+",
-		type=str)
-	parser.add_argument("-r", "--receipt",
-		help="If present, retrieve and display work order receipt",
-		action='store_true')
-	parser.add_argument("-o", "--decrypted_output",
-		help="If present, display decrypted output as JSON",
-		action='store_true')
-	parser.add_argument("-rs", "--requester_signature",
-		help="Enable requester signature for work order requests",
-		action="store_true")
-	options = parser.parse_args(args)
+    parser = argparse.ArgumentParser()
+    mutually_excl_group = parser.add_mutually_exclusive_group()
+    parser.add_argument("-c", "--config",
+        help="The config file containing the Ethereum contract information",
+        type=str)
+    mutually_excl_group.add_argument("-u", "--uri",
+        help="Direct API listener endpoint, default is http://localhost:1947",
+        default="http://localhost:1947",
+        type=str)
+    mutually_excl_group.add_argument("-a", "--address",
+        help="an address (hex string) of the smart contract (e.g. Worker registry listing)",
+        type=str)
+    parser.add_argument("-m", "--mode",
+        help="should be one of listing or registry (default)",
+        default="registry",
+        choices={"registry", "listing"},
+        type=str)
+    parser.add_argument("-w", "--worker_id",
+        help="worker id (hex string) to use to submit a work order",
+        type=str)
+    parser.add_argument("-l", "--workload_id",
+        help='workload id (hex string) for a given worker',
+        type=str)
+    parser.add_argument("-i", "--in_data",
+        help='Input data',
+        nargs="+",
+        type=str)
+    parser.add_argument("-r", "--receipt",
+        help="If present, retrieve and display work order receipt",
+        action='store_true')
+    parser.add_argument("-o", "--decrypted_output",
+        help="If present, display decrypted output as JSON",
+        action='store_true')
+    parser.add_argument("-rs", "--requester_signature",
+        help="Enable requester signature for work order requests",
+        action="store_true")
+    options = parser.parse_args(args)
 
-	if options.config:
-		conf_files = [options.config]
-	else:
-		conf_files = [TCFHOME + \
-			"/examples/common/python/connectors/tcf_connector.toml"]
-	confpaths = [ "." ]
-	try :
-		config = pconfig.parse_configuration_files(conf_files, confpaths)
-		json.dumps(config)
-	except pconfig.ConfigurationException as e :
-		logger.error(str(e))
-		sys.exit(-1)
+    if options.config:
+        conf_files = [options.config]
+    else:
+        conf_files = [TCFHOME + \
+            "/examples/common/python/connectors/tcf_connector.toml"]
+    confpaths = [ "." ]
+    try :
+        config = pconfig.parse_configuration_files(conf_files, confpaths)
+        json.dumps(config)
+    except pconfig.ConfigurationException as e :
+        logger.error(str(e))
+        sys.exit(-1)
 
-	mode = options.mode
+    mode = options.mode
 
-	uri = options.uri
-	if uri:
-		config["tcf"]["json_rpc_uri"] = uri
+    uri = options.uri
+    if uri:
+        config["tcf"]["json_rpc_uri"] = uri
 
-	address = options.address
-	if address:
-		if mode == "listing":
-			config["ethereum"]["direct_registry_contract_address"] = \
-				address
-		elif mode == "registry":
-			logger.error("\n Only Worker registry listing address is supported." +
+    address = options.address
+    if address:
+        if mode == "listing":
+            config["ethereum"]["direct_registry_contract_address"] = \
+                address
+        elif mode == "registry":
+            logger.error("\n Only Worker registry listing address is supported." +
                                 "Worker registry address is unsupported \n");
-			sys.exit(-1)
+            sys.exit(-1)
 
-	worker_id = options.worker_id
+    worker_id = options.worker_id
 
-	workload_id = options.workload_id
-	if not workload_id:
-		logger.error("\nWorkload id is mandatory\n");
-		sys.exit(-1)
+    workload_id = options.workload_id
+    if not workload_id:
+        logger.error("\nWorkload id is mandatory\n");
+        sys.exit(-1)
 
-	in_data = options.in_data
-	show_receipt = options.receipt
-	show_decrypted_output = options.decrypted_output
-	requester_signature = options.requester_signature
+    in_data = options.in_data
+    show_receipt = options.receipt
+    show_decrypted_output = options.decrypted_output
+    requester_signature = options.requester_signature
 
 
 def Main(args=None):
-	ParseCommandLine(args)
+    ParseCommandLine(args)
 
-	config["Logging"] = {
-		"LogFile" : "__screen__",
-		"LogLevel" : "INFO"
-	}
+    config["Logging"] = {
+        "LogFile" : "__screen__",
+        "LogLevel" : "INFO"
+    }
 
-	plogger.setup_loggers(config.get("Logging", {}))
-	sys.stdout = plogger.stream_to_logger(
-		logging.getLogger("STDOUT"), logging.DEBUG)
-	sys.stderr = plogger.stream_to_logger(
-		logging.getLogger("STDERR"), logging.WARN)
+    plogger.setup_loggers(config.get("Logging", {}))
+    sys.stdout = plogger.stream_to_logger(
+        logging.getLogger("STDOUT"), logging.DEBUG)
+    sys.stderr = plogger.stream_to_logger(
+        logging.getLogger("STDERR"), logging.WARN)
 
-	logger.info("***************** TRUSTED COMPUTE FRAMEWORK (TCF)" +
-		" *****************")
+    logger.info("***************** TRUSTED COMPUTE FRAMEWORK (TCF)" +
+        " *****************")
 
-	global direct_jrpc
-	direct_jrpc = DirectJsonRpcApiConnector(config_file=None,config=config)
+    global direct_jrpc
+    direct_jrpc = DirectJsonRpcApiConnector(config_file=None,config=config)
 
-	global address
-	if mode == "registry" and address:
-		logger.error("\n Worker registry contract address is unsupported \n");
-		sys.exit(-1)
+    global address
+    if mode == "registry" and address:
+        logger.error("\n Worker registry contract address is unsupported \n");
+        sys.exit(-1)
 
-	# Connect to registry list and retrieve registry
-	global uri
-	if not uri and mode == "listing":
-		registry_list_instance = direct_jrpc.create_worker_registry_list(
-			config
-		)
-		# Lookup returns tuple, first element is number of registries and
-		# second is element is lookup tag and third is list of organization ids.
-		registry_count, lookup_tag, registry_list = registry_list_instance.registry_lookup()
-		logger.info("\n Registry lookup response: registry count: {} lookup tag: {} registry list: {}\n".format(
-			registry_count, lookup_tag, registry_list
-		))
-		if (registry_count == 0):
-			logger.error("No registries found")
-			sys.exit(1)
-		# Retrieve the fist registry details.
-		registry_retrieve_result = registry_list_instance.registry_retrieve(registry_list[0])
-		logger.info("\n Registry retrieve response: {}\n".format(
-			registry_retrieve_result
-		))
-		config["tcf"]["json_rpc_uri"] = registry_retrieve_result[0]
+    # Connect to registry list and retrieve registry
+    global uri
+    if not uri and mode == "listing":
+        registry_list_instance = direct_jrpc.create_worker_registry_list(
+            config
+        )
+        # Lookup returns tuple, first element is number of registries and
+        # second is element is lookup tag and third is list of organization ids.
+        registry_count, lookup_tag, registry_list = registry_list_instance.registry_lookup()
+        logger.info("\n Registry lookup response: registry count: {} lookup tag: {} registry list: {}\n".format(
+            registry_count, lookup_tag, registry_list
+        ))
+        if (registry_count == 0):
+            logger.error("No registries found")
+            sys.exit(1)
+        # Retrieve the fist registry details.
+        registry_retrieve_result = registry_list_instance.registry_retrieve(registry_list[0])
+        logger.info("\n Registry retrieve response: {}\n".format(
+            registry_retrieve_result
+        ))
+        config["tcf"]["json_rpc_uri"] = registry_retrieve_result[0]
 
-	# Prepare worker
-	req_id = 31
-	global worker_id
-	if not worker_id:
-		worker_registry_instance = direct_jrpc.create_worker_registry(
-			config
-		)
-		worker_lookup_result = worker_registry_instance.worker_lookup(
-			worker_type=WorkerType.TEE_SGX, id=req_id
-		)
-		logger.info("\n Worker lookup response: {}\n".format(
-			json.dumps(worker_lookup_result, indent=4)
-		))
-		if "result" in worker_lookup_result and \
-			"ids" in worker_lookup_result["result"].keys():
-			if worker_lookup_result["result"]["totalCount"] != 0:
-				worker_id = worker_lookup_result["result"]["ids"][0]
-			else:
-				logger.error("ERROR: No workers found")
-				sys.exit(1)
-		else:
-			logger.error("ERROR: Failed to lookup worker")
-			sys.exit(1)
+    # Prepare worker
+    req_id = 31
+    global worker_id
+    if not worker_id:
+        worker_registry_instance = direct_jrpc.create_worker_registry(
+            config
+        )
+        worker_lookup_result = worker_registry_instance.worker_lookup(
+            worker_type=WorkerType.TEE_SGX, id=req_id
+        )
+        logger.info("\n Worker lookup response: {}\n".format(
+            json.dumps(worker_lookup_result, indent=4)
+        ))
+        if "result" in worker_lookup_result and \
+            "ids" in worker_lookup_result["result"].keys():
+            if worker_lookup_result["result"]["totalCount"] != 0:
+                worker_id = worker_lookup_result["result"]["ids"][0]
+            else:
+                logger.error("ERROR: No workers found")
+                sys.exit(1)
+        else:
+            logger.error("ERROR: Failed to lookup worker")
+            sys.exit(1)
 
-	req_id += 1
-	worker_retrieve_result = worker_registry_instance.worker_retrieve(
-		worker_id,req_id
-	)
-	logger.info("\n Worker retrieve response: {}\n".format(
-		json.dumps(worker_retrieve_result, indent=4)
-	))
+    req_id += 1
+    worker_retrieve_result = worker_registry_instance.worker_retrieve(
+        worker_id,req_id
+    )
+    logger.info("\n Worker retrieve response: {}\n".format(
+        json.dumps(worker_retrieve_result, indent=4)
+    ))
 
-	if "error" in worker_retrieve_result:
-		logger.error("Unable to retrieve worker details\n")
-		sys.exit(1)
+    if "error" in worker_retrieve_result:
+        logger.error("Unable to retrieve worker details\n")
+        sys.exit(1)
 
     # Initializing Worker Object
-	worker_obj = worker_details.SGXWorkerDetails()
-	worker_obj.load_worker(worker_retrieve_result)
+    worker_obj = worker_details.SGXWorkerDetails()
+    worker_obj.load_worker(worker_retrieve_result)
 
-	logger.info("**********Worker details Updated with Worker ID" + \
-		"*********\n%s\n", worker_id)
+    logger.info("**********Worker details Updated with Worker ID" + \
+        "*********\n%s\n", worker_id)
 
-	# Convert workloadId to hex
-	global workload_id
-	workload_id = workload_id.encode("UTF-8").hex()
-	work_order_id = secrets.token_hex(32)
-	requester_id = secrets.token_hex(32)
-	session_iv = utility.generate_iv()
-	session_key = utility.generate_key()
-	requester_nonce = secrets.token_hex(16)
-	# Create work order
-	wo_params = WorkOrderParams(
-		work_order_id, worker_id, workload_id, requester_id,
-		session_key, session_iv, requester_nonce,
-		result_uri=" ", notify_uri=" ",
-		worker_encryption_key=worker_obj.encryption_key,
-		data_encryption_algorithm="AES-GCM-256"
-	)
-	# Add worker input data
-	global in_data
-	
-	for value in in_data:
-		wo_params.add_in_data(value)
+    # Convert workloadId to hex
+    global workload_id
+    workload_id = workload_id.encode("UTF-8").hex()
+    work_order_id = secrets.token_hex(32)
+    requester_id = secrets.token_hex(32)
+    session_iv = utility.generate_iv()
+    session_key = utility.generate_key()
+    requester_nonce = secrets.token_hex(16)
+    # Create work order
+    wo_params = WorkOrderParams(
+        work_order_id, worker_id, workload_id, requester_id,
+        session_key, session_iv, requester_nonce,
+        result_uri=" ", notify_uri=" ",
+        worker_encryption_key=worker_obj.encryption_key,
+        data_encryption_algorithm="AES-GCM-256"
+    )
+    # Add worker input data
+    global in_data
 
-	# Encrypt work order request hash
-	wo_params.add_encrypted_request_hash()
+    for value in in_data:
+        wo_params.add_in_data(value)
 
-	if requester_signature:
-		private_key = utility.generate_signing_keys()
-		# Add requester signature and requester verifying_key
-		if wo_params.add_requester_signature(private_key) == False:
-			logger.info("Work order request signing failed")
-			exit(1)
-	# Submit work order
-	logger.info("Work order submit request : %s, \n \n ",
-        wo_params.to_string())
-	work_order_instance = direct_jrpc.create_work_order(
-		config
-	)
-	req_id += 1
-	response = work_order_instance.work_order_submit(
-		wo_params.get_params(),
-		wo_params.get_in_data(),
-		wo_params.get_out_data(),
-		id=req_id
-	)
-	logger.info("Work order submit response : {}\n ".format(
-		json.dumps(response, indent=4)
-	))
+    # Encrypt work order request hash
+    wo_params.add_encrypted_request_hash()
 
-	if "error" in response and response["error"]["code"] != WorkOrderStatus.PENDING:
-		sys.exit(1)
-	# Retrieve result
-	req_id += 1
-	res = work_order_instance.work_order_get_result(
-		work_order_id,
-		req_id
-	)
+    private_key = utility.generate_signing_keys()
+    if requester_signature:
+        # Add requester signature and requester verifying_key
+        if wo_params.add_requester_signature(private_key) == False:
+            logger.info("Work order request signing failed")
+            exit(1)
+    # Submit work order
+    logger.info("Work order submit request : %s, \n \n ",
+        wo_params.to_string(req_id))
+    work_order_instance = direct_jrpc.create_work_order(
+        config
+    )
+    req_id += 1
+    response = work_order_instance.work_order_submit(
+        wo_params.get_params(),
+        wo_params.get_in_data(),
+        wo_params.get_out_data(),
+        id=req_id
+    )
+    logger.info("Work order submit response : {}\n ".format(
+        json.dumps(response, indent=4)
+    ))
 
-	logger.info("Work order get result : {}\n ".format(
-		json.dumps(res, indent=4)
-	))
-	
-	if "result" in res:
-		sig_obj = signature.ClientSignature()
-		status = sig_obj.verify_signature(res, worker_obj.verification_key)
-		try:
-			if status == SignatureStatus.PASSED:
-				logger.info("Signature verification Successful")
-				decrypted_res = utility.decrypted_response(
-					res, session_key, session_iv)
-				if show_decrypted_output:
-					logger.info("\nDecrypted response:\n {}"
-						.format(decrypted_res))
-			else:
-				logger.error("Signature verification Failed")
-				sys.exit(1)
-		except:
-			logger.error("ERROR: Failed to decrypt response")
-			sys.exit(1)
-	else:
-		logger.error("\n Work order get result failed {}\n".format(
-			res
-		))
-		sys.exit(1)
+    if "error" in response and response["error"]["code"] != WorkOrderStatus.PENDING:
+        sys.exit(1)
 
-	if show_receipt:	
-		# Retrieve receipt
-		wo_receipt_instance = direct_jrpc.create_work_order_receipt(
-			config
-		)
-		req_id += 1
-		receipt_res = wo_receipt_instance.work_order_receipt_retrieve(
-			work_order_id,
-			id=req_id
-		)
-		logger.info("\Retrieve receipt response:\n {}".format(
-			json.dumps(receipt_res, indent= 4)
-		))
+    wo_receipt_instance = direct_jrpc.create_work_order_receipt(
+        config
+    )
+    # Create receipt
+    if show_receipt:
+        req_id += 1
+        # Create work order receipt object using WorkOrderReceiptRequest class
+        wo_request = json.loads(wo_params.to_string(req_id))
+        wo_receipt_obj = WorkOrderReceiptRequest()
+        wo_create_receipt = wo_receipt_obj.create_receipt(
+            wo_request,
+            ReceiptCreateStatus.PENDING.value,
+            private_key
+        )
+        logger.info("Work order create receipt request : {} \n \n ".format(
+            json.dumps(wo_create_receipt, indent=4)
+        ))
+        # Submit work order create receipt jrpc request
+        wo_receipt_resp = wo_receipt_instance.work_order_receipt_create(
+            wo_create_receipt["workOrderId"],
+            wo_create_receipt["workerServiceId"],
+            wo_create_receipt["workerId"],
+            wo_create_receipt["requesterId"],
+            wo_create_receipt["receiptCreateStatus"],
+            wo_create_receipt["workOrderRequestHash"],
+            wo_create_receipt["requesterGeneratedNonce"],
+            wo_create_receipt["requesterSignature"],
+            wo_create_receipt["signatureRules"],
+            wo_create_receipt["receiptVerificationKey"],
+            req_id
+        )
+        logger.info("Work order create receipt response : {} \n \n ".format(
+            wo_receipt_resp
+        ))
+
+    # Retrieve result
+    req_id += 1
+    res = work_order_instance.work_order_get_result(
+        work_order_id,
+        req_id
+    )
+
+    logger.info("Work order get result : {}\n ".format(
+        json.dumps(res, indent=4)
+    ))
+    sig_obj = signature.ClientSignature()
+    if "result" in res:
+        status = sig_obj.verify_signature(res, worker_obj.verification_key)
+        try:
+            if status == SignatureStatus.PASSED:
+                logger.info("Signature verification Successful")
+                decrypted_res = utility.decrypted_response(
+                    res, session_key, session_iv)
+                if show_decrypted_output:
+                    logger.info("\nDecrypted response:\n {}"
+                        .format(decrypted_res))
+            else:
+                logger.error("Signature verification Failed")
+                sys.exit(1)
+        except:
+            logger.error("ERROR: Failed to decrypt response")
+            sys.exit(1)
+    else:
+        logger.error("\n Work order get result failed {}\n".format(
+            res
+        ))
+        sys.exit(1)
+
+    if show_receipt:
+        # Retrieve receipt
+        req_id += 1
+        receipt_res = wo_receipt_instance.work_order_receipt_retrieve(
+            work_order_id,
+            id=req_id
+        )
+        logger.info("\n Retrieve receipt response:\n {}".format(
+            json.dumps(receipt_res, indent= 4)
+        ))
+        # Retrieve last update to receipt by passing 0xFFFFFFFF
+        req_id += 1
+        receipt_update_retrieve = wo_receipt_instance.work_order_receipt_update_retrieve(
+            work_order_id,
+            None,
+            1 << 32,
+            id=req_id
+        )
+        logger.info("\n Last update to receipt receipt is:\n {}".format(
+            json.dumps(receipt_update_retrieve, indent= 4)
+        ))
+        status = sig_obj.verify_update_receipt_signature(receipt_update_retrieve)
+        if status == SignatureStatus.PASSED:
+            logger.info("Work order receipt retrieve signature verification Successful")
+        else:
+            logger.info("Work order receipt retrieve signature verification failed!!")
+            sys.exit(1)
+
 #------------------------------------------------------------------------------
 Main()

--- a/examples/apps/heart_disease_eval/client/heart_gui.py
+++ b/examples/apps/heart_disease_eval/client/heart_gui.py
@@ -39,13 +39,14 @@ import worker.worker_details as worker
 from utility.tcf_types import WorkerType
 from work_order.work_order_params import WorkOrderParams
 from connectors.direct.direct_json_rpc_api_connector \
-	import DirectJsonRpcApiConnector
+    import DirectJsonRpcApiConnector
 import config.config as pconfig
 import utility.logger as plogger
 import crypto.crypto as crypto
-from error_code.error_status import WorkOrderStatus
+from error_code.error_status import WorkOrderStatus, ReceiptCreateStatus
 import utility.signature as signature
 from error_code.error_status import SignatureStatus
+from work_order_receipt.work_order_receipt_request import WorkOrderReceiptRequest
 
 # Remove duplicate loggers
 for handler in logging.root.handlers[:]:
@@ -62,690 +63,719 @@ RESULT_BACKGROUND = "pale goldenrod"
 
 # -----------------------------------------------------------------
 def _generate_random_or_normal_number(normal, percent_normal, low, high):
-	"""Generate number "normal" for "percent_normal" % of the time.
-	   Otherwise, generate a random number in the interval ["low", "high"].
-	"""
-	if percent_normal >= random.randint(0, 100):
-		return normal
-	return random.randint(low, high)
+    """Generate number "normal" for "percent_normal" % of the time.
+       Otherwise, generate a random number in the interval ["low", "high"].
+    """
+    if percent_normal >= random.randint(0, 100):
+        return normal
+    return random.randint(low, high)
 
 def _generate_random_data():
-	"""Generate a random data string for input as evaluation data.
-	   For example:	"35 0 1 67 102 125 1 95 0 10 1 1 3 1"
-	"""
+    """Generate a random data string for input as evaluation data.
+       For example:    "35 0 1 67 102 125 1 95 0 10 1 1 3 1"
+    """
 
-	age = _generate_random_or_normal_number(35, 67, 18, 100)
-	sex = _generate_random_or_normal_number(0, 50, 1, 1)
-	cp = _generate_random_or_normal_number(4, 67, 1, 3)
-	trestbps = _generate_random_or_normal_number(67, 67, 108, 218)
-	chol = _generate_random_or_normal_number(102, 67, 126, 309)
-	fbs = _generate_random_or_normal_number(125, 67, 98, 248)
-	restecg = _generate_random_or_normal_number(0, 67, 1, 2)
-	thalach = _generate_random_or_normal_number(95, 67, 61, 198)
-	exang = _generate_random_or_normal_number(0, 67, 1, 1)
-	oldpeak = _generate_random_or_normal_number(10, 67, 0, 100)
-	slop = _generate_random_or_normal_number(0, 67, 1, 2)
-	ca = _generate_random_or_normal_number(0, 67, 1, 3)
-	thaldur = _generate_random_or_normal_number(3, 67, 6, 7)
-	num = _generate_random_or_normal_number(0, 67, 1, 1)
+    age = _generate_random_or_normal_number(35, 67, 18, 100)
+    sex = _generate_random_or_normal_number(0, 50, 1, 1)
+    cp = _generate_random_or_normal_number(4, 67, 1, 3)
+    trestbps = _generate_random_or_normal_number(67, 67, 108, 218)
+    chol = _generate_random_or_normal_number(102, 67, 126, 309)
+    fbs = _generate_random_or_normal_number(125, 67, 98, 248)
+    restecg = _generate_random_or_normal_number(0, 67, 1, 2)
+    thalach = _generate_random_or_normal_number(95, 67, 61, 198)
+    exang = _generate_random_or_normal_number(0, 67, 1, 1)
+    oldpeak = _generate_random_or_normal_number(10, 67, 0, 100)
+    slop = _generate_random_or_normal_number(0, 67, 1, 2)
+    ca = _generate_random_or_normal_number(0, 67, 1, 3)
+    thaldur = _generate_random_or_normal_number(3, 67, 6, 7)
+    num = _generate_random_or_normal_number(0, 67, 1, 1)
 
-	return "{} {} {} {} {} {} {} {} {} {} {} {} {} {}".format(
-		age, sex, cp, trestbps, chol, fbs, restecg, thalach,
-		exang, oldpeak, slop, ca, thaldur, num)
+    return "{} {} {} {} {} {} {} {} {} {} {} {} {} {}".format(
+        age, sex, cp, trestbps, chol, fbs, restecg, thalach,
+        exang, oldpeak, slop, ca, thaldur, num)
 
 def _int_validate(text):
-	"""Validates that input is a non-negative integer."""
+    """Validates that input is a non-negative integer."""
 
-	if str.isdigit(text) or text == "":
-		return True
-	else:
-		return False
+    if str.isdigit(text) or text == "":
+        return True
+    else:
+        return False
 
 def _float_validate(text):
-	"""Validates that input is a non-negative, non-special float."""
+    """Validates that input is a non-negative, non-special float."""
 
-	if text == "":
-		return True
-	try:
-		float(text)
-		if float(text) < 0.0 or float(text) == float("NaN") \
-			or float(text) == float("INF") \
-			or float(text) == float("-INF"):
-			return False
-		return True
-	except ValueError:
-		return False
+    if text == "":
+        return True
+    try:
+        float(text)
+        if float(text) < 0.0 or float(text) == float("NaN") \
+            or float(text) == float("INF") \
+            or float(text) == float("-INF"):
+            return False
+        return True
+    except ValueError:
+        return False
 
 class intEntry:
-	"""User entry for non-negative integer."""
+    """User entry for non-negative integer."""
 
-	def __init__(self, master, name):
-		global cur_row
-		label = tk.Label(master, text=name, background=BACKGROUND)
-		label.grid(row=cur_row, column=0, sticky="e", pady=(5,0))
-		validate = (master.register(_int_validate))
-		self.entry = tk.Entry(master, validate="all",
-			validatecommand=(validate, "%P"), width=5,
-			background=ENTRY_COLOR)
-		self.entry.grid(row=cur_row, column=1, padx=(10,0), pady=(5,0),
-			sticky="w")
-		cur_row += 1
+    def __init__(self, master, name):
+        global cur_row
+        label = tk.Label(master, text=name, background=BACKGROUND)
+        label.grid(row=cur_row, column=0, sticky="e", pady=(5,0))
+        validate = (master.register(_int_validate))
+        self.entry = tk.Entry(master, validate="all",
+            validatecommand=(validate, "%P"), width=5,
+            background=ENTRY_COLOR)
+        self.entry.grid(row=cur_row, column=1, padx=(10,0), pady=(5,0),
+            sticky="w")
+        cur_row += 1
 
-	def get(self):
-		# Fails if empty field
-		try:
-			return int(self.entry.get())
-		except ValueError:
-			return None
+    def get(self):
+        # Fails if empty field
+        try:
+            return int(self.entry.get())
+        except ValueError:
+            return None
 
-	def enable(self):
-		self.entry.config(state=tk.NORMAL)
+    def enable(self):
+        self.entry.config(state=tk.NORMAL)
 
-	def disable(self):
-		self.entry.config(state=tk.DISABLED)
+    def disable(self):
+        self.entry.config(state=tk.DISABLED)
 
 class floatEntry:
-	"""User entry for non-negative, non-special floating point number."""
+    """User entry for non-negative, non-special floating point number."""
 
-	def __init__(self, master, name):
-		global cur_row
-		label = tk.Label(master, text=name, background=BACKGROUND)
-		label.grid(row=cur_row, column=0, sticky="e", pady=(5,))
-		validate = (master.register(_float_validate))
-		self.entry = tk.Entry(master, validate="all",
-			validatecommand=(validate, "%P"), width=10,
-			background=ENTRY_COLOR)
-		self.entry.grid(row=cur_row, column=1, padx=(10,0), pady=(5,),
-			sticky="w")
-		cur_row += 1
+    def __init__(self, master, name):
+        global cur_row
+        label = tk.Label(master, text=name, background=BACKGROUND)
+        label.grid(row=cur_row, column=0, sticky="e", pady=(5,))
+        validate = (master.register(_float_validate))
+        self.entry = tk.Entry(master, validate="all",
+            validatecommand=(validate, "%P"), width=10,
+            background=ENTRY_COLOR)
+        self.entry.grid(row=cur_row, column=1, padx=(10,0), pady=(5,),
+            sticky="w")
+        cur_row += 1
 
-	def get(self):
-		try:
-			return float(self.entry.get())
-		except ValueError:
-			return None
+    def get(self):
+        try:
+            return float(self.entry.get())
+        except ValueError:
+            return None
 
-	def enable(self):
-		self.entry.config(state=tk.NORMAL)
+    def enable(self):
+        self.entry.config(state=tk.NORMAL)
 
-	def disable(self):
-		self.entry.config(state=tk.DISABLED)
+    def disable(self):
+        self.entry.config(state=tk.DISABLED)
 
 class radio:
-	"""User entry for a radio button."""
+    """User entry for a radio button."""
 
-	# Options is a list of text-value pairs
-	def __init__(self, master, name, options):
-		global cur_row
-		if not all(len(tup)==2 for tup in options):
-			print("ERROR: Mismatched text-value pairs")
-			exit(1)
+    # Options is a list of text-value pairs
+    def __init__(self, master, name, options):
+        global cur_row
+        if not all(len(tup)==2 for tup in options):
+            print("ERROR: Mismatched text-value pairs")
+            exit(1)
 
-		self.var = tk.IntVar()
-		self.var.set(None)
-		label = tk.Label(master, text=name, background=BACKGROUND)
-		label.grid(row=cur_row, column=0, pady=(5,0), sticky="e")
+        self.var = tk.IntVar()
+        self.var.set(None)
+        label = tk.Label(master, text=name, background=BACKGROUND)
+        label.grid(row=cur_row, column=0, pady=(5,0), sticky="e")
 
-		self.button_list = []
-		for i in range(len(options)):
-			button = tk.Radiobutton(master, text=options[i][0],
-				variable=self.var, value=options[i][1],
-				background=BACKGROUND)
-			self.button_list.append(button)
-			if i==0:
-				button.grid(row=cur_row, column=1, pady=(5,0),
-					sticky="w")
-			else:
-				button.grid(row=cur_row, column=1, sticky="w")
-			cur_row += 1
+        self.button_list = []
+        for i in range(len(options)):
+            button = tk.Radiobutton(master, text=options[i][0],
+                variable=self.var, value=options[i][1],
+                background=BACKGROUND)
+            self.button_list.append(button)
+            if i==0:
+                button.grid(row=cur_row, column=1, pady=(5,0),
+                    sticky="w")
+            else:
+                button.grid(row=cur_row, column=1, sticky="w")
+            cur_row += 1
 
-	def get(self):
-		try:
-			return self.var.get()
-		except tk.TclError:
-			return None
+    def get(self):
+        try:
+            return self.var.get()
+        except tk.TclError:
+            return None
 
-	def enable(self):
-		for button in self.button_list:
-			button.config(state=tk.NORMAL)
+    def enable(self):
+        for button in self.button_list:
+            button.config(state=tk.NORMAL)
 
-	def disable(self):
-		for button in self.button_list:
-			button.config(state=tk.DISABLED)
+    def disable(self):
+        for button in self.button_list:
+            button.config(state=tk.DISABLED)
 
 class resultWindow(tk.Toplevel):
-	"""Create result window that appears after clicking "Evaluate"."""
+    """Create result window that appears after clicking "Evaluate"."""
 
-	def __init__(self, parent, message):
-		tk.Toplevel.__init__(self, parent)
-		self.config(background=RESULT_BACKGROUND)
-		self.parent = parent
-		# Lock main window
-		self.transient(parent)
-		self.grab_set()
-		self.initial_focus = self
-		self.initial_focus.focus_set()
-		self.title("Evaluation Result")
-		self.protocol("WM_DELETE_WINDOW", self.close)
+    def __init__(self, parent, message):
+        tk.Toplevel.__init__(self, parent)
+        self.config(background=RESULT_BACKGROUND)
+        self.parent = parent
+        # Lock main window
+        self.transient(parent)
+        self.grab_set()
+        self.initial_focus = self
+        self.initial_focus.focus_set()
+        self.title("Evaluation Result")
+        self.protocol("WM_DELETE_WINDOW", self.close)
 
-		# Main content
-		self.main_frame = tk.Frame(self, background=RESULT_BACKGROUND)
-		self.main_frame.pack()
+        # Main content
+        self.main_frame = tk.Frame(self, background=RESULT_BACKGROUND)
+        self.main_frame.pack()
 
-		self.frame1 = tk.Frame(self.main_frame)
-		self.frame1.pack(side=tk.LEFT)
-		self.result_text = tk.StringVar()
-		self.label = tk.Label(self.frame1,
-			textvariable=self.result_text, width=45,
-			background=RESULT_BACKGROUND)
-		default_font = font.Font(font="TkDefaultFont")
-		new_font = default_font
-		new_font.config(weight=font.BOLD)
-		self.label.config(font=new_font)
-		self.label.pack()
+        self.frame1 = tk.Frame(self.main_frame)
+        self.frame1.pack(side=tk.LEFT)
+        self.result_text = tk.StringVar()
+        self.label = tk.Label(self.frame1,
+            textvariable=self.result_text, width=45,
+            background=RESULT_BACKGROUND)
+        default_font = font.Font(font="TkDefaultFont")
+        new_font = default_font
+        new_font.config(weight=font.BOLD)
+        self.label.config(font=new_font)
+        self.label.pack()
 
-		# JSON window display sidebar buttons
-		self.frame2 = tk.Frame(self.main_frame,
-			background=RESULT_BACKGROUND)
-		self.frame2.pack(side=tk.LEFT)
+        # JSON window display sidebar buttons
+        self.frame2 = tk.Frame(self.main_frame,
+            background=RESULT_BACKGROUND)
+        self.frame2.pack(side=tk.LEFT)
 
-		self.frame2 = tk.Frame(self.frame2,
-			background=RESULT_BACKGROUND)
-		self.frame2.pack(side=tk.LEFT)
+        self.frame2 = tk.Frame(self.frame2,
+            background=RESULT_BACKGROUND)
+        self.frame2.pack(side=tk.LEFT)
 
-		self.request_button = tk.Button(
-			self.frame2, text="View Request", command=self.request,
-			background=BUTTON_COLOR)
-		self.request_button.pack(fill=tk.X, padx=(0,10), pady=(10,0))
+        self.request_button = tk.Button(
+            self.frame2, text="View Request", command=self.request,
+            background=BUTTON_COLOR)
+        self.request_button.pack(fill=tk.X, padx=(0,10), pady=(10,0))
 
-		self.result_button = tk.Button(
-			self.frame2, text="View Result", command=self.result,
-			background=BUTTON_COLOR)
-		self.result_button.pack(fill=tk.X, padx=(0,10),pady=(10,0))
+        self.result_button = tk.Button(
+            self.frame2, text="View Result", command=self.result,
+            background=BUTTON_COLOR)
+        self.result_button.pack(fill=tk.X, padx=(0,10),pady=(10,0))
 
-		self.receipt_button = tk.Button(
-			self.frame2, text="View Receipt",
-			command=self.receipt, background=BUTTON_COLOR)
-		self.receipt_button.pack(fill=tk.X, padx=(0,10),pady=(10,0))
+        self.receipt_button = tk.Button(
+            self.frame2, text="View Receipt",
+            command=self.receipt, background=BUTTON_COLOR)
+        self.receipt_button.pack(fill=tk.X, padx=(0,10),pady=(10,0))
 
-		# Close button
-		self.close_button = tk.Button(self, text="Close",
-			command=self.close, background=BUTTON_COLOR)
-		self.close_button.pack(pady=(0,5))
+        # Close button
+        self.close_button = tk.Button(self, text="Close",
+            command=self.close, background=BUTTON_COLOR)
+        self.close_button.pack(pady=(0,5))
 
-		self.evaluate(message)
+        self.evaluate(message)
 
-	def evaluate(self, message):
-		"""Create and submit workorder and wait for result."""
+    def evaluate(self, message):
+        """Create and submit workorder and wait for result."""
 
-		self.result_text.set("Waiting for evaluation result...")
-		self.update()
+        self.result_text.set("Waiting for evaluation result...")
+        self.update()
 
-		# Create, sign, and submit workorder.
-		# Convert workloadId to hex.
-		workload_id = "heart-disease-eval"
-		workload_id = workload_id.encode("UTF-8").hex()
-		session_iv = utility.generate_iv()
-		session_key = utility.generate_key()
-		requester_nonce = secrets.token_hex(16)
-		work_order_id = secrets.token_hex(32)
-		requester_id = secrets.token_hex(32)
-		wo_params = WorkOrderParams(
-			work_order_id, worker_id, workload_id, requester_id,
-			session_key, session_iv, requester_nonce,
-			result_uri=" ", notify_uri=" ",
-			worker_encryption_key=worker_obj.encryption_key,
-			data_encryption_algorithm="AES-GCM-256"
-		)
-		wo_params.add_in_data(message)
+        # Create, sign, and submit workorder.
+        # Convert workloadId to hex.
+        workload_id = "heart-disease-eval"
+        workload_id = workload_id.encode("UTF-8").hex()
+        session_iv = utility.generate_iv()
+        session_key = utility.generate_key()
+        requester_nonce = secrets.token_hex(16)
+        work_order_id = secrets.token_hex(32)
+        requester_id = secrets.token_hex(32)
+        wo_params = WorkOrderParams(
+            work_order_id, worker_id, workload_id, requester_id,
+            session_key, session_iv, requester_nonce,
+            result_uri=" ", notify_uri=" ",
+            worker_encryption_key=worker_obj.encryption_key,
+            data_encryption_algorithm="AES-GCM-256"
+        )
+        wo_params.add_in_data(message)
 
-		wo_params.add_encrypted_request_hash()
+        wo_params.add_encrypted_request_hash()
 
-		if requester_signature:
-			private_key = utility.generate_signing_keys()
-			# Add requester signature and requester verifying_key
-			if wo_params.add_requester_signature(private_key) == \
-				False:
-				logger.info("Work order request signing failed")
-				exit(1)
+        private_key = utility.generate_signing_keys()
+        if requester_signature:
+            # Add requester signature and requester verifying_key
+            if wo_params.add_requester_signature(private_key) == \
+                False:
+                logger.info("Work order request signing failed")
+                exit(1)
 
-		# Set text for JSON sidebar
-		req_id = 51
-		self.request_json = wo_params.to_string()
+        # Set text for JSON sidebar
+        req_id = 51
+        self.request_json = wo_params.to_string(req_id)
 
-		work_order_instance = direct_jrpc.create_work_order(
-			config
-		)
-		response = work_order_instance.work_order_submit(
-			wo_params.get_params(),
-			wo_params.get_in_data(),
-			wo_params.get_out_data(),
-			id=req_id
-		)
-		logger.info("Work order submit response : {}\n ".format(
-			json.dumps(response, indent=4)
-		))
-		if "error" in response and response["error"]["code"] != \
-		    WorkOrderStatus.PENDING:
-			sys.exit(1)
-		req_id += 1
+        work_order_instance = direct_jrpc.create_work_order(
+            config
+        )
+        response = work_order_instance.work_order_submit(
+            wo_params.get_params(),
+            wo_params.get_in_data(),
+            wo_params.get_out_data(),
+            id=req_id
+        )
+        logger.info("Work order submit response : {}\n ".format(
+            json.dumps(response, indent=4)
+        ))
+        if "error" in response and response["error"]["code"] != \
+            WorkOrderStatus.PENDING:
+            sys.exit(1)
+        # Create work order receipt
+        req_id += 1
+        wo_receipt_instance = direct_jrpc.create_work_order_receipt(
+            config
+        )
+        wo_request = json.loads(self.request_json)
+        wo_receipt_obj = WorkOrderReceiptRequest()
+        wo_create_receipt = wo_receipt_obj.create_receipt(
+            wo_request,
+            ReceiptCreateStatus.PENDING.value,
+            private_key
+        )
+        logger.info("Work order create receipt request : {} \n \n ".format(
+            json.dumps(wo_create_receipt, indent=4)
+        ))
+        # Submit work order create receipt jrpc request
+        wo_receipt_resp = wo_receipt_instance.work_order_receipt_create(
+            wo_create_receipt["workOrderId"],
+            wo_create_receipt["workerServiceId"],
+            wo_create_receipt["workerId"],
+            wo_create_receipt["requesterId"],
+            wo_create_receipt["receiptCreateStatus"],
+            wo_create_receipt["workOrderRequestHash"],
+            wo_create_receipt["requesterGeneratedNonce"],
+            wo_create_receipt["requesterSignature"],
+            wo_create_receipt["signatureRules"],
+            wo_create_receipt["receiptVerificationKey"],
+            req_id
+        )
 
-		# Retrieve result and set GUI result text
-		res = work_order_instance.work_order_get_result(
-			work_order_id,
-			req_id
-		)
-		self.result_json = json.dumps(res, indent=4)
-		if "result" in res:
-			sig_obj = signature.ClientSignature()
-			status = sig_obj.verify_signature(res,
-				worker_obj.verification_key)
-			try:
-				if status == SignatureStatus.PASSED:
-					logger.info("Signature verification" + \
-						" Successful")
-					decrypted_res = utility. \
-						decrypted_response(
-						res, session_key, session_iv)
-					logger.info("\n" + \
-						"Decrypted response:\n {}".
-						format(decrypted_res))
-				else:
-					logger.info("Signature verification" + \
-						" Failed")
-					sys.exit(1)
-			except:
-				logger.info("ERROR: Failed to decrypt response")
-				sys.exit(1)
-		else:
-			logger.info("\n Work order get result failed {}\n". \
-				format(res))
-			sys.exit(1)
+        logger.info("Work order create receipt response : {} \n \n ".format(
+            wo_receipt_resp
+        ))
 
-		# Set text for JSON sidebar
-		self.result_text.set(
-			decrypted_res[0]["data"])
+        # Retrieve result and set GUI result text
+        res = work_order_instance.work_order_get_result(
+            work_order_id,
+            req_id
+        )
+        self.result_json = json.dumps(res, indent=4)
+        if "result" in res:
+            sig_obj = signature.ClientSignature()
+            status = sig_obj.verify_signature(res,
+                worker_obj.verification_key)
+            try:
+                if status == SignatureStatus.PASSED:
+                    logger.info("Signature verification" + \
+                        " Successful")
+                    decrypted_res = utility. \
+                        decrypted_response(
+                        res, session_key, session_iv)
+                    logger.info("\n" + \
+                        "Decrypted response:\n {}".
+                        format(decrypted_res))
+                else:
+                    logger.info("Signature verification" + \
+                        " Failed")
+                    sys.exit(1)
+            except:
+                logger.info("ERROR: Failed to decrypt response")
+                sys.exit(1)
+        else:
+            logger.info("\n Work order get result failed {}\n". \
+                format(res))
+            sys.exit(1)
 
-		# Retrieve receipt
-		# Set text for JSON sidebar
-		wo_receipt_instance = direct_jrpc.create_work_order_receipt(
-			config
-		)
-		req_id += 1
-		self.receipt_json = json.dumps(
-			wo_receipt_instance.work_order_receipt_retrieve(
-				work_order_id,
-				req_id
-			),
-			indent=4
-		)
+        # Set text for JSON sidebar
+        self.result_text.set(
+            decrypted_res[0]["data"])
 
-	def request(self):
-		jsonWindow(self, self.request_json, "Request JSON")
+        # Retrieve receipt
+        # Set text for JSON sidebar
+        req_id += 1
+        self.receipt_json = json.dumps(
+            wo_receipt_instance.work_order_receipt_retrieve(
+                work_order_id,
+                req_id
+            ),
+            indent=4
+        )
 
-	def result(self):
-		jsonWindow(self, self.result_json, "Result JSON")
+    def request(self):
+        jsonWindow(self, self.request_json, "Request JSON")
 
-	def receipt(self):
-		jsonWindow(self, self.receipt_json, "Receipt JSON")
+    def result(self):
+        jsonWindow(self, self.result_json, "Result JSON")
 
-	def close(self):
-		self.parent.focus_set()
-		self.destroy()
+    def receipt(self):
+        jsonWindow(self, self.receipt_json, "Receipt JSON")
+
+    def close(self):
+        self.parent.focus_set()
+        self.destroy()
 
 class jsonWindow(tk.Toplevel):
-	"""Template for JSON display
-	   (from clicking View Request/Result/Receipt buttons).
-	"""
+    """Template for JSON display
+       (from clicking View Request/Result/Receipt buttons).
+    """
 
-	def __init__(self, parent, json, title):
-		tk.Toplevel.__init__(self, parent)
-		self.title(title)
-		self.scrollbar = tk.Scrollbar(self)
-		self.scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+    def __init__(self, parent, json, title):
+        tk.Toplevel.__init__(self, parent)
+        self.title(title)
+        self.scrollbar = tk.Scrollbar(self)
+        self.scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
 
-		self.text = tk.Text(self, yscrollcommand=self.scrollbar.set)
-		self.text.insert(tk.END, json)
-		self.text.config(state=tk.DISABLED)
-		self.text.pack(expand=True, fill="both")
+        self.text = tk.Text(self, yscrollcommand=self.scrollbar.set)
+        self.text.insert(tk.END, json)
+        self.text.config(state=tk.DISABLED)
+        self.text.pack(expand=True, fill="both")
 
-		self.scrollbar.config(command=self.text.yview)
+        self.scrollbar.config(command=self.text.yview)
 
 def gui_main():
-	"""Create main Tkinter window and "Evaluate" event handler."""
+    """Create main Tkinter window and "Evaluate" event handler."""
 
-	root = tk.Tk()
-	root.title("Heart Disease Evaluation")
-	root.config(background=BACKGROUND)
+    root = tk.Tk()
+    root.title("Heart Disease Evaluation")
+    root.config(background=BACKGROUND)
 
-	# Display image
-	imageFile = TCFHOME + \
-		"/examples/apps/heart_disease_eval/images/ecg.jpg"
-	img = ImageTk.PhotoImage(Image.open(imageFile))
-	canvas = tk.Canvas(root, width=290, height=220, background=BACKGROUND)
-	canvas.pack()
-	canvas.create_image(20, 20, anchor=tk.NW, image=img) 
+    # Display image
+    imageFile = TCFHOME + \
+        "/examples/apps/heart_disease_eval/images/ecg.jpg"
+    img = ImageTk.PhotoImage(Image.open(imageFile))
+    canvas = tk.Canvas(root, width=290, height=220, background=BACKGROUND)
+    canvas.pack()
+    canvas.create_image(20, 20, anchor=tk.NW, image=img)
 
-	# Setup left and right frames for data entry
-	var_root = tk.Frame(root, background=BACKGROUND)
-	var_root.pack(pady=(10,0))
-	v_frame1 = tk.Frame(var_root, background=BACKGROUND)
-	v_frame1.pack(fill=tk.Y, side=tk.LEFT, padx=(10,0))
-	v_frame2 = tk.Frame(var_root, background=BACKGROUND)
-	v_frame2.pack(fill=tk.Y, side=tk.LEFT, padx=(0,10))
-	# Organizes parameter grid
-	global cur_row
-	cur_row = 0
+    # Setup left and right frames for data entry
+    var_root = tk.Frame(root, background=BACKGROUND)
+    var_root.pack(pady=(10,0))
+    v_frame1 = tk.Frame(var_root, background=BACKGROUND)
+    v_frame1.pack(fill=tk.Y, side=tk.LEFT, padx=(10,0))
+    v_frame2 = tk.Frame(var_root, background=BACKGROUND)
+    v_frame2.pack(fill=tk.Y, side=tk.LEFT, padx=(0,10))
+    # Organizes parameter grid
+    global cur_row
+    cur_row = 0
 
-	# Parameter grid
-	age = intEntry(v_frame1, "Age")
-	sex = radio(v_frame1, "Sex", [("Male", 1), ("Female", 0)])
-	cp = radio(v_frame1, "Chest pain type", [("Typical angina", 1),
-		("Atypical angina", 2), ("Non-anginal pain", 3),
-		("Asymptomatic", 4)])
-	trestbps = intEntry(v_frame1, "Resting blood pressure\n (mm Hg)")
-	chol = intEntry(v_frame1, "Serum cholesterol (mg/dl)")
-	fbs = intEntry(v_frame1, "Fasting blood sugar (mg/dl)")
-	restecg = radio(v_frame1, "Electrocardiographic\n resting results",
-		[("Normal", 0), ("ST-T wave abnormality", 1),
-		("Showing hypertrophy", 2)])
-	thalach = intEntry(v_frame1, "Maximum heart rate")
-	exang = radio(v_frame2, "Exercise induced angina",
-		[("Yes", 1), ("No", 0)])
-	oldpeak = floatEntry(v_frame2,
-		"ST depression induced by\n exercise relative to rest")
-	slope = radio(v_frame2, "Slope of the peak\n exercise ST segment",
-		[("Upsloping", 0), ("Flat", 1), ("Downsloping", 2)])
-	ca = radio(v_frame2, "Major vessels colored\n by flouroscopy",
-		[("0", 0), ("1", 1), ("2", 2), ("3", 3)])
-	thal = radio(v_frame2, "Thallium stress test",
-		[("Normal", 3), ("Fixed defect", 6), ("Reversible defect", 7)])
-	num = radio (v_frame2, "Heart disease diagnosis",
-		[("<50% diameter narrowing", 0),
-		 (">50% diameter narrowing", 1)])
-	var_list = [age, sex, cp, trestbps, chol, fbs, restecg, thalach,
-		exang, oldpeak, slope, ca, thal, num]
+    # Parameter grid
+    age = intEntry(v_frame1, "Age")
+    sex = radio(v_frame1, "Sex", [("Male", 1), ("Female", 0)])
+    cp = radio(v_frame1, "Chest pain type", [("Typical angina", 1),
+        ("Atypical angina", 2), ("Non-anginal pain", 3),
+        ("Asymptomatic", 4)])
+    trestbps = intEntry(v_frame1, "Resting blood pressure\n (mm Hg)")
+    chol = intEntry(v_frame1, "Serum cholesterol (mg/dl)")
+    fbs = intEntry(v_frame1, "Fasting blood sugar (mg/dl)")
+    restecg = radio(v_frame1, "Electrocardiographic\n resting results",
+        [("Normal", 0), ("ST-T wave abnormality", 1),
+        ("Showing hypertrophy", 2)])
+    thalach = intEntry(v_frame1, "Maximum heart rate")
+    exang = radio(v_frame2, "Exercise induced angina",
+        [("Yes", 1), ("No", 0)])
+    oldpeak = floatEntry(v_frame2,
+        "ST depression induced by\n exercise relative to rest")
+    slope = radio(v_frame2, "Slope of the peak\n exercise ST segment",
+        [("Upsloping", 0), ("Flat", 1), ("Downsloping", 2)])
+    ca = radio(v_frame2, "Major vessels colored\n by flouroscopy",
+        [("0", 0), ("1", 1), ("2", 2), ("3", 3)])
+    thal = radio(v_frame2, "Thallium stress test",
+        [("Normal", 3), ("Fixed defect", 6), ("Reversible defect", 7)])
+    num = radio (v_frame2, "Heart disease diagnosis",
+        [("<50% diameter narrowing", 0),
+         (">50% diameter narrowing", 1)])
+    var_list = [age, sex, cp, trestbps, chol, fbs, restecg, thalach,
+        exang, oldpeak, slope, ca, thal, num]
 
-	def string_toggle():
-		"""Disable/enable other variable entries/buttons based on
-		   whether string input option is selected.
-		"""
+    def string_toggle():
+        """Disable/enable other variable entries/buttons based on
+           whether string input option is selected.
+        """
 
-		if string_use.get() == 1 or random_use.get() == 1:
-			for var in var_list:
-				var.disable()
-			string_entry.config(state=tk.NORMAL)
-		else:
-			for var in var_list:
-				var.enable()
-			string_entry.config(state=tk.DISABLED)
+        if string_use.get() == 1 or random_use.get() == 1:
+            for var in var_list:
+                var.disable()
+            string_entry.config(state=tk.NORMAL)
+        else:
+            for var in var_list:
+                var.enable()
+            string_entry.config(state=tk.DISABLED)
 
-	# Input vars as string option with a check button to enable
-	random_frame = tk.Frame(root, background=ENTRY_COLOR)
-	random_frame.pack()
+    # Input vars as string option with a check button to enable
+    random_frame = tk.Frame(root, background=ENTRY_COLOR)
+    random_frame.pack()
 
-	# Option to generate random data entry
-	random_use = tk.IntVar()
-	random_check = tk.Checkbutton(
-		random_frame, command=string_toggle, variable=random_use,
-		background=BACKGROUND)
-	random_check.pack(side=tk.LEFT)
-	random_label = tk.Label(random_frame,
-		text="Generate random data ",
-		background=BACKGROUND)
-	random_label.pack(side=tk.LEFT)
+    # Option to generate random data entry
+    random_use = tk.IntVar()
+    random_check = tk.Checkbutton(
+        random_frame, command=string_toggle, variable=random_use,
+        background=BACKGROUND)
+    random_check.pack(side=tk.LEFT)
+    random_label = tk.Label(random_frame,
+        text="Generate random data ",
+        background=BACKGROUND)
+    random_label.pack(side=tk.LEFT)
 
-	# Option to enter data as space-separated string entries
-	string_frame = tk.Frame(root, background=ENTRY_COLOR)
-	string_frame.pack()
-	string_use = tk.IntVar()
-	string_check = tk.Checkbutton(
-		string_frame, command=string_toggle, variable=string_use,
-		background=BACKGROUND)
-	string_check.pack(side=tk.LEFT)
-	string_label = tk.Label(string_frame,
-		text="Input variables as a string",
-		background=BACKGROUND)
-	string_label.pack(side=tk.LEFT)
-	string_entry = tk.Entry(string_frame, state=tk.DISABLED, width=50,
-		background=ENTRY_COLOR)
-	string_entry.pack(side=tk.LEFT)
+    # Option to enter data as space-separated string entries
+    string_frame = tk.Frame(root, background=ENTRY_COLOR)
+    string_frame.pack()
+    string_use = tk.IntVar()
+    string_check = tk.Checkbutton(
+        string_frame, command=string_toggle, variable=string_use,
+        background=BACKGROUND)
+    string_check.pack(side=tk.LEFT)
+    string_label = tk.Label(string_frame,
+        text="Input variables as a string",
+        background=BACKGROUND)
+    string_label.pack(side=tk.LEFT)
+    string_entry = tk.Entry(string_frame, state=tk.DISABLED, width=50,
+        background=ENTRY_COLOR)
+    string_entry.pack(side=tk.LEFT)
 
-	def evaluate():
-		"""Open window that will submit work order and retrieve
-		   an evaluation result.
-		"""
+    def evaluate():
+        """Open window that will submit work order and retrieve
+           an evaluation result.
+        """
 
-		message = "Heart disease evaluation data: "
-		if string_use.get() == 1: # input is space-separated numbers
-			input_data = string_entry.get()
-			if input_data is None or len(input_data) == 0:
-				messagebox.showwarning("Error",
-					"Must input space-separated variables")
-				return
-			message = message + input_data
+        message = "Heart disease evaluation data: "
+        if string_use.get() == 1: # input is space-separated numbers
+            input_data = string_entry.get()
+            if input_data is None or len(input_data) == 0:
+                messagebox.showwarning("Error",
+                    "Must input space-separated variables")
+                return
+            message = message + input_data
 
-		elif random_use.get() == 1:
-			input_data = _generate_random_data()
-			if input_data is None or len(input_data) == 0:
-				messagebox.showwarning("Error",
-					"Random variable generation error")
-				return
-			message = message + input_data
-		else:
-			for var in var_list:
-				if var.get() is None:
-					messagebox.showwarning("Error",
-						"Must input all variables")
-					return
-				message = message + str(var.get()) + " "
-		root.wait_window(resultWindow(root, message))
+        elif random_use.get() == 1:
+            input_data = _generate_random_data()
+            if input_data is None or len(input_data) == 0:
+                messagebox.showwarning("Error",
+                    "Random variable generation error")
+                return
+            message = message + input_data
+        else:
+            for var in var_list:
+                if var.get() is None:
+                    messagebox.showwarning("Error",
+                        "Must input all variables")
+                    return
+                message = message + str(var.get()) + " "
+        root.wait_window(resultWindow(root, message))
 
-	def aggregate():
-		"""Open window that will submit work order to retrieve
-		   an aggregate result.
-		"""
+    def aggregate():
+        """Open window that will submit work order to retrieve
+           an aggregate result.
+        """
 
-		message = "Heart disease aggregate data: "
-		root.wait_window(resultWindow(root, message))
+        message = "Heart disease aggregate data: "
+        root.wait_window(resultWindow(root, message))
 
-	# "Evaluate" button
-	eval_text = tk.StringVar()
-	eval_label = tk.Label(root, textvariable=eval_text,
-		background=BACKGROUND)
-	eval_label.pack()
-	eval_button = tk.Button(root, text="Evaluate", command=evaluate,
-		background=BUTTON_COLOR)
-	eval_button.pack()
+    # "Evaluate" button
+    eval_text = tk.StringVar()
+    eval_label = tk.Label(root, textvariable=eval_text,
+        background=BACKGROUND)
+    eval_label.pack()
+    eval_button = tk.Button(root, text="Evaluate", command=evaluate,
+        background=BUTTON_COLOR)
+    eval_button.pack()
 
-	# "Aggregate" button
-	aggr_text = tk.StringVar()
-	aggr_label = tk.Label(root, textvariable=aggr_text,
-		background=BACKGROUND)
-	aggr_label.pack()
-	aggr_button = tk.Button(root, text="Aggregate all data",
-		command=aggregate,
-		background=BUTTON_COLOR)
-	aggr_button.pack(pady=(0,10))
+    # "Aggregate" button
+    aggr_text = tk.StringVar()
+    aggr_label = tk.Label(root, textvariable=aggr_text,
+        background=BACKGROUND)
+    aggr_label.pack()
+    aggr_button = tk.Button(root, text="Aggregate all data",
+        command=aggregate,
+        background=BUTTON_COLOR)
+    aggr_button.pack(pady=(0,10))
 
-	root.mainloop()
+    root.mainloop()
 
 def parse_command_line(args):
-	"""Setup and parse command line arguments and help information."""
+    """Setup and parse command line arguments and help information."""
 
-	global worker_obj
-	global worker_id
-	global verbose
-	global config
-	global off_chain
-	global requester_signature
+    global worker_obj
+    global worker_id
+    global verbose
+    global config
+    global off_chain
+    global requester_signature
 
-	parser = argparse.ArgumentParser()
-	use_service = parser.add_mutually_exclusive_group()
-	parser.add_argument("-c", "--config",
-		help="the config file containing the" + \
-		" Ethereum contract information", type=str)
-	use_service.add_argument("-r", "--registry-list",
-		help="the Ethereum address of the registry list",
-		type=str)
-	use_service.add_argument("-s", "--service-uri",
-		help="skip URI lookup and send to specified URI",
-		type=str)
-	use_service.add_argument("-o", "--off-chain",
-		help="skip URI lookup and use the registry in the config file",
-		action="store_true")
-	parser.add_argument("-w", "--worker-id",
-		help="skip worker lookup and retrieve specified worker",
-		type=str)
-	parser.add_argument("-v", "--verbose",
-		help="increase output verbosity",
-		action="store_true")
-	parser.add_argument("-rs", "--requester_signature",
-		help="Enable requester signature for work order requests",
-		action="store_true")
+    parser = argparse.ArgumentParser()
+    use_service = parser.add_mutually_exclusive_group()
+    parser.add_argument("-c", "--config",
+        help="the config file containing the" + \
+        " Ethereum contract information", type=str)
+    use_service.add_argument("-r", "--registry-list",
+        help="the Ethereum address of the registry list",
+        type=str)
+    use_service.add_argument("-s", "--service-uri",
+        help="skip URI lookup and send to specified URI",
+        type=str)
+    use_service.add_argument("-o", "--off-chain",
+        help="skip URI lookup and use the registry in the config file",
+        action="store_true")
+    parser.add_argument("-w", "--worker-id",
+        help="skip worker lookup and retrieve specified worker",
+        type=str)
+    parser.add_argument("-v", "--verbose",
+        help="increase output verbosity",
+        action="store_true")
+    parser.add_argument("-rs", "--requester_signature",
+        help="Enable requester signature for work order requests",
+        action="store_true")
 
-	options = parser.parse_args(args)
+    options = parser.parse_args(args)
 
-	if options.config:
-		conf_files = [options.config]
-	else:
-		conf_files = [ TCFHOME + \
-			"/examples/common/python/connectors/tcf_connector.toml"
-			]
-	conf_paths = [ "." ]
+    if options.config:
+        conf_files = [options.config]
+    else:
+        conf_files = [ TCFHOME + \
+            "/examples/common/python/connectors/tcf_connector.toml"
+            ]
+    conf_paths = [ "." ]
 
-	try :
-		config = pconfig.parse_configuration_files(conf_files,
-			conf_paths)
-		json.dumps(config, indent=4)
-	except pconfig.ConfigurationException as e :
-		logger.error(str(e))
-		sys.exit(-1)
+    try :
+        config = pconfig.parse_configuration_files(conf_files,
+            conf_paths)
+        json.dumps(config, indent=4)
+    except pconfig.ConfigurationException as e :
+        logger.error(str(e))
+        sys.exit(-1)
 
-	global direct_jrpc
-	direct_jrpc = DirectJsonRpcApiConnector(conf_files[0])
+    global direct_jrpc
+    direct_jrpc = DirectJsonRpcApiConnector(conf_files[0])
 
-	# Whether or not to connect to the registry list on the blockchain
-	off_chain = False
+    # Whether or not to connect to the registry list on the blockchain
+    off_chain = False
 
-	if options.registry_list:
-		config["ethereum"]["direct_registry_contract_address"] = \
-			options.registry_list
+    if options.registry_list:
+        config["ethereum"]["direct_registry_contract_address"] = \
+            options.registry_list
 
-	if options.service_uri:
-		service_uri = options.service_uri
-		off_chain = True
+    if options.service_uri:
+        service_uri = options.service_uri
+        off_chain = True
 
-	if options.off_chain:
-		service_uri = config["tcf"].get("json_rpc_uri")
-		off_chain = True
+    if options.off_chain:
+        service_uri = config["tcf"].get("json_rpc_uri")
+        off_chain = True
 
-	requester_signature = options.requester_signature
+    requester_signature = options.requester_signature
 
-	verbose = options.verbose
-	worker_id = options.worker_id
+    verbose = options.verbose
+    worker_id = options.worker_id
 
-	# Initializing Worker Object
-	worker_obj = worker.SGXWorkerDetails()
+    # Initializing Worker Object
+    worker_obj = worker.SGXWorkerDetails()
 
 def initialize_logging(config):
-	"""Initialize logging."""
+    """Initialize logging."""
 
-	if verbose:
-		config["Logging"] = {
-			"LogFile" : "__screen__",
-			"LogLevel" : "INFO"
-		}
-	else:
-		config["Logging"] = {
-			"LogFile" : "__screen__",
-			"LogLevel" : "WARN"
-		}
-	plogger.setup_loggers(config.get("Logging", {}))
-	sys.stdout = plogger.stream_to_logger(
-		logging.getLogger("STDOUT"), logging.DEBUG)
-	sys.stderr = plogger.stream_to_logger(
-		logging.getLogger("STDERR"), logging.WARN)
+    if verbose:
+        config["Logging"] = {
+            "LogFile" : "__screen__",
+            "LogLevel" : "INFO"
+        }
+    else:
+        config["Logging"] = {
+            "LogFile" : "__screen__",
+            "LogLevel" : "WARN"
+        }
+    plogger.setup_loggers(config.get("Logging", {}))
+    sys.stdout = plogger.stream_to_logger(
+        logging.getLogger("STDOUT"), logging.DEBUG)
+    sys.stderr = plogger.stream_to_logger(
+        logging.getLogger("STDERR"), logging.WARN)
 
 def initialize_tcf(config):
-	"""Initialize Avalon: get Avalon worker instance."""
+    """Initialize Avalon: get Avalon worker instance."""
 
-	logger.info("***************** Avalon *****************")
+    logger.info("***************** Avalon *****************")
 
-	# Retrieve Worker Registry
-	if not off_chain:
-		registry_list_instance = direct_jrpc. \
-			create_worker_registry_list(config)
-		registry_count, lookup_tag, registry_list = \
-			registry_list_instance.registry_lookup()
-		logger.info("\n Registry lookup response : registry count {}\
-			lookup tag {} registry list {}\n".format(
-			registry_count, lookup_tag, registry_list
-		))
-		if (registry_count == 0):
-			logger.warn("No registries found")
-			sys.exit(1)
-		registry_retrieve_result = \
-			registry_list_instance.registry_retrieve(
-				registry_list[0]
-		)
-		logger.info("\n Registry retrieve response : {}\n".format(
-			registry_retrieve_result
-		))
-		config["tcf"]["json_rpc_uri"] = registry_retrieve_result[0]
+    # Retrieve Worker Registry
+    if not off_chain:
+        registry_list_instance = direct_jrpc. \
+            create_worker_registry_list(config)
+        registry_count, lookup_tag, registry_list = \
+            registry_list_instance.registry_lookup()
+        logger.info("\n Registry lookup response : registry count {}\
+            lookup tag {} registry list {}\n".format(
+            registry_count, lookup_tag, registry_list
+        ))
+        if (registry_count == 0):
+            logger.warn("No registries found")
+            sys.exit(1)
+        registry_retrieve_result = \
+            registry_list_instance.registry_retrieve(
+                registry_list[0]
+        )
+        logger.info("\n Registry retrieve response : {}\n".format(
+            registry_retrieve_result
+        ))
+        config["tcf"]["json_rpc_uri"] = registry_retrieve_result[0]
 
-	# Prepare worker
+    # Prepare worker
 
-	global worker_id
-	if not worker_id:
-		worker_registry_instance = direct_jrpc.create_worker_registry(
-			config
-		)
-		req_id = 31
-		worker_lookup_result = worker_registry_instance.worker_lookup(
-			worker_type=WorkerType.TEE_SGX,
-			id=req_id
-		)
-		logger.info("\n Worker lookup response : {} \n",
-			json.dumps(worker_lookup_result, indent=4)
-		)
-		if "result" in worker_lookup_result and \
-			"ids" in worker_lookup_result["result"].keys():
-			if worker_lookup_result["result"]["totalCount"] != 0:
-				worker_id = \
-					worker_lookup_result["result"]["ids"][0]
-			else:
-				logger.error("ERROR: No workers found")
-				sys.exit(1)
-		else:
-			logger.error("ERROR: Failed to lookup worker")
-			sys.exit(1)
-	req_id += 1
-	worker = worker_registry_instance.worker_retrieve(
-		worker_id,
-		req_id
-	)
-	logger.info("\n Worker retrieve response : {}\n".format(
-		json.dumps(worker, indent=4)
-	))
-	worker_obj.load_worker(
-		worker
-	)
-	logger.info("**********Worker details Updated with Worker ID" + \
-		"*********\n%s\n", worker_id)
+    global worker_id
+    if not worker_id:
+        worker_registry_instance = direct_jrpc.create_worker_registry(
+            config
+        )
+        req_id = 31
+        worker_lookup_result = worker_registry_instance.worker_lookup(
+            worker_type=WorkerType.TEE_SGX,
+            id=req_id
+        )
+        logger.info("\n Worker lookup response : {} \n".format(
+            json.dumps(worker_lookup_result, indent=4)
+        ))
+        if "result" in worker_lookup_result and \
+            "ids" in worker_lookup_result["result"].keys():
+            if worker_lookup_result["result"]["totalCount"] != 0:
+                worker_id = \
+                    worker_lookup_result["result"]["ids"][0]
+            else:
+                logger.error("ERROR: No workers found")
+                sys.exit(1)
+        else:
+            logger.error("ERROR: Failed to lookup worker")
+            sys.exit(1)
+    req_id += 1
+    worker = worker_registry_instance.worker_retrieve(
+        worker_id,
+        req_id
+    )
+    logger.info("\n Worker retrieve response : {}\n".format(
+        json.dumps(worker, indent=4)
+    ))
+    worker_obj.load_worker(
+        worker
+    )
+    logger.info("**********Worker details Updated with Worker ID" + \
+        "*********\n%s\n", worker_id)
 
 
 def main(args=None):
-	"""Entry point function."""
+    """Entry point function."""
 
-	parse_command_line(args)
+    parse_command_line(args)
 
-	initialize_logging(config)
+    initialize_logging(config)
 
-	initialize_tcf(config)
+    initialize_tcf(config)
 
-	# Open GUI
-	gui_main()
+    # Open GUI
+    gui_main()
 
 #------------------------------------------------------------------------------
 main()

--- a/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 class TCSListener(resource.Resource):
     """
-    TCSListener Class  is comprised of HTTP interface which listens for the end user requests, 
+    TCSListener Class  is comprised of HTTP interface which listens for the end user requests,
     Worker Registry Handler, Work Order Handler and Work Order Receipts Handler .
     """
     # The isLeaf instance variable describes whether or not a resource will have children and only leaf resources get rendered.
@@ -66,9 +66,6 @@ class TCSListener(resource.Resource):
         except Exception as err:
             logger.error(f"failed to open db: {err}")
             sys.exit(-1)
-
-        # Worker registry handler needs to be instantiated before Work order handler. Otherwise, LMDB operations don't operate on updated values.
-        # TODO: Needs further investigation on what is causing the above behavior.
 
         self.worker_registry_handler = TCSWorkerRegistryHandler(self.kv_helper)
         self.workorder_handler = TCSWorkOrderHandler(
@@ -90,6 +87,12 @@ class TCSListener(resource.Resource):
             self.worker_registry_handler.WorkerUpdate,
             self.workorder_handler.WorkOrderSubmit,
             self.workorder_handler.WorkOrderGetResult,
+            self.workorder_receipt_handler.WorkOrderReceiptCreate,
+            self.workorder_receipt_handler.WorkOrderReceiptUpdate,
+            self.workorder_receipt_handler.WorkOrderReceiptRetrieve,
+            self.workorder_receipt_handler.WorkOrderReceiptUpdateRetrieve,
+            self.workorder_receipt_handler.WorkOrderReceiptLookUp,
+            self.workorder_receipt_handler.WorkOrderReceiptLookUpNext
         ]
         for m in rpc_methods:
             self.dispatcher.add_method(m)
@@ -102,28 +105,13 @@ class TCSListener(resource.Resource):
         try:
             input_json = json.loads(input_json_str)
         except:
-            response['error']['message'] = 'Error: Improper Json. Unable to load'
+            response = {
+                "error": {
+                    "code": WorkOrderStatus.INVALID_PARAMETER_FORMAT_OR_VALUE,
+                    "message": "Error: Improper Json. Unable to load",
+                },
+            }
             return response
-
-        if ('jsonrpc' not in input_json or 'id' not in input_json
-                or 'method' not in input_json or 'params' not in input_json):
-            response['error']['message'] = 'Error: Json does not have the required field'
-            return response
-
-        if not isinstance(input_json['id'], int):
-            response['error']['message'] = 'Error: Id should be of type integer'
-            return response
-
-        response['jsonrpc'] = input_json['jsonrpc']
-        response['id'] = input_json['id']
-
-        if not isinstance(input_json['method'], str):
-            response['error']['message'] = 'Error: Method has to be of type string'
-            return response
-
-        if ("WorkOrderReceipt" in input_json['method']):
-            return self.workorder_receipt_handler.workorder_receipt_handler(
-                input_json_str)
 
         logger.info("Received request: %s", input_json['method'])
         # save the full json for WorkOrderSubmit

--- a/examples/common/python/connectors/direct/work_order_receipt_jrpc_impl.py
+++ b/examples/common/python/connectors/direct/work_order_receipt_jrpc_impl.py
@@ -30,50 +30,35 @@ class WorkOrderReceiptJRPCImpl(WorkOrderReceiptInterface):
         self.__uri_client = GenericServiceClient(config["tcf"]["json_rpc_uri"])
 
 
-    def work_order_receipt_create(self, work_order_id, worker_id,  
+    def work_order_receipt_create(self, work_order_id,
         worker_service_id,
+        worker_id,
         requester_id,
         receipt_create_status,
-        work_order_request_hash, id=None):
+        work_order_request_hash,
+        requester_nonce,
+        requester_signature,
+        signature_rules,
+        receipt_verification_key,
+        id=None):
         """
         Creating a Work Order Receipt json rpc request and submit tcs listener
         """
-        if work_order_id is None or not is_valid_hex_str(work_order_id):
-            logging.error("Work order id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Worker id is empty or Invalid")
-
-        if worker_id is None or not is_valid_hex_str(worker_id):
-            logging.error("Worker id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Worker id is empty or Invalid")
-
-        if not isinstance(worker_type, ReceiptCreateStatus):
-            logging.error("Invalid receipt create status")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Invalid receipt create status")
-
-        if worker_service_id is None or not is_valid_hex_str(worker_service_id):
-            logging.error("Worker service id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Worker service id is empty or Invalid")
-
-        if requester_id is None or not is_valid_hex_str(requester_id):
-            logging.error("requester id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "requester id is empty or Invalid")
-
         json_rpc_request = {
             "jsonrpc": "2.0",
             "method": "WorkOrderReceiptCreate",
             "id": id,
             "params": {
                 "workOrderId": work_order_id,
-                "workerId": worker_id,
                 "workerServiceId": worker_service_id,
+                "workerId": worker_id,
                 "requesterId": requester_id,
                 "receiptCreateStatus": receipt_create_status,
-                "workOrderRequestHash": work_order_request_hash
+                "workOrderRequestHash": work_order_request_hash,
+                "requesterGeneratedNonce": requester_nonce,
+                "requesterSignature": requester_signature,
+                "signatureRules": signature_rules,
+                "receiptVerificationKey": receipt_verification_key
             }
         }
         response = self.__uri_client._postmsg(json.dumps(json_rpc_request))
@@ -88,31 +73,6 @@ class WorkOrderReceiptJRPCImpl(WorkOrderReceiptInterface):
         """
         Update a Work Order Receipt json rpc request and submit tcs listener
         """
-        if work_order_id is None or not is_valid_hex_str(work_order_id):
-            logging.error("Work order id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Worker id is empty or Invalid")
-
-        if updater_id is None or not is_valid_hex_str(updater_id):
-            logging.error("Updater id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Worker id is empty or Invalid")
-
-        if not isinstance(update_type, ReceiptCreateStatus):
-            logging.error("Invalid Update type")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Invalid update type")
-
-        if update_data is None or not is_valid_hex_str(update_data):
-            logging.error("Update data is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Update data is empty or Invalid")
-
-        if update_signature is None or not is_valid_hex_str(update_signature):
-            logging.error("update signature is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "update signature is empty or Invalid")
-
         json_rpc_request = {
             "jsonrpc": "2.0",
             "method": "WorkOrderReceiptUpdate",
@@ -134,11 +94,6 @@ class WorkOrderReceiptJRPCImpl(WorkOrderReceiptInterface):
         """
         Retrieve a Work Order Receipt json rpc request and submit tcs listener
         """
-        if work_order_id is None or not is_valid_hex_str(work_order_id):
-            logging.error("Work order id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Worker id is empty or Invalid")
-
         json_rpc_request = {
             "jsonrpc": "2.0",
             "method": "WorkOrderReceiptRetrieve",
@@ -157,16 +112,6 @@ class WorkOrderReceiptJRPCImpl(WorkOrderReceiptInterface):
         """
         Retrieving a Work Order Receipt Update
         """
-        if work_order_id is None or not is_valid_hex_str(work_order_id):
-            logging.error("Work order id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Worker id is empty or Invalid")
-
-        if updater_id is None or not is_valid_hex_str(updater_id):
-            logging.error("Updater id is empty or Invalid")
-            return create_jrpc_response(id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Worker id is empty or Invalid")
-
         json_rpc_request = {
             "jsonrpc": "2.0",
             "method": "WorkOrderReceiptUpdateRetrieve",
@@ -187,43 +132,23 @@ class WorkOrderReceiptJRPCImpl(WorkOrderReceiptInterface):
         """
         json_rpc_request = {
             "jsonrpc": "2.0",
-            "method": "WorkerLookUp",
+            "method": "WorkOrderReceiptLookUp",
             "id": id,
             "params": {
             }
         }
 
         if worker_service_id is not None:
-            if not is_valid_hex_str(worker_service_id):
-                logging.error("Worker service id is Invalid")
-                return create_jrpc_response(
-                    id, JsonRpcErrorCode.INVALID_PARAMETER,
-                    "Worker service id is Invalid")
             json_rpc_request["params"]["workerServiceId"] = worker_service_id
 
         if worker_id is not None:
-            if not is_valid_hex_str(worker_id):
-                logging.error("Worker id is Invalid")
-                return create_jrpc_response(
-                    id, JsonRpcErrorCode.INVALID_PARAMETER,
-                    "Worker id is Invalid")
             json_rpc_request["params"]["workerId"] = worker_id
 
         if requester_id is not None:
-            if not is_valid_hex_str(requester_id):
-                logging.error("Requester id is Invalid")
-                return create_jrpc_response(
-                    id, JsonRpcErrorCode.INVALID_PARAMETER,
-                    "Requester id is Invalid")
             json_rpc_request["params"]["requesterId"] = requester_id
 
         if receipt_status is not None:
-            if not isinstance(receipt_status, ReceiptCreateStatus):
-                logging.error("Receipt status is Invalid")
-                return create_jrpc_response(
-                    id, JsonRpcErrorCode.INVALID_PARAMETER,
-                    "Receipt status is Invalid")
-            json_rpc_request["params"]["receiptStatus"] = receipt_status
+            json_rpc_request["params"]["requestCreateStatus"] = receipt_status
 
         response = self.__uri_client._postmsg(json.dumps(json_rpc_request))
         return response
@@ -244,42 +169,16 @@ class WorkOrderReceiptJRPCImpl(WorkOrderReceiptInterface):
         }
 
         if worker_service_id is not None:
-            if not is_valid_hex_str(worker_service_id):
-                logging.error("Worker service id is Invalid")
-                return create_jrpc_response(
-                    id, JsonRpcErrorCode.INVALID_PARAMETER,
-                    "Worker service id is Invalid")
             json_rpc_request["params"]["workerServiceId"] = worker_service_id
 
         if worker_id is not None:
-            if not is_valid_hex_str(worker_id):
-                logging.error("Worker id is Invalid")
-                return create_jrpc_response(
-                    id, JsonRpcErrorCode.INVALID_PARAMETER,
-                    "Worker id is Invalid")
             json_rpc_request["params"]["workerId"] = worker_id
 
         if requester_id is not None:
-            if not is_valid_hex_str(requester_id):
-                logging.error("Requester id is Invalid")
-                return create_jrpc_response(
-                    id, JsonRpcErrorCode.INVALID_PARAMETER,
-                    "Requester id is Invalid")
             json_rpc_request["params"]["requesterId"] = requester_id
 
         if receipt_status is not None:
-            if not isinstance(receipt_status, ReceiptCreateStatus):
-                logging.error("Invalid receipt status")
-                return create_jrpc_response(
-                    id, JsonRpcErrorCode.INVALID_PARAMETER,
-                    "Invalid receipt status")
-            json_rpc_request["params"]["receiptStatus"] = receipt_status
-
-        if last_lookup_tag is None or not is_valid_hex_str(last_lookup_tag):
-            logging.error("Last lookup tag is empty or Invalid")
-            return create_jrpc_response(
-                id, JsonRpcErrorCode.INVALID_PARAMETER,
-                "Last lookup tag is empty or Invalid")
+            json_rpc_request["params"]["requestCreateStatus"] = receipt_status
 
         response = self.__uri_client._postmsg(json.dumps(json_rpc_request))
         return response

--- a/examples/common/python/error_code/error_status.py
+++ b/examples/common/python/error_code/error_status.py
@@ -71,3 +71,15 @@ class SignatureStatus(IntEnum):
 class QuoteStatus(IntEnum):
     GROUP_OUT_OF_DATE_OK = 1
     GROUP_OUT_OF_DATE_NOT_OK = 2
+
+# Generic jrpc error codes
+@unique
+class JRPCErrorCodes(IntEnum):
+    SUCCESS = 0
+    UNKNOWN_ERROR = 1
+    INVALID_PARAMETER_FORMAT_OR_VALUE = 2
+    ACCESS_DENIED = 3
+    INVALID_SIGNATURE = 4
+    NO_MORE_LOOKUP_RESULTS = 5
+    UNSUPPORTED_MODE = 6
+

--- a/examples/common/python/work_order/work_order_params.py
+++ b/examples/common/python/work_order/work_order_params.py
@@ -249,6 +249,20 @@ class WorkOrderParams():
 			enc_data = utility.encrypt_data(data, encrypted_data_encryption_key, data_iv)
 			return crypto.byte_array_to_base64(enc_data)
 
-	def to_string(self):
-		return json.dumps(self.params_obj, indent=4)
+	def to_string(self, id):
+		"""
+		Create jrpc request in string format using
+		work order params object
+		Parameters
+			- id is jrpc request id
+		Returns
+			work order jrpc request as string
+		"""
+		json_request = {
+			"jsonrpc": "2.0",
+			"method": "WorkOrderSubmit",
+			"id": id,
+			"params": self.params_obj
+		}
+		return json.dumps(json_request, indent=4)
 

--- a/examples/common/python/work_order_receipt/__init__.py
+++ b/examples/common/python/work_order_receipt/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+

--- a/examples/common/python/work_order_receipt/work_order_receipt_request.py
+++ b/examples/common/python/work_order_receipt/work_order_receipt_request.py
@@ -1,0 +1,138 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import random
+
+import crypto.crypto as crypto
+import utility.signature as signature
+import utility.utility as utility
+from error_code.error_status import ReceiptCreateStatus as ReceiptCreateStatus
+from error_code.error_status import WorkOrderStatus
+class WorkOrderReceiptRequest():
+    """
+    Class to create work order receipt APIs like
+    create, update, retrieve and lookup
+    """
+    def __init__(self):
+        self.sig_obj = signature.ClientSignature()
+        self.SIGNING_ALGORITHM = "SECP256K1"
+        self.HASHING_ALGORITHM = "SHA-256"
+
+    def create_receipt(self, wo_request,
+        receipt_create_status, signing_key, nonce=None):
+        """
+        Create work order receipt corresponding to workorder id
+        Parameters:
+            - wo_request is jrpc work order request used to create the
+            work order request as defined in EEA spec 6.1.1.
+            - receipt_create_status is enum of type ReceiptCreateStatus
+            - signing_key is private key
+            - nonce is int type random number or monotonic counter
+        Returns jrpc request of type dictionary
+        """
+        final_hash_str = self.sig_obj.calculate_request_hash(wo_request)
+        wo_request_params = wo_request["params"]
+        worker_id = wo_request_params["workerId"]
+        requester_nonce = nonce
+        if nonce is None:
+            requester_nonce = str(random.randint(1, 10**10))
+        public_key =  signing_key.GetPublicKey().Serialize()
+        wo_receipt_request = {
+            "workOrderId": wo_request_params["workOrderId"],
+            # TODO: workerServiceId is same as worker id,
+            # needs to be updated with actual service id
+            "workerServiceId": worker_id,
+            "workerId": worker_id,
+            "requesterId": wo_request_params["requesterId"],
+            "receiptCreateStatus": receipt_create_status,
+            "workOrderRequestHash": final_hash_str,
+            "requesterGeneratedNonce": requester_nonce,
+            "signatureRules": self.HASHING_ALGORITHM + "/" + self.SIGNING_ALGORITHM,
+            "receiptVerificationKey": public_key
+        }
+        wo_receipt_str = wo_receipt_request["workOrderId"] + \
+            wo_receipt_request["workerServiceId"] + \
+            wo_receipt_request["workerId"] + \
+            wo_receipt_request["requesterId"] + \
+            str(wo_receipt_request["receiptCreateStatus"]) + \
+            wo_receipt_request["workOrderRequestHash"] + \
+            wo_receipt_request["requesterGeneratedNonce"]
+        wo_receipt_bytes = bytes(wo_receipt_str, "UTF-8")
+        wo_receipt_hash = crypto.compute_message_hash(wo_receipt_bytes)
+        status, wo_receipt_sign = self.sig_obj.generate_signature(
+            wo_receipt_hash,
+            signing_key
+        )
+        if status == False:
+            # if generate signature is failed.
+            wo_receipt_request["requesterSignature"] = ""
+            raise Exception("Generate signature is failed")
+        else:
+            wo_receipt_request["requesterSignature"] = wo_receipt_sign
+        return wo_receipt_request
+
+    def update_receipt(self, work_order_id, update_type,
+                       update_data, signing_key):
+        """
+        Update the existing work order receipt with
+        update_type, update_data.
+        Parameters:
+            - work_order_id is work order id whose receipt
+              needs to be updated.
+            - update_type is integer, these values corresponds to
+              receipt status as defined in 7.1.1
+            - update_data is update-specific data that depend on
+              the workOrderStatus
+        Returns jrpc work order update receipt request of type dictionary
+        """
+        data = update_data
+        if update_type in [ReceiptCreateStatus.PROCESSED.value,\
+            ReceiptCreateStatus.COMPLETED.value]:
+            # Work Order Receipt status is set to be completed or processed,
+            # then update_data should be work order response.
+            wo_resp_str = json.dumps(update_data)
+            wo_resp_bytes = bytes(wo_resp_str, "UTF-8")
+            # Hash of work order response is update_data
+            wo_resp_hash = crypto.compute_message_hash(wo_resp_bytes)
+            wo_resp_hash_str = crypto.byte_array_to_hex(wo_resp_hash)
+            data = wo_resp_hash_str
+        public_key = signing_key.GetPublicKey().Serialize()
+        updater_id = utility.strip_begin_end_key(public_key)
+
+        wo_receipt_update = {
+            "workOrderId": work_order_id,
+            "updaterId": updater_id,
+            "updateType": update_type,
+            "updateData": data,
+            "signatureRules": self.HASHING_ALGORITHM + "/" + self.SIGNING_ALGORITHM,
+            "receiptVerificationKey": public_key
+        }
+        wo_receipt_str = wo_receipt_update["workOrderId"] + \
+            str(wo_receipt_update["updateType"]) + \
+            wo_receipt_update["updateData"]
+        wo_receipt_bytes = bytes(wo_receipt_str, "UTF-8")
+        wo_receipt_hash = crypto.compute_message_hash(wo_receipt_bytes)
+        status, wo_receipt_sign = self.sig_obj.generate_signature(
+            wo_receipt_hash,
+            signing_key
+        )
+        if status == False:
+            # if generating signature failed.
+            wo_receipt_update["updateSignature"] = ""
+            raise Exception("Generate signature is failed")
+        else:
+            wo_receipt_update["updateSignature"] = wo_receipt_sign
+        return wo_receipt_update
+


### PR DESCRIPTION
1. Work order receipt API's create, update, retrieve and update retrieve
are implemented. Updating receipt is done by enclave manager based on the
work order execution status.
2. Modify work receipt jrpc wrapper as per the new EEA spec changes
3. Update to echo client with receipt APIs to test end to end flow.

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>