### PR TITLE
Add Missing make Instructions to BUILD.md and tcs_startup.sh

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -95,7 +95,7 @@ The steps below will set up a Python virtual environment to run Avalon.
    Refer to the [PREREQUISITES document](PREREQUISITES.md)
    for more details on these variables
 
-5. Create Python virtual environment, Build and Install Avalon
+5. Create a Python virtual environment, and build and install Avalon
    components into it:
    ```bash
    cd $TCF_HOME/tools/build
@@ -105,7 +105,29 @@ The steps below will set up a Python virtual environment to run Avalon.
    make
    ```
 
-6. Activate the new Python virtual environment for the current shell session.
+6. Build the Client SDK Python module:
+
+   ```bash
+   cd $TCF_HOME/client_sdk
+   python3 setup.py bdist_wheel
+   pip3 install dist/*.whl
+   ```
+
+7. Build the LMDB listener and shared key/value storage modules:
+
+ 
+   ```bash
+   cd $TCF_HOME/examples/shared_kv_storage/db_store/packages
+   mkdir -p build
+   cd build
+   cmake ..
+   make
+   cd $TCF_HOME/examples/shared_kv_storage
+   make
+   make install
+   ```
+
+8. Activate the new Python virtual environment for the current shell session.
    You will need to do this in each new shell session (in addition to
    exporting environment variables).
    ```bash

--- a/tools/rebuild.sh
+++ b/tools/rebuild.sh
@@ -173,3 +173,22 @@ yell --------------- ENCLAVE MANAGER ---------------
 cd $TCF_HOME/examples/enclave_manager
 try make "-j$NUM_CORES"
 try make install
+
+yell --------------- CLIENT SDK ---------------
+Please add following instructions to rebuild.sh to build client sdk python module.
+cd $TCF_HOME/client_sdk
+try python3 setup.py bdist_wheel
+try pip3 install dist/*.whl
+
+yell --------------- LMDB LISTENER ---------------
+cd $TCF_HOME/examples/shared_kv_storage/db_store/packages
+mkdir -p build
+cd build
+try cmake ..
+try make
+
+yell --------------- SHARED KV STORAGE ---------------
+cd $TCF_HOME/examples/shared_kv_storage
+try make
+try make install
+


### PR DESCRIPTION
Missing are make instructions for:
- SDK Client: $TCF_HOME/client_sdk
- LMDB listener: $TCF_HOME/examples/shared_kv_storage/db_store/packages
- KV storage: $TCF_HOME/examples/shared_kv_storage

Signed-off-by: danintel <daniel.anderson@intel.com>