### PR TITLE
Fix PREREQUISITES.md and BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -29,7 +29,7 @@ Follow the instructions below to execute a Docker-based build and execution.
 1. Install Docker Engine and Docker Compose, if not already installed.
    See [PREREQUISITES](PREREQUISITES.md#docker) for instructions
 2. Build and run the Docker image from the top-level directory of your
-   `trusted-compute-framework` source repository.
+   `avalon` source repository.
 
    **Intel SGX Simulator mode (for hosts without Intel SGX)**:
    1. Run `sudo docker-compose up --build`
@@ -72,12 +72,12 @@ The steps below will set up a Python virtual environment to run Avalon.
 
 2. Download the Avalon source repository if you have not already done this:
    ```bash
-   git clone https://github.com/hyperledger-labs/trusted-compute-framework
-   cd trusted-compute-framework
+   git clone https://github.com/hyperledger/avalon 
+   cd avalon
    ```
 
 3. Set `TCF_HOME` to the top level directory of your
-   `trusted-compute-framework` source repository.
+   `avalon` source repository.
    You will need these environment variables set in every shell session
    where you interact with Avalon.
    Append this line (with `pwd` expanded) to your login shell script
@@ -90,10 +90,33 @@ The steps below will set up a Python virtual environment to run Avalon.
 4. If you are using Intel SGX hardware, check that `SGX_MODE=HW` before
    building the code.
    By default `SGX_MODE=SIM` indicating use the Intel SGX simulator.
+   if you are not using Intel SGX hardware, go to the next step.
 
-   If `SGX_MODE=HW`, also check that `TCF_ENCLAVE_CODE_SIGN_PEM` is set.
+   Check that `TCF_ENCLAVE_CODE_SIGN_PEM` is set.
    Refer to the [PREREQUISITES document](PREREQUISITES.md)
-   for more details on these variables
+   for more details on these variables.
+
+   You will also need to obtain an Intel IAS subscription key and SPID
+   from the portal
+   https://api.portal.trustedservices.intel.com/
+   Replace the SPID and IAS Subscription key values in file
+   `$TCF_HOME/config/tcs_config.toml` with the actual hexadecimal values
+   (the IAS key may be either your Primary key or Secondary key):
+
+   ```bash
+   spid = '<spid obtained from portal>'
+   ias_api_key = '<ias subscription key obtained from portal>'
+   ```
+
+   In the same file, if you are behind a corporate proxy,
+   uncomment and update the https_proxy line:
+
+   ```bash
+   #https_proxy = "http://your-proxy:your-port/"
+   ```
+   If you are not behind a corporate proxy (the usual case),
+   then leave this line commented out.
+
 
 5. Create Python virtual environment, Build and Install Avalon
    components into it:

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -80,10 +80,11 @@ On a minimal Ubuntu system, Hyperledger Avalon requires the following packages.
 Other distributions will require similar packages.
 ```bash
 sudo apt-get update
-sudo apt-get install -y cmake swig pkg-config python3-dev python3-venv python \
+sudo apt-get install -y cmake swig pkg-config python3-dev python \
      software-properties-common virtualenv curl xxd git unzip dh-autoreconf \
      ocaml ocamlbuild liblmdb-dev protobuf-compiler python3-pip python3-toml \
      python3-requests python3-colorlog python3-twisted
+sudo apt-get install -y python3-venv
 ```
 
 Also, install the following pip packages
@@ -242,27 +243,6 @@ If installation of the Intel SGX driver fails due to syntax errors,
 you may need to install a newer version of a non-DCAP Intel SGX driver
 for your version of Linux. See
 https://01.org/intel-software-guard-extensions/downloads
-
-You will need to obtain an Intel IAS subscription key and SPID from the portal
-https://api.portal.trustedservices.intel.com/
-
-Replace the SPID and IAS Subscription key values in file
-`$TCF_HOME/config/tcs_config.toml` with the actual hexadecimal values
-(the IAS key may be either your Primary key or Secondary key):
-
-```bash
-spid = '<spid obtained from portal>'
-ias_api_key = '<ias subscription key obtained from portal>'
-```
-
-In the same file, if you are behind a corporate proxy,
-uncomment and update the https_proxy line:
-
-```bash
-#https_proxy = "http://your-proxy:your-port/"
-```
-If you are not behind a corporate proxy (the usual case),
-then leave this line commented out.
 
 **The following steps apply only to standalone builds.**
 
@@ -470,4 +450,7 @@ problems.
 - If you are not running in a corporate proxy environment (and not connected
   directly to Internet), comment out the `https_proxy` line in
   `config/tcs_config.toml`
+
+- If you reinstall the Intel SGX SDK and you modified `/etc/aesmd.conf`
+  then save and restore the file before installing the SDK.
 

--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -78,6 +78,7 @@ RUN apt-get update \
 
 # Install setuptools, py-solc and web3 packages using pip because
 # these are not available in apt repository.
+# Install nose2 for running tests.
 RUN pip3 install --upgrade setuptools json-rpc py-solc web3 nose2
 
 # Make Python3 default


### PR DESCRIPTION
PREREQUISITES.md
- Add installing python3-venv as a separate step
  (otherwise does not install due to missing prerequisites)
- Add note that reinstalling Intel SGX SDK overwrites aesmd.conf

BUILD.md
- Move IAS subscription key instructions from PREREQUISITES.md to BUILD.md
  (because Avalon is not installed yet, config/tcs_config.toml
  cannot be modified)
- Update https://github.com/hyperledger-labs/trusted-compute-framework
  to https://github.com/hyperledger/avalon 
- Update trusted-compute-framework to avalon

docker/Dockerfile.tcf-dev
- Add comment about extra pip3 package nose2

Signed-off-by: danintel <daniel.anderson@intel.com>