### PR TITLE
Fix Regression in `tcs_startup.sh` Removing `check_avalon_components`

### DIFF
--- a/scripts/tcs_startup.sh
+++ b/scripts/tcs_startup.sh
@@ -45,6 +45,7 @@ start_avalon_components()
     echo "Avalon Enclave Manager started"
 
     sleep 5s
+    check_avalon_components
 
     if [ "$YES" != "1" ] ; then
         while true; do


### PR DESCRIPTION
A recent integration removed the call to `check_avalon_components`.
This fixes this regression by restoring the call added in PR #238.

The regression removing the call was made with PR #229 and commit
1ad463ae780dd35969f0dc0678aa7644ffb11b9e.

Signed-off-by: danintel <daniel.anderson@intel.com>