### PR TITLE
Fix Docker Syntax Error

### DIFF
--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -144,7 +144,7 @@ ARG TCF_DEBUG_BUILD
 ARG DISPLAY
 ARG XAUTHORITY
 
-#TODO need to be removed latter
+#TODO need to be removed later
 #install avalon-client python package.
 RUN cd /project/TrustedComputeFramework/client_sdk \
    && python setup.py bdist_wheel \
@@ -192,6 +192,6 @@ WORKDIR /project/TrustedComputeFramework/tools/build
 
 RUN make lint && echo "LINT SUCCESS"
 
-RUN if [ $MAKECLEAN != 0 ]; then echo "Clean build" && make clean; fi \
+RUN if [ "$MAKECLEAN" != 0 ]; then echo "Clean build" && make clean; fi \
  && make \
  && echo "BUILD SUCCESS"


### PR DESCRIPTION
Fix Docker Syntax Error

File `docker/Dockerfile.tcf-dev

`08:42:32  Step 34/34 : RUN if [ $MAKECLEAN != 0 ]; then echo "Clean build" && make clean; fi  && make  && echo "BUILD SUCCESS"`
`08:42:33 /bin/sh: 1: [: !=: unexpected operator`

The problem is `$MAKECLEAN` is not surrounded by double quotes.
If $MAKECLEAN is not defined, the if expression becomes a syntax error: `if [ != 0 ] ...`
As a result a `make clean` is never ran.

Signed-off-by: danintel <daniel.anderson@intel.com>