### PR TITLE
Separate SGX error handling into a new file

### DIFF
--- a/tc/sgx/common/avalon_sgx_error.cpp
+++ b/tc/sgx/common/avalon_sgx_error.cpp
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "avalon_sgx_error.h"
 #include "error.h"
 #include "sgx_support.h"
 #include "c11_support.h"

--- a/tc/sgx/common/avalon_sgx_error.h
+++ b/tc/sgx/common/avalon_sgx_error.h
@@ -1,0 +1,49 @@
+/* Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdexcept>
+
+#include "sgx_error.h"
+
+namespace tcf {
+    namespace error {
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        class SgxError : public std::exception {
+        public:
+            explicit SgxError() : errorCode(SGX_SUCCESS) {}
+            explicit SgxError(
+                sgx_status_t inErrorCode
+                ) :
+                errorCode(inErrorCode) {}
+            virtual ~SgxError() {}
+
+            sgx_status_t error() { return errorCode; }
+
+            virtual char const * what() const throw() {
+                return "Sgx Call Failed.";
+            }
+
+        private:
+            sgx_status_t errorCode;
+        }; // class SgxError
+
+        // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        void ThrowSgxError(
+            sgx_status_t ret,
+            const char* msg = nullptr
+            );
+
+    }  // error
+}  // tcf

--- a/tc/sgx/common/error.h
+++ b/tc/sgx/common/error.h
@@ -19,32 +19,9 @@
 #include <string>
 
 #include "tcf_error.h"
-#include "sgx_error.h"
 
 namespace tcf {
     namespace error {
-
-        // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-        class SgxError : public std::exception {
-        public:
-            explicit SgxError() : errorCode(SGX_SUCCESS) {}
-            explicit SgxError(
-                sgx_status_t inErrorCode
-                ) :
-                errorCode(inErrorCode) {}
-            virtual ~SgxError() {}
-
-            sgx_status_t error() { return errorCode; }
-
-            virtual char const * what() const throw() {
-                return "Sgx Call Failed.";
-            }
-
-        private:
-            sgx_status_t errorCode;
-        }; // class SgxError
-
-        // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         class Error : public std::runtime_error {
         private:
             tcf_err_t _error_code;
@@ -176,12 +153,6 @@ namespace tcf {
                 throw except(msg);
             }
         } // ThrowIf
-
-        // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-        void ThrowSgxError(
-            sgx_status_t ret,
-            const char* msg = nullptr
-            );
     }
 
 } // namespace tcf

--- a/tc/sgx/common/packages/base64/CMakeLists.txt
+++ b/tc/sgx/common/packages/base64/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 Intel Corporation
+# Copyright 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tc/sgx/common/packages/parson/CMakeLists.txt
+++ b/tc/sgx/common/packages/parson/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 Intel Corporation
+# Copyright 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tc/sgx/trusted_worker_manager/enclave/base_enclave.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/base_enclave.cpp
@@ -28,6 +28,7 @@
 #include "auto_handle_sgx.h"
 
 #include "error.h"
+#include "avalon_sgx_error.h"
 #include "tcf_error.h"
 #include "zero.h"
 

--- a/tc/sgx/trusted_worker_manager/enclave/enclave_data.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/enclave_data.cpp
@@ -22,6 +22,7 @@
 
 #include "crypto.h"
 #include "error.h"
+#include "avalon_sgx_error.h"
 #include "tcf_error.h"
 #include "zero.h"
 

--- a/tc/sgx/trusted_worker_manager/enclave/signup_enclave.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/signup_enclave.cpp
@@ -30,6 +30,7 @@
 
 #include "crypto.h"
 #include "error.h"
+#include "avalon_sgx_error.h"
 #include "tcf_error.h"
 #include "zero.h"
 #include "jsonvalue.h"

--- a/tc/sgx/trusted_worker_manager/enclave_wrapper/enclave.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_wrapper/enclave.cpp
@@ -29,6 +29,7 @@
 #include "log.h"
 
 #include "error.h"
+#include "avalon_sgx_error.h"
 #include "hex_string.h"
 #include "tcf_error.h"
 #include "types.h"

--- a/tc/sgx/trusted_worker_manager/enclave_wrapper/signup.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_wrapper/signup.cpp
@@ -23,6 +23,7 @@
 #include <sgx_uae_service.h>
 
 #include "error.h"
+#include "avalon_sgx_error.h"
 #include "log.h"
 #include "tcf_error.h"
 #include "types.h"

--- a/tc/sgx/trusted_worker_manager/enclave_wrapper/work_order.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_wrapper/work_order.cpp
@@ -17,6 +17,7 @@
 
 #include "tcf_error.h"
 #include "error.h"
+#include "avalon_sgx_error.h"
 #include "log.h"
 #include "types.h"
 #include "zero.h"


### PR DESCRIPTION
This change is done to avoid SGX dependency on any module which just needs
to use general error handling functionalities provided by error.h

Signed-off-by: manju956 <manjunath.a.c@intel.com>