### PR TITLE
Fix `apt` and `pip install` Installation Instructions

### DIFF
--- a/client_sdk/TestingContracts.md
+++ b/client_sdk/TestingContracts.md
@@ -65,7 +65,7 @@
    https://web3py.readthedocs.io/en/stable/quickstart.html
 
     ```bash
-    sudo pip install web3
+    pip install web3
     ```
 
 9.  Run `cd $TCF_HOME/examples/common/python/connectors/ethereum`

--- a/examples/apps/heart_disease_eval/README.md
+++ b/examples/apps/heart_disease_eval/README.md
@@ -67,7 +67,7 @@ The Avalon Enclave Manager and Avalon Listener run in a Docker container.
 5.  In Terminal 2 run `cd $TCF_HOME/examples/apps/heart_disease_eval/client`
 6.  In Terminal 2 install Python3's TKInter GUI library with
     ```bash
-    apt update; apt -y install python3-tk python3-pil.imagetk
+    sudo apt update; sudo apt -y install python3-tk python3-pil.imagetk
     ```
 7.  In Terminal 2 install the Solidity compiler as follows:
     ```bash


### PR DESCRIPTION
`examples/apps/heart_disease_eval/README.md`
- Prefix `sudo` to `apt` because it requires root address

`client_sdk/TestingContracts.md`
- Do not prefix `sudo` to `pip install` or `pip3 install`
  because it is account-specific

Signed-off-by: danintel <daniel.anderson@intel.com>