### PR TITLE
Build static libraries for base64 and parson packages

### DIFF
--- a/examples/common/python/setup.py
+++ b/examples/common/python/setup.py
@@ -91,7 +91,8 @@ library_dirs = [
 ] + openssl_lib_dirs
 
 libraries = [
-    'utcf-common'
+    'uavalon-common',
+    'uavalon-base64'
 ] + openssl_libs
 
 if sgx_mode_env == "HW":

--- a/examples/enclave_manager/setup.py
+++ b/examples/enclave_manager/setup.py
@@ -76,7 +76,9 @@ library_dirs = [
 ]
 
 libraries = [
-    'utcf-common',
+    'uavalon-common',
+    'uavalon-base64',
+    'uavalon-parson'
 ]
 
 if sgx_mode_env == "HW":

--- a/tc/sgx/common/CMakeLists.txt
+++ b/tc/sgx/common/CMakeLists.txt
@@ -23,8 +23,8 @@ INCLUDE(CMakeVariables.txt)
 # Common components for both trusted and untrusted common libraries
 ################################################################################
 
-FILE(GLOB PROJECT_HEADERS *.h crypto/*.h verify_ias_report/*.h packages/base64/*.h packages/parson/*.h)
-FILE(GLOB PROJECT_SOURCES *.cpp crypto/*.cpp verify_ias_report/*.cpp packages/base64/*.cpp packages/parson/*.cpp)
+FILE(GLOB PROJECT_HEADERS *.h crypto/*.h verify_ias_report/*.h)
+FILE(GLOB PROJECT_SOURCES *.cpp crypto/*.cpp verify_ias_report/*.cpp)
 
 SET(COMMON_PRIVATE_INCLUDE_DIRS "." "tests" "crypto" "verify_ias_report" "packages/base64" "packages/parson" "state")
 SET(COMMON_CXX_FLAGS ${DEBUG_FLAGS} "-m64" "-fvisibility=hidden" "-fpie" "-fPIC" "-fstack-protector" "-std=c++11" "-Wall")
@@ -44,7 +44,7 @@ add_custom_command(OUTPUT  ${PROJECT_GENERATED_IAS_SOURCES}
 # Untrusted Common Library
 ################################################################################
 
-SET(UNTRUSTED_LIB_NAME utcf-common)
+SET(UNTRUSTED_LIB_NAME uavalon-common)
 PROJECT(${UNTRUSTED_LIB_NAME} CXX)
 
 pkg_check_modules (OPENSSL REQUIRED openssl>=1.1.1d)
@@ -65,7 +65,7 @@ TARGET_COMPILE_DEFINITIONS(${UNTRUSTED_LIB_NAME} PRIVATE "-D_UNTRUSTED_=1")
 ################################################################################
 
 if(NOT UNTRUSTED_ONLY)
-	SET(TRUSTED_LIB_NAME ttcf-common)
+	SET(TRUSTED_LIB_NAME tavalon-common)
 	PROJECT(${TRUSTED_LIB_NAME} CXX)
 
 	ADD_LIBRARY(${TRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_GENERATED_IAS_SOURCES} ${PROJECT_SOURCES})
@@ -91,4 +91,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 link_directories(${CMAKE_BINARY_DIR})
+
+ADD_SUBDIRECTORY(packages/base64)
+ADD_SUBDIRECTORY(packages/parson)
 

--- a/tc/sgx/common/packages/base64/CMakeLists.txt
+++ b/tc/sgx/common/packages/base64/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2 FATAL_ERROR)
+find_package(PkgConfig REQUIRED)
+
+option(UNTRUSTED_ONLY "Build only untrusted components" OFF)
+
+################################################################################
+# Common components for both trusted and untrusted base64 libraries
+################################################################################
+
+FILE(GLOB PROJECT_HEADERS *.h)
+FILE(GLOB PROJECT_SOURCES *.cpp)
+
+SET(COMMON_CXX_FLAGS ${DEBUG_FLAGS} "-m64" "-fvisibility=hidden" "-fpie" "-fPIC" "-fstack-protector" "-std=c++11" "-Wall")
+
+################################################################################
+# Untrusted Base64 Library
+################################################################################
+
+SET(UNTRUSTED_LIB_NAME uavalon-base64)
+PROJECT(${UNTRUSTED_LIB_NAME} CXX)
+
+ADD_LIBRARY(${UNTRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_SOURCES})
+
+TARGET_COMPILE_OPTIONS(${UNTRUSTED_LIB_NAME} PRIVATE ${COMMON_CXX_FLAGS})
+
+TARGET_COMPILE_DEFINITIONS(${UNTRUSTED_LIB_NAME} PRIVATE "-D_UNTRUSTED_=1")
+
+################################################################################
+# Trusted Base64 Library
+################################################################################
+
+if(NOT UNTRUSTED_ONLY)
+        SET(TRUSTED_LIB_NAME tavalon-base64)
+        PROJECT(${TRUSTED_LIB_NAME} CXX)
+
+        ADD_LIBRARY(${TRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_SOURCES})
+
+        TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include)
+        TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SSL}/include)
+        TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include/tlibc)
+        TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include/libcxx)
+
+        TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE ${COMMON_CXX_FLAGS})
+        TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -nostdinc)
+        TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -nostdinc++)
+        TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -fno-builtin-printf)
+endif()
+

--- a/tc/sgx/common/packages/base64/base64.cpp
+++ b/tc/sgx/common/packages/base64/base64.cpp
@@ -47,7 +47,7 @@ static inline bool is_base64(unsigned char c) {
     return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-Base64EncodedString base64_encode(const ByteArray& buf) {
+std::string base64_encode(const std::vector<uint8_t>& buf) {
     std::string ret;
     int i = 0;
     int j = 0;
@@ -87,13 +87,13 @@ Base64EncodedString base64_encode(const ByteArray& buf) {
     return ret;
 }
 
-ByteArray base64_decode(const Base64EncodedString& encoded_string) {
+std::vector<uint8_t> base64_decode(const std::string& encoded_string) {
     int in_len = encoded_string.size();
     int i = 0;
     int j = 0;
     int in_ = 0;
     unsigned char char_array_4[4], char_array_3[3];
-    ByteArray ret;
+    std::vector<uint8_t> ret;
 
     while (in_len-- && (encoded_string[in_] != '=') && is_base64(encoded_string[in_])) {
         char_array_4[i++] = encoded_string[in_];

--- a/tc/sgx/common/packages/base64/base64.h
+++ b/tc/sgx/common/packages/base64/base64.h
@@ -9,12 +9,11 @@
 
 #pragma once
 
-#include "types.h"
+#include <string>
+#include <vector>
 
-#define BASE64_SIZE(x) (static_cast<size_t>(((((x) - 1) / 3) * 4 + 4) + 1))
+std::string base64_encode(
+    const std::vector<uint8_t>& raw_buffer);
 
-Base64EncodedString base64_encode(
-    const ByteArray& raw_buffer);
-
-ByteArray base64_decode(
-    const Base64EncodedString& encoded_string);
+std::vector<uint8_t> base64_decode(
+    const std::string& encoded_string);

--- a/tc/sgx/common/packages/parson/CMakeLists.txt
+++ b/tc/sgx/common/packages/parson/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2 FATAL_ERROR)
+find_package(PkgConfig REQUIRED)
+
+option(UNTRUSTED_ONLY "Build only untrusted components" OFF)
+
+################################################################################
+# Common components for both trusted and untrusted parson libraries
+################################################################################
+
+FILE(GLOB PROJECT_HEADERS *.h)
+FILE(GLOB PROJECT_SOURCES *.cpp)
+
+SET(COMMON_CXX_FLAGS ${DEBUG_FLAGS} "-m64" "-fvisibility=hidden" "-fpie" "-fPIC" "-fstack-protector" "-std=c++11" "-Wall")
+
+################################################################################
+# Untrusted Parson Library
+################################################################################
+
+SET(UNTRUSTED_LIB_NAME uavalon-parson)
+PROJECT(${UNTRUSTED_LIB_NAME} CXX)
+
+ADD_LIBRARY(${UNTRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_SOURCES})
+
+TARGET_COMPILE_OPTIONS(${UNTRUSTED_LIB_NAME} PRIVATE ${COMMON_CXX_FLAGS})
+
+TARGET_COMPILE_DEFINITIONS(${UNTRUSTED_LIB_NAME} PRIVATE "-D_UNTRUSTED_=1")
+
+################################################################################
+# Trusted Parson Library
+################################################################################
+
+if(NOT UNTRUSTED_ONLY)
+        SET(TRUSTED_LIB_NAME tavalon-parson)
+        PROJECT(${TRUSTED_LIB_NAME} CXX)
+
+        ADD_LIBRARY(${TRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_SOURCES})
+
+        TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include)
+        TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SSL}/include)
+        TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include/tlibc)
+        TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include/libcxx)
+
+        TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE ${COMMON_CXX_FLAGS})
+        TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -nostdinc)
+        TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -nostdinc++)
+        TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -fno-builtin-printf)
+endif()
+

--- a/tc/sgx/trusted_worker_manager/enclave/CMakeLists.txt
+++ b/tc/sgx/trusted_worker_manager/enclave/CMakeLists.txt
@@ -236,7 +236,7 @@ TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--whole-archive -linside_out_eval -Wl,
 # Add simple wallet workload
 TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--whole-archive -lsimple_wallet -Wl,--no-whole-archive)
 
-TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--start-group  -lttcf-common -lsgx_tsgxssl_crypto -lsgx_tstdc -lsgx_tcxx -lsgx_tcrypto  -l${SERVICE_LIBRARY_NAME} -Wl,--end-group)
+TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--start-group  -ltavalon-common -ltavalon-base64 -ltavalon-parson -lsgx_tsgxssl_crypto -lsgx_tstdc -lsgx_tcxx -lsgx_tcrypto  -l${SERVICE_LIBRARY_NAME} -Wl,--end-group)
 
 TARGET_INCLUDE_DIRECTORIES( ${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${SGX_ENCLAVE_INCLUDE} ${SGX_INCLUDE})
 TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME} PRIVATE ${TCF_TOP_DIR}/examples/apps)


### PR DESCRIPTION
Previously both base64 and parson packages used to build as part of tc/sgx/common library.
Due to this, any module which needs to used them has to build bulk sized common library.
Seperating these packages into libraries make them light weight.

Signed-off-by: manju956 <manjunath.a.c@intel.com>