### PR TITLE
Fix Python lint errors and alerts

### DIFF
--- a/examples/apps/echo/client/echo_client.py
+++ b/examples/apps/echo/client/echo_client.py
@@ -16,7 +16,6 @@
 
 import os
 import sys
-import random
 import json
 import argparse
 import logging
@@ -25,7 +24,6 @@ import secrets
 
 import config.config as pconfig
 import utility.logger as plogger
-from service_client.generic import GenericServiceClient
 import utility.utility as utility
 from utility.tcf_types import WorkerType
 import worker.worker_details as worker
@@ -91,7 +89,7 @@ def ParseCommandLine(args) :
 	confpaths = [ "." ]
 	try :
 		config = pconfig.parse_configuration_files(conf_files, confpaths)
-		config_json_str = json.dumps(config)
+		json.dumps(config)
 	except pconfig.ConfigurationException as e :
 		logger.error(str(e))
 		sys.exit(-1)
@@ -117,7 +115,7 @@ def ParseCommandLine(args) :
 	input_data_hash = options.data_hash
 	worker_id = options.worker_id
 	message = options.message
-	if options.message == None or options.message == "":
+	if options.message is None or options.message == "":
 		message = "Test Message"
 
 	# Initializing Worker Object

--- a/examples/apps/generic_client/generic_client.py
+++ b/examples/apps/generic_client/generic_client.py
@@ -99,7 +99,7 @@ def ParseCommandLine(args) :
 	confpaths = [ "." ]
 	try :
 		config = pconfig.parse_configuration_files(conf_files, confpaths)
-		config_json_str = json.dumps(config)
+		json.dumps(config)
 	except pconfig.ConfigurationException as e :
 		logger.error(str(e))
 		sys.exit(-1)

--- a/examples/apps/heart_disease_eval/client/heart_gui.py
+++ b/examples/apps/heart_disease_eval/client/heart_gui.py
@@ -23,7 +23,6 @@ import json
 import argparse
 import logging
 import secrets
-import time
 
 # Tkinter imports
 import tkinter as tk
@@ -285,8 +284,6 @@ class resultWindow(tk.Toplevel):
 		workload_id = workload_id.encode("UTF-8").hex()
 		session_iv = utility.generate_iv()
 		session_key = utility.generate_key()
-		encrypted_session_key = utility.generate_encrypted_key(
-			session_key, worker_obj.encryption_key)
 		requester_nonce = secrets.token_hex(16)
 		work_order_id = secrets.token_hex(32)
 		requester_id = secrets.token_hex(32)
@@ -524,7 +521,7 @@ def gui_main():
 			message = message + input_data
 		else:
 			for var in var_list:
-				if var.get()==None:
+				if var.get() is None:
 					messagebox.showwarning("Error",
 						"Must input all variables")
 					return
@@ -607,7 +604,7 @@ def parse_command_line(args):
 	try :
 		config = pconfig.parse_configuration_files(conf_files,
 			conf_paths)
-		config_json_str = json.dumps(config, indent=4)
+		json.dumps(config, indent=4)
 	except pconfig.ConfigurationException as e :
 		logger.error(str(e))
 		sys.exit(-1)
@@ -625,16 +622,13 @@ def parse_command_line(args):
 	if options.service_uri:
 		service_uri = options.service_uri
 		off_chain = True
-		uri_client = GenericServiceClient(service_uri)
 
 	if options.off_chain:
 		service_uri = config["tcf"].get("json_rpc_uri")
 		off_chain = True
-		uri_client = GenericServiceClient(service_uri)
 
 	requester_signature = options.requester_signature
 
-	service_uri = options.service_uri
 	verbose = options.verbose
 	worker_id = options.worker_id
 

--- a/examples/common/python/config/config.py
+++ b/examples/common/python/config/config.py
@@ -20,10 +20,6 @@ NOTE: Functions defined in this file are designed to be run
 before logging is enabled.
 """
 
-import os
-import sys
-import warnings
-
 import re
 import toml
 from string import Template

--- a/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py
@@ -27,14 +27,10 @@
 import os
 import sys
 import argparse
-import random
 import json
 
-import urllib.request
-import urllib.error
 from twisted.web import server, resource, http
 from twisted.internet import reactor
-from twisted.web.error import Error
 from tcs_work_order_handler import TCSWorkOrderHandler
 from tcs_worker_registry_handler import TCSWorkerRegistryHandler
 from tcs_workorder_receipt_handler import TCSWorkOrderReceiptHandler

--- a/examples/common/python/connectors/direct/tcs_listener/tcs_work_order_handler.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_work_order_handler.py
@@ -15,7 +15,6 @@
 import time
 import json
 import logging
-import crypto.crypto as crypto
 from error_code.error_status import WorkOrderStatus
 from error_code.enclave_error import EnclaveError
 import utility.utility as utility

--- a/examples/common/python/connectors/direct/tcs_listener/tcs_worker_encryption_key_handler.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_worker_encryption_key_handler.py
@@ -92,7 +92,6 @@ class WorkerEncryptionKeyHandler:
         # calculate signature
         concat_string = worker_id.encode('UTF-8') + encryptionKey.encode(
             'UTF-8') + encryptionKeyNonce.encode('UTF-8') + tag.encode('UTF-8')
-        concat_hash = bytes()
         concat_hash = bytes(concat_string)
         hash_1 = crypto.compute_message_hash(concat_hash)
         s1 = crypto.byte_array_to_base64(hash_1)

--- a/examples/common/python/connectors/direct/tcs_listener/tcs_worker_registry_handler.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_worker_registry_handler.py
@@ -135,7 +135,7 @@ class TCSWorkerRegistryHandler:
         try:
             worker_status = params["status"]
             status = int(worker_status)
-            wo_status = WorkerStatus(status)
+            WorkerStatus(status)
             return True
         except:
             logger.error("Invalid worker status code")

--- a/examples/common/python/connectors/direct/tcs_listener/tcs_workorder_receipt_handler.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_workorder_receipt_handler.py
@@ -17,7 +17,6 @@ import logging
 from error_code.error_status import ReceiptCreateStatus
 from error_code.error_status import WorkOrderStatus
 import utility.utility as utility
-from itertools import cycle
 
 logger = logging.getLogger(__name__)
 

--- a/examples/common/python/connectors/direct/worker_registry_jrpc_impl.py
+++ b/examples/common/python/connectors/direct/worker_registry_jrpc_impl.py
@@ -47,7 +47,6 @@ class WorkerRegistryJRPCImpl(WorkerRegistryInterface):
                     return create_jrpc_response(
                         id, JsonRpcErrorCode.INVALID_PARAMETER,
                         "Invalid application type id")
-                    break
         if details is not None:
             is_valid = validate_details(details)
             if is_valid is not None:

--- a/examples/common/python/connectors/ethereum/direct_registry_bridge.py
+++ b/examples/common/python/connectors/ethereum/direct_registry_bridge.py
@@ -14,10 +14,7 @@
 
 ''' this Component acts as bridge between smart contract deployed in blockchain and KV storage'''
 
-import os
 import sys
-from os import urandom
-import argparse
 import time
 import json
 import logging

--- a/examples/common/python/connectors/ethereum/eth_cli.py
+++ b/examples/common/python/connectors/ethereum/eth_cli.py
@@ -17,7 +17,7 @@
 import toml
 import errno
 import logging
-import os,time
+import os
 from os.path import exists, realpath
 
 from connectors.ethereum.ethereum_wrapper import EthereumWrapper as ethereum_wrapper

--- a/examples/common/python/connectors/ethereum/ethereum_worker_registry_impl.py
+++ b/examples/common/python/connectors/ethereum/ethereum_worker_registry_impl.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 import binascii
-import json
 import logging
 from os import environ
-from os.path import exists, realpath
 
 from utility.hex_utils import is_valid_hex_str
 

--- a/examples/common/python/connectors/ethereum/ethereum_wrapper.py
+++ b/examples/common/python/connectors/ethereum/ethereum_wrapper.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import logging
-import os,sys
+import os
 from os.path import exists, realpath
-import json
 from connectors.utils import construct_message
 
 from solc import compile_source

--- a/examples/common/python/connectors/utils.py
+++ b/examples/common/python/connectors/utils.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import logging
-import os,sys
-from os.path import exists, realpath
 import json
 from utility.hex_utils import is_valid_hex_str
 

--- a/examples/common/python/service_client/generic.py
+++ b/examples/common/python/service_client/generic.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import json
 import urllib.request
 import urllib.error

--- a/examples/common/python/shared_kv/remote_lmdb/lmdb_listener.py
+++ b/examples/common/python/shared_kv/remote_lmdb/lmdb_listener.py
@@ -15,7 +15,6 @@
 import os
 import sys
 import argparse
-import json
 from urllib.parse import urlparse
 from twisted.web import server
 from twisted.internet import reactor

--- a/examples/common/python/shared_kv/remote_lmdb/lmdb_request_handler.py
+++ b/examples/common/python/shared_kv/remote_lmdb/lmdb_request_handler.py
@@ -13,11 +13,7 @@
 # limitations under the License.
 
 import os
-import urllib.request
-import urllib.error
 from twisted.web import resource, http
-from twisted.web.error import Error
-import tcf_enclave_manager.tcf_enclave as db_store
 from string_escape import escape, unescape
 from shared_kv.shared_kv_interface import KvStorage
 

--- a/examples/common/python/shared_kv/remote_lmdb/test_lmdb_app.py
+++ b/examples/common/python/shared_kv/remote_lmdb/test_lmdb_app.py
@@ -172,7 +172,7 @@ def main(args=None):
 
     try:
         config = pconfig.parse_configuration_files(conffiles, confpaths)
-        config_json_str = json.dumps(config, indent=4)
+        json.dumps(config, indent=4)
     except pconfig.ConfigurationException as e:
         logger.error(str(e))
         sys.exit(-1)

--- a/examples/common/python/utility/ias_client.py
+++ b/examples/common/python/utility/ias_client.py
@@ -16,9 +16,7 @@
 Provide rest api helper functions for communicating with IAS.
 """
 
-from urllib.parse import urljoin
 import requests
-import sys
 import urllib
 import json
 
@@ -107,7 +105,6 @@ class IasClient(object):
             'ias_signature': result.headers.get('x-iasreport-signature'),
             'ias_certificate': urllib.parse.unquote(result.headers.get('x-iasreport-signing-certificate'))
         }
-        logger.debug("received ias certificate: %s", returnblob['ias_certificate'])
         return returnblob
 
     def verify_report_fields(self, original_quote, received_report):

--- a/examples/common/python/utility/signature.py
+++ b/examples/common/python/utility/signature.py
@@ -18,20 +18,11 @@ functions based on Spec 1.0 compatibility
 
 """
 
-import base64
-import os
-import sys
-import json
-import urllib.request
-import urllib.error
-import random
 import json
 import logging
 import crypto.crypto as crypto
-import utility.file_utils as putils
 import utility.utility as utility
 from utility.hex_utils import is_valid_hex_str, byte_array_to_hex_str
-import worker.worker_details as worker
 from error_code.error_status import SignatureStatus
 
 logger = logging.getLogger(__name__)

--- a/examples/common/python/utility/utility.py
+++ b/examples/common/python/utility/utility.py
@@ -23,7 +23,6 @@ import utility.hex_utils as hex_utils
 import crypto.crypto as crypto
 import config.config as pconfig
 import logging
-import toml
 
 logger = logging.getLogger(__name__)
 

--- a/examples/common/python/work_order/work_order_params.py
+++ b/examples/common/python/work_order/work_order_params.py
@@ -14,7 +14,6 @@
 
 import json
 import logging
-from os import sys
 
 import crypto.crypto as crypto
 import utility.utility as utility

--- a/examples/enclave_manager/setup.py
+++ b/examples/enclave_manager/setup.py
@@ -17,7 +17,6 @@
 import os
 import sys
 import subprocess
-import re
 
 # This should only be run with python3
 import sys

--- a/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py
+++ b/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py
@@ -274,7 +274,7 @@ def validate_request(wo_request):
     Validate JSON workorder request
     """
     try:
-        j_req = json.loads(wo_request)
+        json.loads(wo_request)
     except ValueError as e:
         logger.error("Invalid JSON format found for workorder - %s", e)
         return False

--- a/examples/enclave_manager/tcf_enclave_manager/sgx_work_order_request.py
+++ b/examples/enclave_manager/tcf_enclave_manager/sgx_work_order_request.py
@@ -14,10 +14,8 @@
 import os
 import json
 import logging
-import base64
 
 import crypto.crypto as crypto
-import utility.keys as keys
 
 logger = logging.getLogger(__name__)
 

--- a/tests/Demo.py
+++ b/tests/Demo.py
@@ -256,7 +256,7 @@ def Main(args=None):
 
     try :
         config = pconfig.parse_configuration_files(conffiles, confpaths)
-        config_json_str = json.dumps(config, indent=4)
+        json.dumps(config, indent=4)
     except pconfig.ConfigurationException as e :
         logger.error(str(e))
         sys.exit(-1)

--- a/tests/test_encrypted_data_encryption.py
+++ b/tests/test_encrypted_data_encryption.py
@@ -74,7 +74,7 @@ def ParseCommandLine(args) :
         confpaths = [ "." ]
         try :
                 config = pconfig.parse_configuration_files(conffiles, confpaths)
-                config_json_str = json.dumps(config)
+                json.dumps(config)
         except pconfig.ConfigurationException as e :
                 logger.error(str(e))
                 sys.exit(-1)

--- a/tests/test_ias_attestation.py
+++ b/tests/test_ias_attestation.py
@@ -80,7 +80,7 @@ def ParseCommandLine(args) :
         confpaths = [ "." ]
         try :
                 config = pconfig.parse_configuration_files(conf_files, confpaths)
-                config_json_str = json.dumps(config)
+                json.dumps(config)
         except pconfig.ConfigurationException as e :
                 logger.error(str(e))
                 sys.exit(-1)


### PR DESCRIPTION
1. Remove unused import, unused variables
2. Remove logging sensitive data like IAS certifcate
3. Use is operator in place of == for null checks

Signed-off-by: manju956 <manjunath.a.c@intel.com>