### PR TITLE
Fix C++ Build Warning

### DIFF
--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/enclave.h
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/enclave.h
@@ -106,11 +106,7 @@ namespace tcf {
 
             std::string enclaveError;
         };  // class Enclave
-
-        static void* Worker(void* arg);
-
     }  /* namespace enclave_api */
-
 }  // namespace tcf
 
 


### PR DESCRIPTION
`tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/enclave.h`
- Remove unused static function `Worker()`

Signed-off-by: danintel <daniel.anderson@intel.com>