### PR TITLE
Fix RSA crypro error for Besu

### DIFF
--- a/enclave_manager/avalon_enclave_manager/enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/enclave_manager.py
@@ -21,6 +21,7 @@ import os
 import sys
 import time
 import random
+import hashlib
 
 import avalon_enclave_manager.sgx_work_order_request as work_order_request
 import avalon_enclave_manager.avalon_enclave_helper as enclave_helper
@@ -93,11 +94,10 @@ class EnclaveManager:
         logger.info("Adding enclave workers to workers table")
         worker_id = crypto_utils.strip_begin_end_public_key(self.enclave_id) \
             .encode("UTF-8")
-        # Truncate worker id to 32 bytes since TC spec proxy model
-        # contracts expect byte32
-        worker_id = worker_id[:32]
-        # convert worderid to hex string
-        worker_id = worker_id.hex()
+        # Calculate sha256 of worker id to get 32 bytes. The TC spec proxy
+        # model contracts expect byte32. Then take a hexdigest for hex str.
+        worker_id = hashlib.sha256(worker_id).hexdigest()
+
         kv_helper.set("workers", worker_id, worker_info)
 
         # Cleanup wo-processing" table

--- a/sdk/avalon_sdk/ethereum/ethereum_work_order.py
+++ b/sdk/avalon_sdk/ethereum/ethereum_work_order.py
@@ -99,22 +99,11 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
             An error code, 0 - success, otherwise an error.
         """
         if (self.__contract_instance is not None):
-            if not is_valid_hex_str(work_order_id):
-                logging.error("Invalid work order id {}".format(work_order_id))
-                return ERROR
-
-            if not is_valid_hex_str(worker_id):
-                logging.error("Invalid worker id {}".format(worker_id))
-                return ERROR
-
-            if not is_valid_hex_str(requester_id):
-                logging.error("Invalid requester id {}".format(requester_id))
-                return ERROR
 
             if not _is_valid_work_order_json(work_order_id, worker_id,
                                              requester_id, work_order_request):
-                logging.error("Invalid request string {}"
-                              .format(work_order_request))
+                logging.error("Invalid request string {}"\
+                    .format(work_order_request))
                 return ERROR
 
             txn_dict = self.__contract_instance.functions.workOrderSubmit(
@@ -127,12 +116,12 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
                 return SUCCESS
             except Exception as e:
                 logging.error(
-                    "exception occured when trying to execute workOrderSubmit \
-                     transaction on chain"+str(e))
+                    "Exception occured when trying to execute workOrderSubmit "
+                    + "transaction on chain"+str(e))
                 return ERROR
         else:
             logging.error(
-                "work order contract instance is not initialized")
+                "Work order contract instance is not initialized")
             return ERROR
 
     def work_order_complete(self, work_order_id, work_order_response):
@@ -147,9 +136,7 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
             An error code, 0 - success, otherwise an error.
         """
         if (self.__contract_instance is not None):
-            if not is_valid_hex_str(work_order_id):
-                logging.error("Invalid work order id {}".format(work_order_id))
-                return ERROR
+
             txn_dict = self.__contract_instance.functions.workOrderComplete(
                 work_order_id, work_order_response).buildTransaction(
                     self.__eth_client.get_transaction_params()
@@ -157,14 +144,14 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
             try:
                 txn_receipt = self.__eth_client.execute_transaction(txn_dict)
                 return SUCCESS
-            except Execption as e:
+            except Exception as e:
                 logging.error(
-                    "execption occured when trying to execute \
-                     workOrderComplete transaction on chain"+str(e))
+                    "Execption occured when trying to execute "
+                    + "workOrderComplete transaction on chain"+str(e))
                 return ERROR
         else:
             logging.error(
-                "work order contract instance is not initialized")
+                "Work order contract instance is not initialized")
             return ERROR
 
     def start_work_order_completed_event_handler(self, evt_handler,

--- a/sdk/avalon_sdk/ethereum/ethereum_worker_registry.py
+++ b/sdk/avalon_sdk/ethereum/ethereum_worker_registry.py
@@ -186,30 +186,10 @@ class EthereumWorkerRegistryImpl(WorkerRegistry):
         """
 
         if (self.__contract_instance is not None):
-            if not is_valid_hex_str(worker_id):
-                logging.error("Invalid worker id {}".format(worker_id))
-                return None
-            if not isinstance(worker_type, WorkerType):
-                logging.error("Invalid workerType {}".format(worker_type))
-                return None
-            if not is_valid_hex_str(organization_id):
-                logging.error("Invalid organization id {}"
-                              .format(organization_id))
-                return None
-            for app_id in application_type_ids:
-                if not is_valid_hex_str(app_id):
-                    logging.error("Invalid application id {}".format(app_id))
-                    return None
-            if details is not None:
-                worker = WorkerDetails()
-                is_valid = worker.validate_worker_details(details)
-                if is_valid is not None:
-                    logging.error(
-                        "Worker details not valid : {}".format(is_valid))
-                    return None
 
             txn_dict = self.__contract_instance.functions.workerRegister(
-                worker_type, organization_id, application_type_ids, details)\
+                worker_id, worker_type, organization_id,
+                application_type_ids, details)\
                 .buildTransaction(
                 self.__eth_client.get_transaction_params())
             txn_receipt = self.__eth_client.execute_transaction(
@@ -230,13 +210,6 @@ class EthereumWorkerRegistryImpl(WorkerRegistry):
         """
 
         if (self.__contract_instance is not None):
-            if details is not None:
-                worker = WorkerDetails()
-                is_valid = worker.validate_worker_details(details)
-                if is_valid is not None:
-                    logging.error(
-                        "Worker details not valid : {}".format(is_valid))
-                    return None
 
             txn_dict = self.__contract_instance.functions.workerUpdate(
                 worker_id, details)\

--- a/sdk/avalon_sdk/ethereum/ethereum_wrapper.py
+++ b/sdk/avalon_sdk/ethereum/ethereum_wrapper.py
@@ -62,8 +62,8 @@ class EthereumWrapper():
             # Amount of Ether you’re willing to pay for every unit of gas
             self.__gas_price = config["ethereum"]["gas_price"]
             set_solc_version(config['ethereum']['solc_version'])
-            logging.info("Solidity compiler version being used : {}"
-                         .format(get_solc_version()))
+            logging.debug("Solidity compiler version being used : {}"
+                          .format(get_solc_version()))
         else:
             raise Exception("Invalid configuration parameter")
 

--- a/sdk/avalon_sdk/ethereum/ethereum_wrapper.py
+++ b/sdk/avalon_sdk/ethereum/ethereum_wrapper.py
@@ -158,7 +158,7 @@ class EthereumWrapper():
         tx_hash = self.__w3.eth.sendRawTransaction(signed_tx.rawTransaction)
         tx_receipt = self.__w3.eth.waitForTransactionReceipt(
             tx_hash.hex(), 120)
-        logging.info("executed transaction hash: %s, receipt: %s",
+        logging.debug("Executed transaction hash: %s, receipt: %s",
                      format(tx_hash.hex()), format(tx_receipt))
         return tx_receipt
 
@@ -170,7 +170,7 @@ class EthereumWrapper():
         """
         tx_hash = self.__w3.eth.sendTransaction(tx_dict)
         tx_receipt = self.__w3.eth.waitForTransactionReceipt(tx_hash)
-        logging.info("executed transaction hash: %s, receipt: %s",
+        logging.debug("Executed transaction hash: %s, receipt: %s",
                      format(tx_hash.hex()), format(tx_receipt))
         return tx_receipt
 


### PR DESCRIPTION
Check Besu blockchain for worker before adding. If worker
already present, make a workerUpdate contract call.
Worker details were not being updated if the same network
of Besu was being used across restarts of Avalon. This caused
stale verification/encryption key to be used in consequent runs
after a worker is added to a fresh blockchain.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>