### PR TITLE
PREREQUISITES.md: Fix ModuleNotFoundError with twisted and colorlog

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -89,7 +89,7 @@ sudo apt-get install -y python3-venv
 
 Also, install the following pip3 packages:
 ```bash
-pip3 install --upgrade setuptools json-rpc py-solc web3 wheel
+pip3 install --upgrade setuptools json-rpc py-solc web3 colorlog twisted wheel
 ```
 
 # <a name="docker"></a>Docker


### PR DESCRIPTION
Currently, the following errors occur running `./tcs_startup.sh`
after a standalone build:

`ModuleNotFoundError: No module named 'twisted'`
`ModuleNotFoundError: No module named 'colorlog'`

The solution is to run this:

`pip3 install twisted colorlog`

This is despite the fact apt packages `python3-colorlog` and
`python3-twisted` are installed.

The solution was hinted at with
https://stackoverflow.com/questions/47846084/no-module-named-twisted

Signed-off-by: danintel <daniel.anderson@intel.com>