### PR TITLE
Fix SGX HW mode

### DIFF
--- a/common/python/Makefile
+++ b/common/python/Makefile
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/' | tr -d .}
+# Get python version
+PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/' | cut -b 1}
 MOD_VERSION=${shell ../../bin/get_version}
 
 # Format of wheel package is <pkg_name>-{python-tag}-{abi-tag}-{platform}
-WHEEL_FILE=dist/avalon_common-${MOD_VERSION}-none-any.whl
+WHEEL_FILE=dist/avalon_common-${MOD_VERSION}-py${PY_VERSION}-none-any.whl
 SOURCE_DIR=$(shell pwd)
 
 

--- a/docker-compose-sgx.yaml
+++ b/docker-compose-sgx.yaml
@@ -39,12 +39,12 @@ services:
     entrypoint: bash -c "tail -f /dev/null"
     stop_signal: SIGKILL
     depends_on:
-      - avalon-enclave-manager
+      - avalon-sgx-enclave-manager
       - avalon-listener
 
-  avalon-enclave-manager:
-    container_name: avalon-enclave-manager
-    image: avalon-enclave-manager-dev
+  avalon-sgx-enclave-manager:
+    container_name: avalon-sgx-enclave-manager
+    image: avalon-sgx-enclave-manager-dev
     build:
       context: .
       dockerfile: ./enclave_manager/Dockerfile

--- a/enclave_manager/Dockerfile
+++ b/enclave_manager/Dockerfile
@@ -218,51 +218,26 @@ RUN mkdir -p build \
 
 WORKDIR /project/avalon/common/python
 
-RUN make
+RUN make && make install
 
 WORKDIR /project/avalon/common/crypto_utils
 
-RUN make
+RUN make && make install
 
 WORKDIR /project/avalon/sdk
 
-RUN make
+RUN make && make install
 
 WORKDIR /project/avalon/enclave_manager
 
-RUN echo "Building avalon enclave manager" \
-  && make
+RUN echo "Build and Install avalon enclave manager" \
+  && make && make install
 
-# Build Final image and install dependent modules
-FROM base_image as final_image
+FROM build_image as final_image
 
-ENV TCF_HOME=/project/avalon
-
-WORKDIR /project/avalon/
-
-COPY --from=build_image /project/avalon/config/tcs_config.toml /project/avalon/config/
-COPY --from=build_image /project/avalon/tc/sgx/trusted_worker_manager/enclave/build/lib/*.so /project/avalon/tc/sgx/trusted_worker_manager/enclave/build/lib/
-COPY --from=build_image /project/avalon/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/build/lib/*.so /project/avalon/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/build/lib/
-# Copy sgxsdk, sgxssl to final image.
-COPY --from=build_image /opt/intel/sgxsdk/bin/ /opt/intel/sgxsdk/bin
-COPY --from=build_image /opt/intel/sgxsdk/lib64/ /opt/intel/sgxsdk/lib64
-COPY --from=build_image /opt/intel/sgxssl/lib64/ /opt/intel/sgxssl/lib64
-
-# Copy Python build artifacts
-COPY --from=build_image /project/avalon/common/python/dist/*.whl dist/
-COPY --from=build_image /project/avalon/common/crypto_utils/dist/*.whl dist/
-COPY --from=build_image /project/avalon/sdk/dist/*.whl dist/
-COPY --from=build_image /project/avalon/enclave_manager/dist/*.whl dist/
-
-
-# Installing wheel file requires python3-pip package.
-# But python3-pip package will increase size of final docker image.
-# So remove python3-pip package and dependencies after installing wheel file.
-RUN apt-get update \
- && apt-get install -y -q python3-pip \
- && echo "Install Common Python, SDK and Enclave Manager packages\n" \
- && pip3 install dist/*.whl \
- && echo "Remove unused packages from image\n" \
+# python3-pip package will increase size of final docker image.
+# So remove python3-pip package and dependencies
+RUN echo "Remove unused packages from image\n" \
  && apt-get autoremove --purge -y -q python3-pip \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Avalon workflow is broken in SGX HW mode.
Following SGX error is observed during enclave initialization.
failed to initialize enclave; Failed to get SGX quote size.: UNKNOWN SGX ERROR:<error_value>

This issue is observed since changes to containerizing enclave manager was introduced.
Also, the issue is due to some discrepency in final image of enclave manager dockerfile.
As a temporary workaround, final image is removed. All the necessary binaries and environement
will be available in build image of dockerfile itself.

Signed-off-by: manju956 <manjunath.a.c@intel.com>