### PR TITLE
tcs_startup.sh: Add LMDB Option and Change Name to Hyperledger Avalon

### DIFF
--- a/ci/tcf-tests.yaml
+++ b/ci/tcf-tests.yaml
@@ -25,7 +25,7 @@ services:
         - no_proxy
     working_dir: "/project/TrustedComputeFramework/"
     entrypoint: "bash -c \"\
-        source scripts/tcs_startup.sh -y \
+        source scripts/tcs_startup.sh -y -l http://avalon-lmdb:9090 \
         && sleep 5 \
         && source tools/run_tests.sh \""
     depends_on:

--- a/docker-compose-sgx.yaml
+++ b/docker-compose-sgx.yaml
@@ -39,7 +39,7 @@ services:
       - "/dev/isgx:/dev/isgx"
     working_dir: "/project/TrustedComputeFramework"
     entrypoint: "bash -c \"\
-        source scripts/tcs_startup.sh -y \
+        source scripts/tcs_startup.sh -y -l http://avalon-lmdb:9090 \
         && tail -f /dev/null \""
     stop_signal: SIGKILL
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
     working_dir: "/project/TrustedComputeFramework"
     command: |
       bash -c "
-        source scripts/tcs_startup.sh -y
+        source scripts/tcs_startup.sh -y -l http://avalon-lmdb:9090
         tail -f /dev/null
       "
     stop_signal: SIGKILL

--- a/scripts/tcs_startup.sh
+++ b/scripts/tcs_startup.sh
@@ -14,30 +14,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-enclave_manager="${TCF_HOME}/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py"
-listener="${TCF_HOME}/common/python/connectors/direct/tcs_listener/tcs_listener.py"
-version="$(cat ${TCF_HOME}/VERSION)"
+ENCLAVE_MANAGER="${TCF_HOME}/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py"
+LISTENER="${TCF_HOME}/common/python/connectors/direct/tcs_listener/tcs_listener.py"
+VERSION="$(cat ${TCF_HOME}/VERSION)"
+# Default values
+LMDB_URL="http://localhost:9090" # -l default
 
 # Trap handler
-trap 'stop_tcs_components' HUP INT QUIT ABRT ALRM TERM
+trap 'stop_avalon_components' HUP INT QUIT ABRT ALRM TERM
 
-start_tcs_components()
+start_avalon_components()
 {
     # Read Listener port from config file
-    listener_port=`grep listener_port ${TCF_HOME}/config/tcs_config.toml \
+    LISTENER_PORT=`grep listener_port ${TCF_HOME}/config/tcs_config.toml \
         | awk {'print $3'}`
-    if [ -z "$listener_port" ]; then
-        listener_port=1947
+    if [ -z "$LISTENER_PORT" ]; then
+        LISTENER_PORT=1947
     fi
 
-    echo "Starting Avalon Enclave Manager $version ..."
-    python3 $enclave_manager --lmdb_url http://avalon-lmdb:9090 &
+    echo "Using LMDB URL $LMDB_URL."
+
+    echo "Starting Avalon Enclave Manager $VERSION ..."
+    python3 $ENCLAVE_MANAGER --lmdb_url $LMDB_URL &
     echo "Avalon Enclave Manager started"
 
     sleep 5s
 
-    echo "Starting Avalon Listener $version ..."
-    python3 $listener --bind_uri $listener_port --lmdb_url http://avalon-lmdb:9090 &
+    echo "Starting Avalon Listener $VERSION ..."
+    python3 $LISTENER --bind_uri $LISTENER_PORT --lmdb_url $LMDB_URL &
     echo "Avalon Listener started"
 
     if [ "$YES" != "1" ] ; then
@@ -45,35 +49,39 @@ start_tcs_components()
         echo "If you wish to exit the program, press y and enter"
         read -t 5 yn
         case $yn in
-            y ) stop_tcs_components;;
+            y ) stop_avalon_components;;
             * ) echo " ";;
         esac
         done
     fi
 }
 
-stop_tcs_components()
+stop_avalon_components()
 {
-    echo "TCS successfully ended."
-    pkill -f "$listener"
-    pkill -f "$enclave_manager"
+    echo "Hyperledger Avalon successfully ended."
+    pkill -f "$LISTENER"
+    pkill -f "$ENCLAVE_MANAGER"
     exit
 }
 
 
-while getopts "tyh" OPTCHAR ; do
+while getopts "l:hty" OPTCHAR ; do
     case $OPTCHAR in
+        l )
+            LMDB_URL=$OPTARG
+            ;;
         y )
             YES=1
             ;;
         t )
-            stop_tcs_components
+            stop_avalon_components
             ;;
         \?|h )
             BN=$(basename $0)
-            echo "$BN: Start or Stop TCS" 1>&2
-            echo "Usage: $BN [-t|-y|-h|-?]" 1>&2
+            echo "$BN: Start or Stop Hyperledger Avalon" 1>&2
+            echo "Usage: $BN [-l|-t|-y|-h|-?]" 1>&2
             echo "Where:" 1>&2
+            echo "   -l       LMDB server URL. Default is $LMDB_URL" 1>&2
             echo "   -t       terminate the program" 1>&2
             echo "   -y       do not prompt to end program" 1>&2
             echo "   -? or -h print usage information" 1>&2
@@ -83,4 +91,4 @@ while getopts "tyh" OPTCHAR ; do
 done
 shift `expr $OPTIND - 1`
 
-start_tcs_components
+start_avalon_components


### PR DESCRIPTION
Add option to specify LMDB server.  For example:
        tcs_startup.sh -l http://avalon-lmdb:9090
Default to http://localhost:9090

Change TCS or TCF to Hyperledger Avalon

Signed-off-by: danintel <daniel.anderson@intel.com>