### PR TITLE
Update Besu based Avalon setup

### DIFF
--- a/docs/BesuProxyModel.md
+++ b/docs/BesuProxyModel.md
@@ -6,7 +6,9 @@
     ```
     This requires Requires ``NodeJS v8.9.4 or later`` preinstalled.
 
-2.  Set the environment variable ``TCF_HOME`` to the Avalon root directory
+2.  Set the environment variable ``TCF_HOME`` to the Avalon root directory. Update ``no_proxy`` environment variable if you are behind a proxy
+    server. Add these private IP - ``172.13.0.2, 172.13.0.3, 172.13.0.4, 172.13.0.5``. These are the IP addresses used in the default Besu 
+    network defined in the corresponding [docker-compose file](dev-environments/besu/docker-compose.yaml)
 
 3.  Start the Ethereum network with 2 nodes and 2 eth-signers. To bring up the network, do the following
        ```
@@ -26,7 +28,7 @@
         truffle migrate --network avalon
         ```
 5. The ``truffle migrate`` command would deploy contracts to the Ethereum network. If the command is successful, you should see something like 
-
+	```
 	2_deploy_contracts.js
 	=====================
 	
@@ -41,13 +43,12 @@
 	> balance:             1000000000
 	> gas used:            667475
 	> ...
+	```
    Only partial output is seen here. The actual output has more data.
 6. Update configuration fields in ``$TCF_HOME/sdk/avalon_sdk/tcf_connector.toml ``
 	- **proxy_worker_registry_contract_address** - Read the field ``contract address`` from Step 4 under ``Deploying 'WorkerRegistry'``
 	- **work_order_contract_address** - Read the field ``contract address`` from Step 4 under ``Deploying 'WorkerOrderRegistry'``
 	- **eth_account** - Read the field account from Step 4
-	- **provider** - Replace the placeholder IP(only IP and not the port) with the IP address of your host machine
-	- **event_provider** - Replace the placeholder IP with the IP address of your host machine
 
 7. Start the Avalon containers
 
@@ -65,4 +66,5 @@ use these steps
 cd $TCF_HOME/docs/dev-environments/besu
 docker-compose down
 ./cleanup.sh
+rm -f $TCF_HOME/blockchain_connector/bookmark $TCF_HOME/examples/apps/generic_client/bookmark
 ```

--- a/docs/dev-environments/besu/README.md
+++ b/docs/dev-environments/besu/README.md
@@ -13,7 +13,6 @@ To set up the local environment in order to run Avalon tests, you need the follo
 Pull down the docker images:
 
 ```
-cd local
 docker-compose pull
 ```
 

--- a/sdk/avalon_sdk/tcf_connector.toml
+++ b/sdk/avalon_sdk/tcf_connector.toml
@@ -56,12 +56,11 @@ acc_pvt_key = "4F611197A6E82715F4D2446FE015D1667E9C40A351411F3A7300F71F285D01B4"
 
 #Version of solc to be used for compiling Solidity contracts 
 solc_version = "v0.5.15"
-#Provider for test network. The default url is for a Hyperledger Besu client.
+#Provider/event_provider for test network. The default urls are for a Hyperledger Besu client. These
+#addresses need to be consistent with that in docs/dev-environments/besu/docker-compose.yaml.
 #This could be replaced with a Ropsten(Infura as the IAAS) provider or a Ganache client.
-#provider = "http://10.66.245.80:8545"
-provider = "http://10.223.155.81:22001"
-event_provider = "http://10.223.155.81:22011"
-#event_provider = "http://10.66.245.80:8545"
+provider = "http://172.13.0.3:8555"
+event_provider = "http://172.13.0.2:8545"
 #chain_id is 3 for ropsten test network
 #"1": Ethereum Mainnet
 #"2": Morden Testnet (deprecated)


### PR DESCRIPTION
Address minor syntactic issue impeding legibility in Besu setup document.
Update tcf_connector.toml for provider address. use Besu's private network address.

