### PR TITLE
Build crypto and verify_ias_report libraries independent of SGX

### DIFF
--- a/examples/common/python/crypto/crypto.i
+++ b/examples/common/python/crypto/crypto.i
@@ -16,6 +16,7 @@
 %module crypto
 
 %{
+#include "utils.h"
 #include "types.h"
 #include "crypto.h"
 #include "error.h"
@@ -106,10 +107,9 @@ namespace std {
 
 %ignore ByteArrayToString;
 
+%include "utils.h"
 %include "types.h"
-%include "crypto.h"
 %include "crypto_utils.h"
-%include "crypto_shared.h"
 %include "sig.h"
 %include "pkenc.h"
 %include "skenc.h"

--- a/examples/common/python/setup.py
+++ b/examples/common/python/setup.py
@@ -32,14 +32,6 @@ tcf_root_dir = os.environ.get('TCF_HOME', '../../..')
 version = subprocess.check_output(
     os.path.join(tcf_root_dir, 'bin/get_version')).decode('ascii').strip()
 
-sgx_sdk_env = os.environ.get('SGX_SDK', '/opt/intel/sgxsdk')
-sgx_ssl_env = os.environ.get('SGX_SSL', '/opt/intel/sgxssl')
-sgx_mode_env = os.environ.get('SGX_MODE', 'SIM')
-if not sgx_mode_env or (sgx_mode_env != "SIM" and sgx_mode_env != "HW"):
-    print("error: SGX_MODE value must be HW or SIM, current value is: ",
-          sgx_mode_env)
-    sys.exit(2)
-
 openssl_cflags = subprocess.check_output(
     ['pkg-config', 'openssl', '--cflags']).decode('ascii').strip().split()
 openssl_include_dirs = list(
@@ -56,8 +48,6 @@ openssl_lib_dirs = list(
            subprocess.check_output(['pkg-config', 'openssl', '--libs-only-L'])
            .decode('ascii').strip())))
 
-debug_flag = os.environ.get('TCF_DEBUG_BUILD', 0)
-
 compile_args = [
     '-std=c++11',
     '-Wno-switch',
@@ -65,44 +55,29 @@ compile_args = [
     '-Wno-unused-variable',
 ]
 
-# by default the extension class adds '-O2' to the compile
-# flags, this lets us override since these are appended to
-# the compilation switches
-if debug_flag:
-    compile_args += ['-g']
 
 crypto_include_dirs = [
-    os.path.join(tcf_root_dir, 'tc/sgx/common/crypto'),
     os.path.join(tcf_root_dir, 'tc/sgx/common'),
-    os.path.join(sgx_sdk_env,  'include'),
+    os.path.join(tcf_root_dir, 'tc/sgx/common/crypto'),
 ] + openssl_include_dirs
 
 verify_report_include_dirs = [
-    os.path.join(tcf_root_dir, 'tc/sgx/common/verify_ias_report'),
     os.path.join(tcf_root_dir, 'tc/sgx/common'),
-    os.path.join(sgx_sdk_env,  'include'),
+    os.path.join(tcf_root_dir, 'tc/sgx/common/verify_ias_report'),
 ]
 
 library_dirs = [
     os.path.join(tcf_root_dir, "tc/sgx/common/build"),
-    os.path.join(sgx_sdk_env, 'lib64'),
-    os.path.join(sgx_ssl_env, 'lib64'),
-    os.path.join(sgx_ssl_env, 'lib64', 'release')
 ] + openssl_lib_dirs
 
 libraries = [
     'uavalon-common',
-    'uavalon-base64'
+    'uavalon-base64',
+    'uavalon-parson',
+    'uavalon-crypto',
+    'uavalon-verify-ias-report'
 ] + openssl_libs
 
-if sgx_mode_env == "HW":
-    libraries.append('sgx_urts')
-    libraries.append('sgx_uae_service')
-if sgx_mode_env == "SIM":
-    libraries.append('sgx_urts_sim')
-    libraries.append('sgx_uae_service_sim')
-
-libraries.append('sgx_usgxssl')
 libraries = libraries + openssl_libs
 
 crypto_modulefiles = [

--- a/examples/common/python/verify_report/verify_report.i
+++ b/examples/common/python/verify_report/verify_report.i
@@ -18,7 +18,6 @@
 %{
 #include "types.h"
 #include "error.h"
-#include "sgx_quote.h"
 #include "ias_attestation_util.h"
 %}
 

--- a/examples/enclave_manager/setup.py
+++ b/examples/enclave_manager/setup.py
@@ -77,6 +77,8 @@ library_dirs = [
 
 libraries = [
     'uavalon-common',
+    'uavalon-crypto',
+    'uavalon-verify-ias-report',
     'uavalon-base64',
     'uavalon-parson'
 ]

--- a/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py
+++ b/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py
@@ -26,7 +26,6 @@ import sgx_work_order_request as work_order_request
 import tcf_enclave_helper as enclave_helper
 import utility.signature as signature
 import utility.utility as utils
-import crypto.crypto as crypto
 from database import connector
 from error_code.error_status import ReceiptCreateStatus, WorkOrderStatus
 from utility.tcf_types import WorkerStatus, WorkerType

--- a/tc/sgx/common/crypto/CMakeLists.txt
+++ b/tc/sgx/common/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Intel Corporation
+# Copyright 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,23 +17,21 @@ find_package(PkgConfig REQUIRED)
 
 option(UNTRUSTED_ONLY "Build only untrusted components" OFF)
 
-INCLUDE(CMakeVariables.txt)
-
 ################################################################################
-# Common components for both trusted and untrusted common libraries
+# Common components for both trusted and untrusted crypto library
 ################################################################################
 
 FILE(GLOB PROJECT_HEADERS *.h)
 FILE(GLOB PROJECT_SOURCES *.cpp)
 
-SET(COMMON_PRIVATE_INCLUDE_DIRS "." "tests" "crypto" "packages/base64" "packages/parson")
+SET(COMMON_PRIVATE_INCLUDE_DIRS ".." "../packages/base64")
 SET(COMMON_CXX_FLAGS ${DEBUG_FLAGS} "-m64" "-fvisibility=hidden" "-fpie" "-fPIC" "-fstack-protector" "-std=c++11" "-Wall")
 
 ################################################################################
-# Untrusted Common Library
+# Untrusted Crypto Library
 ################################################################################
 
-SET(UNTRUSTED_LIB_NAME uavalon-common)
+SET(UNTRUSTED_LIB_NAME uavalon-crypto)
 PROJECT(${UNTRUSTED_LIB_NAME} CXX)
 
 pkg_check_modules (OPENSSL REQUIRED openssl>=1.1.1d)
@@ -41,18 +39,17 @@ pkg_check_modules (OPENSSL REQUIRED openssl>=1.1.1d)
 ADD_LIBRARY(${UNTRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_SOURCES})
 
 TARGET_INCLUDE_DIRECTORIES(${UNTRUSTED_LIB_NAME} PRIVATE ${COMMON_PRIVATE_INCLUDE_DIRS})
-TARGET_INCLUDE_DIRECTORIES(${UNTRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include)
 
 TARGET_COMPILE_OPTIONS(${UNTRUSTED_LIB_NAME} PRIVATE ${COMMON_CXX_FLAGS} ${OPENSSL_CFLAGS})
 
 TARGET_COMPILE_DEFINITIONS(${UNTRUSTED_LIB_NAME} PRIVATE "-D_UNTRUSTED_=1")
 
 ################################################################################
-# Trusted Common Library
+# Trusted Crypto Library
 ################################################################################
 
 if(NOT UNTRUSTED_ONLY)
-	SET(TRUSTED_LIB_NAME tavalon-common)
+	SET(TRUSTED_LIB_NAME tavalon-crypto)
 	PROJECT(${TRUSTED_LIB_NAME} CXX)
 
 	ADD_LIBRARY(${TRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_SOURCES})
@@ -69,17 +66,3 @@ if(NOT UNTRUSTED_ONLY)
 	TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -fno-builtin-printf)
 endif()
 
-
-################################################################################
-# Other libraries in common
-################################################################################
-
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-link_directories(${CMAKE_BINARY_DIR})
-
-ADD_SUBDIRECTORY(packages/base64)
-ADD_SUBDIRECTORY(packages/parson)
-ADD_SUBDIRECTORY(crypto)
-ADD_SUBDIRECTORY(verify_ias_report)

--- a/tc/sgx/common/crypto/crypto_utils.cpp
+++ b/tc/sgx/common/crypto/crypto_utils.cpp
@@ -15,7 +15,6 @@
 
 #include <string.h>
 #include <assert.h>
-#include "crypto_utils.h"
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/sha.h>
@@ -24,8 +23,10 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+
 #include "base64.h"  // Simple base64 enc/dec routines
 #include "crypto_shared.h"
+#include "crypto_utils.h"
 #include "error.h"
 #include "tcf_error.h"
 #include "hex_string.h"
@@ -36,6 +37,9 @@
 #if _UNTRUSTED_
 #include <openssl/crypto.h>
 #include <stdio.h>
+
+// memcpy_s definition is not present in std C library, hence mapping to memcpy
+#define memcpy_s(dest, dest_size, src, count) memcpy(dest, src, count)
 #else
 #include "tSgxSSL_api.h"
 #endif

--- a/tc/sgx/common/verify_ias_report/CMakeLists.txt
+++ b/tc/sgx/common/verify_ias_report/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Intel Corporation
+# Copyright 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,45 +17,54 @@ find_package(PkgConfig REQUIRED)
 
 option(UNTRUSTED_ONLY "Build only untrusted components" OFF)
 
-INCLUDE(CMakeVariables.txt)
-
 ################################################################################
-# Common components for both trusted and untrusted common libraries
+# Common components for both trusted and untrusted verify_ias_report library
 ################################################################################
 
 FILE(GLOB PROJECT_HEADERS *.h)
 FILE(GLOB PROJECT_SOURCES *.cpp)
 
-SET(COMMON_PRIVATE_INCLUDE_DIRS "." "tests" "crypto" "packages/base64" "packages/parson")
+SET(COMMON_PRIVATE_INCLUDE_DIRS ".." "../packages/base64" "../packages/parson" "../crypto")
 SET(COMMON_CXX_FLAGS ${DEBUG_FLAGS} "-m64" "-fvisibility=hidden" "-fpie" "-fPIC" "-fstack-protector" "-std=c++11" "-Wall")
 
 ################################################################################
-# Untrusted Common Library
+# Generated source
 ################################################################################
 
-SET(UNTRUSTED_LIB_NAME uavalon-common)
+MESSAGE( "current bin dir " ${CMAKE_CURRENT_BINARY_DIR})
+SET(PROJECT_GENERATED_IAS_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/../../verify_ias_report/ias-certificates.cpp)
+add_custom_command(OUTPUT  ${PROJECT_GENERATED_IAS_SOURCES}
+                     COMMAND ./build_ias_certificates_cpp.sh
+                     DEPENDS ias-certificates.template build_ias_certificates_cpp.sh
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../verify_ias_report
+)
+
+################################################################################
+# Untrusted Verify-Ias-Report Library
+################################################################################
+
+SET(UNTRUSTED_LIB_NAME uavalon-verify-ias-report)
 PROJECT(${UNTRUSTED_LIB_NAME} CXX)
 
 pkg_check_modules (OPENSSL REQUIRED openssl>=1.1.1d)
 
-ADD_LIBRARY(${UNTRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_SOURCES})
+ADD_LIBRARY(${UNTRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_GENERATED_IAS_SOURCES} ${PROJECT_SOURCES})
 
 TARGET_INCLUDE_DIRECTORIES(${UNTRUSTED_LIB_NAME} PRIVATE ${COMMON_PRIVATE_INCLUDE_DIRS})
-TARGET_INCLUDE_DIRECTORIES(${UNTRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include)
 
 TARGET_COMPILE_OPTIONS(${UNTRUSTED_LIB_NAME} PRIVATE ${COMMON_CXX_FLAGS} ${OPENSSL_CFLAGS})
 
 TARGET_COMPILE_DEFINITIONS(${UNTRUSTED_LIB_NAME} PRIVATE "-D_UNTRUSTED_=1")
 
 ################################################################################
-# Trusted Common Library
+# Trusted Verify-Ias-Report Library
 ################################################################################
 
 if(NOT UNTRUSTED_ONLY)
-	SET(TRUSTED_LIB_NAME tavalon-common)
+	SET(TRUSTED_LIB_NAME tavalon-verify-ias-report)
 	PROJECT(${TRUSTED_LIB_NAME} CXX)
 
-	ADD_LIBRARY(${TRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_SOURCES})
+	ADD_LIBRARY(${TRUSTED_LIB_NAME} STATIC ${PROJECT_HEADERS} ${PROJECT_GENERATED_IAS_SOURCES} ${PROJECT_SOURCES})
 
 	TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PRIVATE ${COMMON_PRIVATE_INCLUDE_DIRS})
 	TARGET_INCLUDE_DIRECTORIES(${TRUSTED_LIB_NAME} PUBLIC ${SGX_SDK}/include)
@@ -68,18 +77,3 @@ if(NOT UNTRUSTED_ONLY)
 	TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -nostdinc++)
 	TARGET_COMPILE_OPTIONS(${TRUSTED_LIB_NAME} PRIVATE -fno-builtin-printf)
 endif()
-
-
-################################################################################
-# Other libraries in common
-################################################################################
-
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-link_directories(${CMAKE_BINARY_DIR})
-
-ADD_SUBDIRECTORY(packages/base64)
-ADD_SUBDIRECTORY(packages/parson)
-ADD_SUBDIRECTORY(crypto)
-ADD_SUBDIRECTORY(verify_ias_report)

--- a/tc/sgx/common/verify_ias_report/verify-report.cpp
+++ b/tc/sgx/common/verify_ias_report/verify-report.cpp
@@ -24,39 +24,6 @@
 #include "crypto_utils.h"
 #include "ias-certificates.h"
 
-void get_quote_from_report(const uint8_t* report, const int report_len, sgx_quote_t* quote)
-{
-    // Move report into \0 terminated buffer such that we can work
-    // with str* functions.
-    int buf_len = report_len + 1;
-    char buf[buf_len];
-
-    memcpy_s(buf, buf_len, report, report_len);
-    buf[report_len] = '\0';
-
-    const int json_string_max_len = 64;
-    const char json_string[json_string_max_len] = "\"isvEnclaveQuoteBody\":\"";
-    char* p_begin = strstr(buf, json_string);
-    assert(p_begin != NULL);
-    p_begin += strnlen(json_string, json_string_max_len);
-    const char* p_end = strchr(p_begin, '"');
-    assert(p_end != NULL);
-
-    const int quote_base64_len = p_end - p_begin;
-    uint8_t* quote_bin = (uint8_t*)malloc(quote_base64_len);
-    uint32_t quote_bin_len = quote_base64_len;
-
-    int ret = tcf::crypto::decode_base64_block(quote_bin,
-                  (unsigned char*)p_begin, quote_base64_len);
-    assert(ret != -1);
-    quote_bin_len = ret;
-
-    assert(quote_bin_len <= sizeof(sgx_quote_t));
-    memset(quote, 0, sizeof(sgx_quote_t));
-    memcpy_s(quote, sizeof(sgx_quote_t), quote_bin, quote_bin_len);
-    free(quote_bin);
-}
-
 bool verify_ias_report_signature(
     const char* ias_attestation_signing_cert_pem,
     const char* ias_report,

--- a/tc/sgx/common/verify_ias_report/verify-report.h
+++ b/tc/sgx/common/verify_ias_report/verify-report.h
@@ -16,13 +16,6 @@
 #ifndef VERIFY_REPORT_H
 #define VERIFY_REPORT_H
 
-#include <sgx_quote.h>
-
-// Extracts enclave quote from report
-void get_quote_from_report(const uint8_t* report,
-                           const int report_len,
-                           sgx_quote_t* quote);
-
 // Verifies enclave quote status
 bool verify_enclave_quote_status(const char* ias_report,
                                  int ias_report_len,

--- a/tc/sgx/trusted_worker_manager/enclave/CMakeLists.txt
+++ b/tc/sgx/trusted_worker_manager/enclave/CMakeLists.txt
@@ -236,7 +236,7 @@ TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--whole-archive -linside_out_eval -Wl,
 # Add simple wallet workload
 TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--whole-archive -lsimple_wallet -Wl,--no-whole-archive)
 
-TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--start-group  -ltavalon-common -ltavalon-base64 -ltavalon-parson -lsgx_tsgxssl_crypto -lsgx_tstdc -lsgx_tcxx -lsgx_tcrypto  -l${SERVICE_LIBRARY_NAME} -Wl,--end-group)
+TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--start-group  -ltavalon-common -ltavalon-base64 -ltavalon-parson -ltavalon-crypto -ltavalon-verify-ias-report -lsgx_tsgxssl_crypto -lsgx_tstdc -lsgx_tcxx -lsgx_tcrypto  -l${SERVICE_LIBRARY_NAME} -Wl,--end-group)
 
 TARGET_INCLUDE_DIRECTORIES( ${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${SGX_ENCLAVE_INCLUDE} ${SGX_INCLUDE})
 TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME} PRIVATE ${TCF_TOP_DIR}/examples/apps)

--- a/tc/sgx/trusted_worker_manager/enclave/signup_enclave.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/signup_enclave.cpp
@@ -27,6 +27,7 @@
 #include <sgx_tcrypto.h>
 #include <sgx_trts.h>
 #include <sgx_utils.h>  // sgx_get_key, sgx_create_report
+#include <sgx_quote.h>
 
 #include "crypto.h"
 #include "error.h"


### PR DESCRIPTION
Both crypto and verify as report modules are built as independent static libaries.
SGX SDK and SGX SSL dependency on these modules are removed for untrsuted code and both trusted and untrusted libraries are built.

Signed-off-by: manju956 <manjunath.a.c@intel.com>