### PR TITLE
Fix Docker Examples

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -203,24 +203,32 @@ Follow these steps to run the `Demo.py` testcase:
    6. To run the Demo test case, open a new terminal, Terminal 2
    7. In Terminal 2, run `source $TCF_HOME/tools/build/_dev/bin/activate`.
       You should see the `(_dev)` prompt
+   8. In Terminal 2, cd to `$TCF_HOME/tests` and
+      type this command to run the `Demo.py` test:
+      ```bash
+      cd $TCF_HOME/tests
+      python3 Demo.py --input_dir ./json_requests/ \
+         --connect_uri "http://localhost:1947" work_orders/output.json
+      ```
 2. For Docker-based builds:
    1. Follow the steps above for
       ["Docker-based Build and Execution"](#dockerbuild)
    2. Terminal 1 is running `docker-compose` and Terminal 2 is running the
       "tcf" Docker container shell from the previous build steps
-3. In Terminal 2, run `cd $TCF_HOME/tests`
-4. In Terminal 2, use this command to run the `Demo.py` test:
-   ```bash
-   python3 Demo.py --input_dir ./json_requests/ \
-           --connect_uri "http://localhost:1947" work_orders/output.json
-   ```
-5. The response to the Avalon listener and Intel&reg; SGX enclave Manager can be
-   seen at Terminal 1
-6. The response to the test case request can be seen at Terminal 2
-7. If you wish to exit the Avalon program, press `y` and `Enter` at Terminal 1
+   3. In Terminal 2, cd to `$TCF_HOME/tests` and
+      type this command to run the `Demo.py` test:
+      ```bash
+      cd $TCF_HOME/tests
+      python3 Demo.py --input_dir ./json_requests/ \
+         --connect_uri "http://avalon-listener:1947" work_orders/output.json
+      ```
+3. The response to the Avalon listener and Intel&reg; SGX enclave Manager
+   can be seen at Terminal 1
+4. The response to the test case request can be seen at Terminal 2
+5. If you wish to exit the Avalon program, press `y` and `Enter` at Terminal 1
    for standalone builds.
    For Docker-based builds, press `Ctrl-c`
-8. For standalone mode, delete virtual environment
+6. For standalone mode, delete virtual environment
    ```bash
    rm -rf $TCF_HOME/tools/build/_dev/
    ```

--- a/examples/apps/generic_client/README.md
+++ b/examples/apps/generic_client/README.md
@@ -48,6 +48,8 @@ If `--uri` is passed, `--mode` is not used. It will fetch the worker details
 from the LMDB database and submit work order to the first available worker.
 The Avalon Listener uses TCP port 1947, so the default URI is
 `http://localhost:1947` .
+If you are using Docker, add `--uri "http://avalon-listener:1947"`
+to the command line.
 
 ## Using the Generic Client
 
@@ -73,14 +75,29 @@ worker requests on the command line.
 ./generic_client.py --uri "http://localhost:1947" \
     --workload_id "echo-result" --in_data "Hello"
 ```
-Or omit the URI if you use the default:
+
+Add or change the `--uri` parameter if using Docker:
+```bash
+./generic_client.py --uri "http://avalon-listener:1947" \
+    --workload_id "echo-result" --in_data "Hello"
+```
+
+Or omit the URI if you use the default URI (standalone mode) :
 ```bash
 ./generic_client.py --workload_id "echo-result" --in_data "Hello"
 ```
 
 ### Heart disease eval workload using a URI
+Standalone mode (no Docker):
 ```bash
 ./generic_client.py --uri "http://localhost:1947" \
+    --workload_id "heart-disease-eval" \
+    --in_data "Data: 25 10 1 67  102 125 1 95 5 10 1 11 36 1"
+```
+
+With Docker:
+```bash
+./generic_client.py --uri "http://avalon-listener:1947" \
     --workload_id "heart-disease-eval" \
     --in_data "Data: 25 10 1 67  102 125 1 95 5 10 1 11 36 1"
 ```


### PR DESCRIPTION
Docker examples are missing or incorrect in
- `BUILD.md`
- `examples/apps/generic_client/README.md`

The examples need to use the URL `http://avalon-listner:1947`
instead of `http://localhost:1947` for Docker.

Reported by someone trying out examples.

Signed-off-by: danintel <daniel.anderson@intel.com>