### PR TITLE
Fix syntax error in test_cryptoWrapper.py

### DIFF
--- a/tc/sgx/common/tests/test_cryptoWrapper.py
+++ b/tc/sgx/common/tests/test_cryptoWrapper.py
@@ -170,7 +170,7 @@ except Exception as exc:
                      "test successful!")
     else:
         logger.error("error: Asymmetric encryption invalid public key " +
-                     ""deserialize test failed: ", exc)
+                     "deserialize test failed: ", exc)
         sys.exit(-1)
 
 


### PR DESCRIPTION
Fix syntax error in test_cryptoWrapper.py

- Remove extra double quote
Signed-off-by: danintel <daniel.anderson@intel.com>