### PR TITLE
Fix `make clean` Failure When Wheel Package is Not Installed

### DIFF
--- a/common/python/Makefile
+++ b/common/python/Makefile
@@ -32,14 +32,14 @@ build_ext :
 
 build :
 	mkdir $@
-	cd $@ 
+	cd $@
 
 install:
 	@echo INSTALLING WHEEL FILE =================
 	pip3 install $(WHEEL_FILE)
 
 clean:
-	pip3 uninstall --yes $(WHEEL_FILE)
+	if [[ -f $(WHEEL_FILE) ]] ; then pip3 uninstall --yes $(WHEEL_FILE); fi
 	rm -rf build deps dist *.egg-info
 	rm -f crypto/crypto.py crypto/crypto_wrap.cpp
 	rm -f verify_report/verify_report.py verify_report/verify_report_wrap.cpp

--- a/examples/enclave_manager/Makefile
+++ b/examples/enclave_manager/Makefile
@@ -38,7 +38,7 @@ install:
 	pip3 install $(WHEEL_FILE)
 
 clean:
-	pip3 uninstall --yes $(WHEEL_FILE)
+	if [[ -f $(WHEEL_FILE) ]] ; then pip3 uninstall --yes $(WHEEL_FILE); fi
 	rm -f tcf_enclave_manager/tcf_enclave.py tcf_enclave_manager/tcf_enclave_wrap.cpp
 	rm -rf build deps dist *.egg-info
 	find . -iname '*.pyc' -delete


### PR DESCRIPTION
Running `make clean` in `tools/build/` fails when the pip3 wheel package
is not installed with this failure:

```
pip3 uninstall --yes dist/avalon_common-0.5.0.dev1-cp36-cp36m-linux_x86_64.whl
Requirement 'dist/avalon_common-0.5.0.dev1-cp36-cp36m-linux_x86_64.whl' looks like a filename, but the file does not exist
Cannot uninstall requirement avalon-common, not installed
Makefile:42: recipe for target 'clean' failed
```

The fix is to run `pip uninstall` only if the wheel package exists.

Signed-off-by: danintel <daniel.anderson@intel.com>