### PR TITLE
Fix enclave security issues

### DIFF
--- a/tc/sgx/trusted_worker_manager/enclave/enclave_data.h
+++ b/tc/sgx/trusted_worker_manager/enclave/enclave_data.h
@@ -70,6 +70,8 @@ public:
     EnclaveData(void);
     EnclaveData(const uint8_t* inSealedData);
 
+    ~EnclaveData(void);
+
     ByteArray encrypt_message(const ByteArray& message) const {
         return public_encryption_key_.EncryptMessage(message);
     }

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor.cpp
@@ -347,7 +347,7 @@ namespace tcf {
 
         tcf::crypto::sig::PublicKey public_signing_key_(verifying_key);
 
-        int SIG_result = public_signing_key_.VerifySignature(final_hash, Signature_byte);
+        size_t SIG_result = public_signing_key_.VerifySignature(final_hash, Signature_byte);
         if (SIG_result == 1) {
             Log(TCF_LOG_INFO, "Client Signature Verification Passed");
         } else if (SIG_result == 0) {
@@ -367,8 +367,8 @@ namespace tcf {
 
         std::string hash_1 = base64_encode(tcf::crypto::ComputeMessageHash(StrToByteArray(concat_string)));
 
-        int i = 0;
-        int out_data_size = data_items_out.size();
+        size_t i = 0;
+        size_t out_data_size = data_items_out.size();
 
         for (auto data : wo_data) {
             if (i < out_data_size) {
@@ -400,7 +400,7 @@ namespace tcf {
 
         ByteArray hash_2;
         std::string outhash = "";
-        for (int i = 0; i < data_items_out.size(); i++) {
+        for (size_t i = 0; i < data_items_out.size(); i++) {
             tcf::WorkOrderDataHandler& d = data_items_out.at(i);
             if (!d.concat_string.empty()) {
                 concat_hashes = StrToByteArray(d.concat_string);
@@ -469,8 +469,8 @@ namespace tcf {
                     "Signature verification of client request failed. Request is tampered.");
             }
             std::vector<tcf::WorkOrderData> wo_data = ExecuteWorkOrder();
-            int i = 0;
-            int out_data_size = data_items_out.size();
+            size_t i = 0;
+            size_t out_data_size = data_items_out.size();
             ByteArray hash = ResponseHashCalculate(wo_data);
             ComputeSignature(enclaveData, hash);
             return CreateJsonOutput();

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor.h
@@ -27,6 +27,11 @@ namespace tcf {
         class WorkOrderProcessor {
         public:
                 WorkOrderProcessor() {}
+                ~WorkOrderProcessor() {
+                    // Sanitize class members storing secrets
+                    worker_encryption_key.clear();
+                    session_key.clear();
+                }
                 ByteArray CreateErrorResponse(int err_code, const char* err_message);
                 ByteArray Process(EnclaveData& enclaveData, std::string json_str);
 


### PR DESCRIPTION
This commit address followin security concerns
- Sanitization of local variables on stack containing secrets
- Sanitization of local variables before reassigning them new values
- Signed type used for indexing or size are converted to unsigned
- Defined destructors to sanitize objects from heap memory

Signed-off-by: manju956 <manjunath.a.c@intel.com>