### PR TITLE
Fix errors running `make clean`

### DIFF
--- a/common/crypto_utils/Makefile
+++ b/common/crypto_utils/Makefile
@@ -38,7 +38,7 @@ install:
 	pip3 install $(WHEEL_FILE)
 
 clean:
-	if [[ -f $(WHEEL_FILE) ]] ; then pip3 uninstall --yes $(WHEEL_FILE); fi
+	if [ -f $(WHEEL_FILE) ] ; then pip3 uninstall --yes $(WHEEL_FILE); fi
 	rm -rf build deps dist *.egg-info
 	rm -f crypto/crypto.py crypto/crypto_wrap.cpp
 	rm -f verify_report/verify_report.py verify_report/verify_report_wrap.cpp

--- a/common/python/Makefile
+++ b/common/python/Makefile
@@ -34,7 +34,7 @@ install:
 	pip3 install $(WHEEL_FILE)
 
 clean:
-	if [[ -f $(WHEEL_FILE) ]] ; then pip3 uninstall --yes $(WHEEL_FILE); fi
+	if [ -f $(WHEEL_FILE) ] ; then pip3 uninstall --yes $(WHEEL_FILE); fi
 	rm -rf build deps dist *.egg-info
 	find . -iname '*.pyc' -delete
 	find . -iname '__pycache__' -delete

--- a/enclave_manager/Makefile
+++ b/enclave_manager/Makefile
@@ -38,7 +38,7 @@ install:
 	pip3 install $(WHEEL_FILE)
 
 clean:
-	if [[ -f $(WHEEL_FILE) ]] ; then pip3 uninstall --yes $(WHEEL_FILE); fi
+	if [ -f $(WHEEL_FILE) ] ; then pip3 uninstall --yes $(WHEEL_FILE); fi
 	rm -f avalon_enclave_manager/avalon_enclave.py avalon_enclave_manager/avalon_enclave_wrap.cpp
 	rm -rf build deps dist *.egg-info
 	find . -iname '*.pyc' -delete

--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -37,8 +37,8 @@ rm -f $SRCDIR/config/Kv_Shared*
 cd $SRCDIR/common/python
 make clean
 
-# --------------- EXAMPLES ENCLAVE MANAGER ---------------
-cd $SRCDIR/examples/enclave_manager
+# --------------- ENCLAVE MANAGER ---------------
+cd $SRCDIR/enclave_manager
 SGX_MODE=${SGX_MODE:-SIM} make clean
 
 # --------------- COMMON SGX WORKLOAD ---------------


### PR DESCRIPTION
Fix these errors running `make clean` from `$TCF_HOME/tools/build`:
- `/bin/sh: 1: [[: not found`
  Fix is to use `[` instead of `[[`
- `make[1]: *** No rule to make target 'clean'.  Stop.`
  Fix is to use `$SRCDIR/enclave_manager` instead of
  `$SRCDIR/examples/enclave_manager`

Signed-off-by: danintel <daniel.anderson@intel.com>