### PR TITLE
PREREQUISITES.md: Set SGX_MODE for Building Intel SGX OpenSSL

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -136,7 +136,8 @@ The steps below will set up a Python virtual environment to run Avalon.
    cd $TCF_HOME/tools/build
    # Create virtual environment directory with name _dev
    python3 -m venv _dev
-   sudo make clean
+   make clean
+   pip3 install wheel
    make
    ```
 

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -89,7 +89,7 @@ sudo apt-get install -y python3-venv
 
 Also, install the following pip3 packages:
 ```bash
-pip3 install --upgrade setuptools json-rpc py-solc web3 wheel
+pip3 install --upgrade setuptools json-rpc py-solc web3 colorlog twisted wheel
 ```
 
 # <a name="docker"></a>Docker
@@ -374,6 +374,7 @@ problems.
   Environment variable `SGX_MODE` must be set to `SIM` or `HW` .
   ```bash
   cd Linux
+  export SGX_MODE=${SGX_MODE:-SIM}
   make DESTDIR=/opt/intel/sgxssl all test
   sudo make install
   cd ../../..


### PR DESCRIPTION
`PREREQUISITES.md`
OpenSSL for Intel SGX (SGXSSL) does not default `$SGX_MODE`,
so it must be set explicitly when building SGXSSL.

Problem reported by a user.

Add twisted and colorlog to `pip3 install``

`BUILD.md`
Do not run `pip3 install` as root.
`pip3 install wheel` required after `make clean` because `make clean`
uninstalls wheel.

Signed-off-by: danintel <daniel.anderson@intel.com>