### PR TITLE
BUILD.md: Fix `make clean` Build Instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -136,7 +136,8 @@ The steps below will set up a Python virtual environment to run Avalon.
    cd $TCF_HOME/tools/build
    # Create virtual environment directory with name _dev
    python3 -m venv _dev
-   sudo make clean
+   make clean
+   pip3 install wheel
    make
    ```
 


### PR DESCRIPTION
- `make clean` must run without `sudo` because it runs `pip3 uninstall`
  which must be run as non-root
- `pip3 install wheel` is required after `make clean` or build fails with
   `error: invalid command bdist_wheel`

Signed-off-by: danintel <daniel.anderson@intel.com>