### PR TITLE
Dockerfile optimizations wrt to openssl

### DIFF
--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-
 # Description:
 #   Builds the environment needed to build Trusted Compute Framework.
 #
@@ -32,11 +31,41 @@
 #   make clean && make
 
 
+# -------------=== Build openssl_image ===-------------
+
+#Build openssl intermediate docker image
+FROM ubuntu:bionic as openssl_image
+
+RUN apt-get update \
+ && apt-get install -y -q \
+    ca-certificates \
+    pkg-config \
+    make \
+    wget \
+    tar \
+ && apt-get -y -q upgrade \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+# Build ("Untrusted") OpenSSL
+RUN OPENSSL_VER=1.1.1d \
+ && wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz \
+ && tar -zxf openssl-$OPENSSL_VER.tar.gz \
+ && cd openssl-$OPENSSL_VER/ \
+ && ./config \
+ && THREADS=8 \
+ && make -j$THREADS \
+ && make test
+
+
+# -------------=== build avalon image ===-------------
+#Build docker image
 FROM ubuntu:bionic
 
 # Ignore timezone prompt in apt
 ENV DEBIAN_FRONTEND=noninteractive
-
 # Add necessary packages
 RUN apt-get update \
  && apt-get install -y -q \
@@ -75,7 +104,6 @@ RUN apt-get update \
  && apt-get -y -q upgrade \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
 # Install setuptools,py-solc-x and web3 packages using pip because
 # these are not available in apt repository.
 # Install nose2 for running tests.
@@ -87,21 +115,17 @@ RUN python3 -m solcx.install v0.5.15
 RUN add-apt-repository ppa:ethereum/ethereum \
    && apt-get update \
    && apt-get install solc
-
 # Make Python3 default
 RUN ln -sf /usr/bin/python3 /usr/bin/python
-
 # SGX common library and SDK are installed in /opt/intel directory.
 # Installation of SGX libsgx-common packages requires /etc/init directory. In docker image this directory doesn't exist.
 # Hence creating /etc/init directory.
 RUN mkdir -p /opt/intel \
  && mkdir -p /etc/init
 WORKDIR /opt/intel
-
 # Install SGX common library
 RUN wget https://download.01.org/intel-sgx/sgx-linux/2.7.1/distro/ubuntu18.04-server/libsgx-enclave-common_2.7.101.3-bionic1_amd64.deb \
  && dpkg -i libsgx-enclave-common_2.7.101.3-bionic1_amd64.deb
-
 # Install SGX SDK
 RUN SGX_SDK_FILE=sgx_linux_x64_sdk_2.7.101.3.bin \
  && wget https://download.01.org/intel-sgx/sgx-linux/2.7.1/distro/ubuntu18.04-server/$SGX_SDK_FILE \
@@ -111,22 +135,20 @@ RUN SGX_SDK_FILE=sgx_linux_x64_sdk_2.7.101.3.bin \
 
 
 WORKDIR /tmp
+ENV OPENSSL_VER=1.1.1d
+COPY --from=openssl_image /tmp/openssl-$OPENSSL_VER /tmp/openssl-$OPENSSL_VER/
+COPY --from=openssl_image /tmp/openssl-$OPENSSL_VER.tar.gz /tmp/
 # Build ("Untrusted") OpenSSL, then build ("trusted") SGX OpenSSL
 # Note: The latter will compile in HW or SIM mode depending on the
 # availability of /dev/isgx and /var/run/aesmd/aesm.socket
-RUN OPENSSL_VER=1.1.1d \
- && wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz \
- && tar -zxf openssl-$OPENSSL_VER.tar.gz \
- && cd openssl-$OPENSSL_VER/ \
- && ./config \
+
+RUN cd openssl-$OPENSSL_VER/ \
  && THREADS=8 \
- && make -j$THREADS \
- && make test \
  && make install -j$THREADS \
  && ldconfig \
  && ln -s /etc/ssl/certs/* /usr/local/ssl/certs/ \
  && cd .. \
- && rm -rf openssl-$OPENSSL_VER \
+ && rm -rf openssl-$OPENSSL_VER/ \
  && git clone https://github.com/intel/intel-sgx-ssl.git  \
  && . /opt/intel/sgxsdk/environment \
  && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-$OPENSSL_VER.tar.gz . ) \
@@ -138,15 +160,12 @@ RUN OPENSSL_VER=1.1.1d \
  && (cd intel-sgx-ssl/Linux; make install ) \
  && rm -rf /tmp/intel-sgx-ssl \
  && echo "SGX_SSL=/opt/intel/sgxssl" >> /etc/environment
-
 COPY . /project/TrustedComputeFramework
-
 ARG SGX_MODE
 ARG MAKECLEAN
 ARG TCF_DEBUG_BUILD
 ARG DISPLAY
 ARG XAUTHORITY
-
 #TODO need to be removed later
 #install avalon-client sdk python package.
 RUN cd /project/TrustedComputeFramework/sdk \
@@ -182,7 +201,6 @@ RUN echo "TCF_HOME=/project/TrustedComputeFramework/" >> /etc/environment \
         echo "HTTPS_PROXY=$(echo $https_proxy | sed 's,[a-zA-Z]*://,,')" \
              >> /etc/environment; \
     fi
-
 ENV http_proxy=$http_proxy
 ENV https_proxy=$https_proxy
 ENV TCF_HOME=/project/TrustedComputeFramework
@@ -195,9 +213,8 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SGX_SDK/sdk_libs
 ENV DISPLAY=:0
 
 WORKDIR /project/TrustedComputeFramework/tools/build
-
 RUN make lint && echo "LINT SUCCESS"
-
 RUN if [ "$MAKECLEAN" != 0 ]; then echo "Clean build" && make clean; fi \
  && make \
  && echo "BUILD SUCCESS"
+

--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -36,25 +36,22 @@ RUN apt-get update \
 # Make Python3 default
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
-#Build Avalon Listener intermediate docker image
-FROM base_image as build_image
+
+# -------------=== openssl build ===-------------
+
+#Build openssl intermediate docker image
+FROM ubuntu:bionic as openssl_image
 
 RUN apt-get update \
  && apt-get install -y -q \
-    cmake \
+    ca-certificates \
+    pkg-config \
     make \
-    libprotobuf-dev \
-    python3-dev \
-    python3-pip \
-    swig \
-    software-properties-common \
     wget \
-    tar
-
-
-# Install setuptools packages using pip because
-# these are not available in apt repository.
-RUN pip3 install --upgrade setuptools json-rpc
+    tar \
+ && apt-get -y -q upgrade \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
 
@@ -66,12 +63,38 @@ RUN OPENSSL_VER=1.1.1d \
  && ./config \
  && THREADS=8 \
  && make -j$THREADS \
- && make test \
+ && make test
+
+
+# -------------=== build_image ===-------------
+#Build Avalon Listener intermediate docker image
+FROM base_image as build_image
+
+RUN apt-get update \
+ && apt-get install -y -q \
+    cmake \
+    make \
+    libprotobuf-dev \
+    python3-dev \
+    python3-pip \
+    swig \
+    software-properties-common
+
+ENV OPENSSL_VER=1.1.1d
+RUN THREADS=8
+COPY --from=openssl_image /tmp/openssl-$OPENSSL_VER /tmp/openssl-$OPENSSL_VER/
+WORKDIR /tmp
+RUN cd openssl-$OPENSSL_VER/ \
  && make install -j$THREADS \
  && ldconfig \
  && ln -s /etc/ssl/certs/* /usr/local/ssl/certs/ \
  && cd .. \
- && rm -rf openssl-$OPENSSL_VER
+ && rm -rf openssl-$OPENSSL_VER/
+
+
+# Install setuptools packages using pip because
+# these are not available in apt repository.
+RUN pip3 install --upgrade setuptools json-rpc
 
 ENV TCF_HOME=/project/avalon
 
@@ -93,7 +116,7 @@ RUN mkdir -p build \
 WORKDIR /project/avalon/common/python
 
 RUN echo "Building Avalon Common Python\n" \
- && make \ 
+ && make \
  && echo "Installing Avalon Common Python" \
  && make install
 
@@ -109,9 +132,12 @@ RUN echo "Building Avalon SDK\n" \
 WORKDIR /project/avalon/listener/
 
 RUN echo "Building avalon listener\n" \
-  && make \
-  && echo "Installing Avalon Listener" \
-  && make install
+ && make \
+ && echo "Installing Avalon Listener" \
+ && make install
+
+
+# -------------=== final_image ===-------------
 
 # Build final image and install modules
 FROM base_image as final_image


### PR DESCRIPTION
Openssl is being installed and used by various Avalon components.
Installing openssl and compiling takes lot of time. This PR
addresses to create a openssl docker image which is cached in
the system and is being used by other components. This way, other
components don't have to redo the openssl fetch and compilation.

Signed-off-by: pankajgoyal2 <pankaj.goyal@intel.com>