### PR TITLE
Fixing docker-compose-fabric.yaml

### DIFF
--- a/docker-compose-fabric.yaml
+++ b/docker-compose-fabric.yaml
@@ -127,7 +127,7 @@ services:
       - ~/mywork/vars/mychannel_network.json:/project/avalon/sdk/avalon_sdk/fabric/network.json
     depends_on:
       - avalon-listener
-      - tcf
+      - avalon-enclave-manager
 
 networks:
   default:


### PR DESCRIPTION
-> The avalon-blockchain-connector service in docker-compose-fabric.yaml
   should depend on "avalon-enclave-manager" instead of "tcf" which doesn't
   exit anymore. This PR address this issue.

Signed-off-by: pankajgoyal2 <pankaj.goyal@intel.com>