### PR TITLE
tcs_startup.sh: Add kv_storage startup

### DIFF
--- a/ci/tcf-tests.yaml
+++ b/ci/tcf-tests.yaml
@@ -25,7 +25,7 @@ services:
         - no_proxy
     working_dir: "/project/TrustedComputeFramework/"
     entrypoint: "bash -c \"\
-        source scripts/tcs_startup.sh -y \
+        source scripts/tcs_startup.sh -y -s \
         && sleep 5 \
         && source tools/run_tests.sh \""
     depends_on:

--- a/docker-compose-sgx.yaml
+++ b/docker-compose-sgx.yaml
@@ -39,7 +39,7 @@ services:
       - "/dev/isgx:/dev/isgx"
     working_dir: "/project/TrustedComputeFramework"
     entrypoint: "bash -c \"\
-        source scripts/tcs_startup.sh -y \
+        source scripts/tcs_startup.sh -y -s \
         && tail -f /dev/null \""
     stop_signal: SIGKILL
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
     working_dir: "/project/TrustedComputeFramework"
     command: |
       bash -c "
-        source scripts/tcs_startup.sh -y
+        source scripts/tcs_startup.sh -y -s
         tail -f /dev/null
       "
     stop_signal: SIGKILL


### PR DESCRIPTION
tcs_startup.sh: Add kv_storage startup

tcs_startup.sh
- Start kv_storage before everything else:
   `kv_storage --bind http://avalon-lmdb:9090`
   (or the value provided by the `-l` option)
- Add `-s` option to optionally not start kv_storage

Dockerfiles
- Add `-s` option when caling tcs_startup.sh from Docker

Signed-off-by: danintel <daniel.anderson@intel.com>