### PR TITLE
Dockerfile optimizations wrt to openssl

### DIFF
--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -32,6 +32,37 @@
 #   make clean && make
 
 
+# -------------=== Build openssl_image ===-------------
+
+#Build openssl intermediate docker image
+FROM ubuntu:bionic as openssl_image
+
+RUN apt-get update \
+ && apt-get install -y -q \
+    ca-certificates \
+    pkg-config \
+    make \
+    wget \
+    tar \
+ && apt-get -y -q upgrade \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+# Build ("Untrusted") OpenSSL
+RUN OPENSSL_VER=1.1.1d \
+ && wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz \
+ && tar -zxf openssl-$OPENSSL_VER.tar.gz \
+ && cd openssl-$OPENSSL_VER/ \
+ && ./config \
+ && THREADS=8 \
+ && make -j$THREADS \
+ && make test \
+ && make install -j$THREADS
+
+# -------------=== build avalon image ===-------------
+#Build docker image
 FROM ubuntu:bionic
 
 # Ignore timezone prompt in apt
@@ -109,24 +140,19 @@ RUN SGX_SDK_FILE=sgx_linux_x64_sdk_2.7.101.3.bin \
  && rm $SGX_SDK_FILE \
  && echo ". /opt/intel/sgxsdk/environment" >> /etc/environment
 
+# Copy openssl build artifacts from openssl_image
+ENV OPENSSL_VER=1.1.1d
+COPY --from=openssl_image /usr/local/ssl /usr/local/ssl
+COPY --from=openssl_image /usr/local/bin /usr/local/bin
+COPY --from=openssl_image /usr/local/include /usr/local/include
+COPY --from=openssl_image /usr/local/lib /usr/local/lib
+COPY --from=openssl_image /tmp/openssl-$OPENSSL_VER.tar.gz /tmp/
 
-WORKDIR /tmp
-# Build ("Untrusted") OpenSSL, then build ("trusted") SGX OpenSSL
-# Note: The latter will compile in HW or SIM mode depending on the
+# Build ("trusted") SGX OpenSSL
+# Note: This will compile in HW or SIM mode depending on the
 # availability of /dev/isgx and /var/run/aesmd/aesm.socket
-RUN OPENSSL_VER=1.1.1d \
- && wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz \
- && tar -zxf openssl-$OPENSSL_VER.tar.gz \
- && cd openssl-$OPENSSL_VER/ \
- && ./config \
- && THREADS=8 \
- && make -j$THREADS \
- && make test \
- && make install -j$THREADS \
- && ldconfig \
+RUN ldconfig \
  && ln -s /etc/ssl/certs/* /usr/local/ssl/certs/ \
- && cd .. \
- && rm -rf openssl-$OPENSSL_VER \
  && git clone https://github.com/intel/intel-sgx-ssl.git  \
  && . /opt/intel/sgxsdk/environment \
  && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-$OPENSSL_VER.tar.gz . ) \

--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -36,25 +36,22 @@ RUN apt-get update \
 # Make Python3 default
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
-#Build Avalon Listener intermediate docker image
-FROM base_image as build_image
+
+# -------------=== openssl build ===-------------
+
+#Build openssl intermediate docker image
+FROM ubuntu:bionic as openssl_image
 
 RUN apt-get update \
  && apt-get install -y -q \
-    cmake \
+    ca-certificates \
+    pkg-config \
     make \
-    libprotobuf-dev \
-    python3-dev \
-    python3-pip \
-    swig \
-    software-properties-common \
     wget \
-    tar
-
-
-# Install setuptools packages using pip because
-# these are not available in apt repository.
-RUN pip3 install --upgrade setuptools json-rpc
+    tar \
+ && apt-get -y -q upgrade \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
 
@@ -67,11 +64,34 @@ RUN OPENSSL_VER=1.1.1d \
  && THREADS=8 \
  && make -j$THREADS \
  && make test \
- && make install -j$THREADS \
- && ldconfig \
- && ln -s /etc/ssl/certs/* /usr/local/ssl/certs/ \
- && cd .. \
- && rm -rf openssl-$OPENSSL_VER
+ && make install -j$THREADS
+
+#Build Avalon Listener intermediate docker image
+FROM base_image as build_image
+
+RUN apt-get update \
+ && apt-get install -y -q \
+    cmake \
+    make \
+    libprotobuf-dev \
+    python3-dev \
+    python3-pip \
+    swig \
+    software-properties-common
+
+
+# Copy openssl build artifacts from openssl_image
+COPY --from=openssl_image /usr/local/ssl /usr/local/ssl
+COPY --from=openssl_image /usr/local/bin /usr/local/bin
+COPY --from=openssl_image /usr/local/include /usr/local/include
+COPY --from=openssl_image /usr/local/lib /usr/local/lib
+
+RUN ldconfig \
+ && ln -s /etc/ssl/certs/* /usr/local/ssl/certs/
+
+# Install setuptools packages using pip because
+# these are not available in apt repository.
+RUN pip3 install --upgrade setuptools json-rpc
 
 ENV TCF_HOME=/project/avalon
 


### PR DESCRIPTION
Openssl is being installed and used by various Avalon components.
Installing openssl and compiling takes lot of time. This PR
addresses to create a openssl docker image which is cached in
the system and is being used by other components. This way, other
components don't have to redo the openssl fetch and compilation.

Signed-off-by: pankajgoyal2 <pankaj.goyal@intel.com>