### PR TITLE
Map aesm service running on host to docker container

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -196,6 +196,19 @@ wget https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/libsgx-enclave-co
 sudo dpkg -i libsgx-enclave-common_2.3.101.46683-1_amd64.deb
 ```
 
+### Run aesm service on host machine
+If you are behind a corporate proxy,
+uncomment and update the proxy type and aesm proxy lines in /etc/aesmd.conf:  
+```
+proxy type = manual
+aesm proxy = http://your-proxy:your-port
+```
+
+Start aesm service on host machine  
+```
+sudo source /opt/intel/libsgx-enclave-common/aesm/aesm_service
+```
+
 ### Remove Old `/dev/sgx` Intel SGX DCAP Driver
 If device file `/dev/sgx` is present, remove the old DCAP driver:
 ```bash

--- a/docker-compose-sgx.yaml
+++ b/docker-compose-sgx.yaml
@@ -33,6 +33,8 @@ services:
       # Below volume mappings are required for DISPLAY settings by heart disease GUI client
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ~/.Xauthority:/root/.Xauthority
+      # Map aesm service on host to docker, required only in HW mode.
+      - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
     devices:
       - "/dev/isgx:/dev/isgx"
     working_dir: "/project/TrustedComputeFramework"

--- a/tools/rebuild.sh
+++ b/tools/rebuild.sh
@@ -75,26 +75,10 @@ fi
 : "${SGX_SDK?Missing environment variable SGX_SDK}"
 : "${PKG_CONFIG_PATH?Missing environment variable PKG_CONFIG_PATH}"
 
-# Set proxy for Intel Architectural Enclave Service Manager (AESM) and start
 if [[ ${SGX_MODE} &&  "${SGX_MODE}" == "HW" ]]; then
-
-    # Add proxy settings, if proxy is present and not set
-    grep -qs "^proxy type" /etc/aesmd.conf
-    if [ $? -ne 0 -a -n "$http_proxy" ] ; then
-       echo "Setting AESMD proxy type"
-       echo "proxy type = manual" >> /etc/aesmd.conf
-    fi
-    grep -qs "^aesm proxy" /etc/aesmd.conf
-    if [ $? -ne 0 -a -n "$http_proxy" ] ; then
-       echo "Setting AESMD proxy"
-       echo "aesm proxy = $http_proxy" >> /etc/aesmd.conf
-    fi
-
-    # Starting aesm service
-    echo "Starting aesm service"
-    /opt/intel/libsgx-enclave-common/aesm/aesm_service &
+    echo "SGX mode is set to HW"
 else
-    echo "Setting default SGX mode=SIM"
+    echo "Setting default SGX mode to SIM"
     export SGX_MODE=SIM
 fi
 


### PR DESCRIPTION
aesm service manages enclaves running on platform, its not useful to
run aesm service on every instance of docker container.
Hence service running on host is mapping in the form of socket to
docker container (required only in SGX HW mode).

Signed-off-by: manju956 <manjunath.a.c@intel.com>