### PR TITLE
Add pip3 Module jsonrpc

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -89,7 +89,7 @@ sudo apt-get install -y python3-venv
 
 Also, install the following pip3 packages:
 ```bash
-pip3 install --upgrade setuptools json-rpc py-solc web3 wheel
+pip3 install --upgrade setuptools jsonrpc json-rpc py-solc web3 wheel
 ```
 
 # <a name="docker"></a>Docker

--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -79,7 +79,7 @@ RUN apt-get update \
 # Install setuptools, py-solc and web3 packages using pip because
 # these are not available in apt repository.
 # Install nose2 for running tests.
-RUN pip3 install --upgrade setuptools json-rpc py-solc web3 nose2
+RUN pip3 install --upgrade setuptools jsonrpc json-rpc py-solc web3 nose2
 
 # Make Python3 default
 RUN ln -sf /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
If pip3 module `jsonrpc` is not installed, the Avalon Listner gives this error:
`ModuleNotFoundError: No module named 'jsonrpc'`

But if pip3 module `json-rpc` is not installed, the Avalon Listner gives this error:
`ModuleNotFoundError: No module named 'jsonrpc.exceptions'`

So both `jsonrpc` and `json-rpc` are required.

Signed-off-by: danintel <daniel.anderson@intel.com>