### PR TITLE
Format Inside-Out I/O Source for Doxygen

### DIFF
--- a/common/sgx_workload/iohandler/file_io.cpp
+++ b/common/sgx_workload/iohandler/file_io.cpp
@@ -13,6 +13,12 @@
 * limitations under the License.
 */
 
+/**
+ * @file
+ * FileIoExecutor C++ class implementation for Avalon Inside-Out File I/O.
+ * To use, #include "file_io.h"
+ */
+
 #include <string>
 #include <stdlib.h>
 #include <stdio.h>
@@ -26,58 +32,90 @@
 #define MAX_FILE_SIZE 1024
 #define MAX_IO_RESULT_SIZE 128
 
-// Returns iohandler id corresponding to iohandler name
+
+/**
+ * Get the I/O handler ID corresponding to IoHandler handler_name.
+ *
+ * @param   handlerName Name of handler
+ * @returns I/O handler ID. That is, 1 for handler "tcf-base-file-io"
+ * @returns 0 on error
+ */
 uint32_t FileIoExecutor::GetIoHandlerId(const char* handler_name) {
     return TcfGetIoHandlerId(handler_name);
 }
 
-// Maximum size of buffer that is used for file io
+
+/**
+ * Get the maximum size of the buffer used for file I/O.
+ *
+ * @returns Maximum buffer size in bytes
+ */
 size_t FileIoExecutor::GetMaxFileSize() {
     return MAX_FILE_SIZE;
 }
 
-// Maximum size of result buffer that is used to store status of io
+
+/**
+ * Get the maximum size of the result buffer used to store the
+ * I/O status.
+ *
+ * @returns Maximum result buffer size in bytes
+ */
 size_t FileIoExecutor::GetMaxIoResultSize() {
     return MAX_IO_RESULT_SIZE;
 }
 
-/*
-  Opens given file and updates status in result buffer
-  result - status of file open operation
-  result_size - Maximum size of the result buffer
 
-*/
+/**
+ * Opens given file and updates status in the result buffer.
+ *
+ * @param result      Status of file open operation (0 is success,
+ *                    non-0 is failure)
+ * @param result_size Maximum size of the result buffer in bytes
+ * @returns           Status of operation (0 on success, non-0 on failure)
+ */
 uint32_t FileIoExecutor::FileOpen(uint8_t *result, size_t result_size) {
     uint32_t status;
     std::string file_operation = "open";
     std::string command = file_operation + " " + this->file_name;
-    status = TcfExecuteIoCommand(this->handler_id, (const uint8_t *)command.c_str(),
+    status = TcfExecuteIoCommand(this->handler_id,
+        (const uint8_t *)command.c_str(),
         command.length(), result, result_size, NULL, 0, NULL, 0);
     return status;
 }
 
-/*
-  Closes given file and updates status in result buffer
-  result - status of file close operation
-  result_size - Maximum size of the result buffer
-*/
+
+/**
+ * Closes given file and updates status in the result buffer.
+ *
+ * @param result      Status of file close operation (0 is success,
+ *                    non-0 is failure)
+ * @param result_size Maximum size of the result buffer in bytes
+ * @returns           Status of operation (0 on success, non-0 on failure)
+ */
 uint32_t FileIoExecutor::FileClose(uint8_t *result, size_t result_size) {
     uint32_t status;
     std::string file_operation = "close";
     std::string command = file_operation + " " + this->file_name;
-    status = TcfExecuteIoCommand(this->handler_id, (const uint8_t *)command.c_str(),
+    status = TcfExecuteIoCommand(this->handler_id,
+        (const uint8_t *)command.c_str(),
         command.length(), result, result_size, NULL, 0, NULL, 0);
     return status;
 }
 
-/*
-   Reads given file, stores content in out buffer
-   and updates status in result buffer
-   result - status of file read operation
-   result_size - Maximum size of the result buffer
-   out_buf - buffer to hold file content
-   out_buf_size - max size of buffer having file content
-*/
+
+/**
+ * Reads given file, stores content in out buffer
+ * and updates status in result buffer.
+ *
+ * @param result       Status of file read operation (0 is success,
+ *                     non-0 is failure)
+ * @param result_size  Maximum size of the result buffer in bytes
+ * @param out_buf      Buffer to hold file content
+ * @param out_buf_size Maximum size of out_buf to contain the file contents
+ *                     in bytes
+ * @returns            Status of operation (0 on success, non-0 on failure)
+ */
 uint32_t FileIoExecutor::FileRead(uint8_t *result, size_t result_size,
     uint8_t *out_buf, size_t out_buf_size) {
     uint32_t status;
@@ -89,14 +127,18 @@ uint32_t FileIoExecutor::FileRead(uint8_t *result, size_t result_size,
     return status;
 }
 
-/*
-   Writes given file with content in input buffer
-   and updates status in result buffer
-   result - status of file write operation
-   result_size - Maximum size of the result buffer
-   in_buf - buffer having file content to be written
-   in_buf_size - max size of buffer having file content
-*/
+
+/**
+ * Writes given file with content in input buffer
+ * and updates status in result buffer.
+ *
+ * @param result      Status of file write operation (0 is success,
+ *                    non-0 is failure)
+ * @param result_size Maximum size of the result buffer in bytes
+ * @param in_buf      Buffer with content to be written to the file
+ * @param in_buf_size Maximum size of in_buf to write to the file in bytes
+ * @returns           Status of operation (0 on success, non-0 on failure)
+ */
 uint32_t FileIoExecutor::FileWrite(uint8_t *result, size_t result_size,
     const uint8_t *in_buf, size_t in_buf_size) {
     uint32_t status;
@@ -108,14 +150,19 @@ uint32_t FileIoExecutor::FileWrite(uint8_t *result, size_t result_size,
     return status;
 }
 
-/*
-   Tells current position of file pointer, stores it in out buffer
-   and updates status in result buffer
-   result - status of file ftell operation
-   result_size - Maximum size of the result buffer
-   out_buf - buffer to hold position of file pointer
-   out_buf_size - max size of buffer having file content
-*/
+
+/**
+ * Gets the current position of the file, stores it in buffer out_buf,
+ * and updates status in result buffer.
+ *
+ * @param result       status of file tell operation (0 is success,
+ *                     non-0 is failure)
+ * @param result_size  Maximum size of the result buffer in bytes
+ * @param out_buf      Buffer to hold file position
+ * @param out_buf_size Maximum size of out_buf to contain the file position
+ *                     in bytes
+ * @returns            Status of operation (0 on success, non-0 on failure)
+ */
 uint32_t FileIoExecutor::FileTell(uint8_t *result, size_t result_size,
     uint8_t *out_buf, size_t out_buf_size) {
     uint32_t status;
@@ -128,12 +175,18 @@ uint32_t FileIoExecutor::FileTell(uint8_t *result, size_t result_size,
 }
 
 
-/*
-   Places the file pointer to given position and updates status in result buffer
-   result - status of file fseek operation
-   result_size - Maximum size of the result buffer
-*/
-uint32_t FileIoExecutor::FileSeek(size_t position, uint8_t *result, size_t result_size) {
+/**
+ * Moves the file position the file to the given position and
+ * updates the status in result buffer.
+ *
+ * @param position    Byte offset of new file position
+ * @param result      Status of file seek operation (0 is success,
+ *                    non-0 is failure)
+ * @param result_size Maximum size of the result buffer in bytes
+ * @returns           Status of operation (0 on success, non-0 on failure)
+ */
+uint32_t FileIoExecutor::FileSeek(size_t position, uint8_t *result,
+        size_t result_size) {
     uint32_t status;
     std::string file_operation = "seek";
     std::string command = file_operation + " " + this->file_name + " " +
@@ -144,12 +197,15 @@ uint32_t FileIoExecutor::FileSeek(size_t position, uint8_t *result, size_t resul
     return status;
 }
 
-/*
-   Deletes the file whose name is stored in the FileIoExecutor instance
-   result - status of file delete operation
-   result_size - Maximum size of the result buffer
-*/
 
+/**
+ * Deletes the file whose name is stored in the FileIoExecutor instance.
+ *
+ * @param result      Status of file delete operation (0 is success,
+ *                    non-0 is failure)
+ * @param result_size Maximum size of the result buffer in bytes
+ * @returns           Status of operation (0 on success, non-0 on failure)
+ */
 uint32_t FileIoExecutor::FileDelete(uint8_t *result, size_t result_size) {
     uint32_t status;
     std::string file_operation = "delete";

--- a/common/sgx_workload/iohandler/file_io.h
+++ b/common/sgx_workload/iohandler/file_io.h
@@ -13,6 +13,12 @@
 * limitations under the License.
 */
 
+/**
+ * @file
+ * FileIoExecutor C++ class definitions for Avalon Inside-Out File I/O.
+ * To use, #include "file_io.h"
+ */
+
 #include <string>
 #include <stdint.h>
 

--- a/common/sgx_workload/iohandler/file_io_wrapper.cpp
+++ b/common/sgx_workload/iohandler/file_io_wrapper.cpp
@@ -13,11 +13,24 @@
 * limitations under the License.
 */
 
+/**
+ * @file
+ * C++ non-class wrapper implementation for Avalon Inside-Out File I/O.
+ * To use, #include "file_io_wrapper.h"
+ */
+
 #include <string>
 
 #include "file_io.h"
 #include "file_io_wrapper.h"
 
+/**
+ * Read a file named file_name and return the contents in a string.
+ * Return an empty string ("") on failure.
+ *
+ * @param file_name Name of the file to be read
+ * @returns         String containing file contents
+ */
 std::string Read(std::string file_name) {
     FileIoExecutor file_io;
     uint32_t file_handler_id = file_io.GetIoHandlerId("tcf-base-file-io");
@@ -35,11 +48,19 @@ std::string Read(std::string file_name) {
     uint32_t status = file_io.FileRead((uint8_t *)result.c_str(), result_size,
         (uint8_t *)out_buf.c_str(), out_buf_size);
     if (status == 0) {
-        return out_buf.c_str(); 
+        return out_buf.c_str();
     }
-    return "";    
+    return "";  // failure
 }
 
+/**
+ * Write the contents of string data to a file named file_name.
+ * Return the integer status (0 is success, non-0 is failure).
+ *
+ * @param file_name Name of the file to write
+ * @param data      Contents of file to write
+ * @returns         Status of operation (0 on success, non-0 on failure)
+ */
 uint32_t Write(std::string file_name, std::string data) {
     FileIoExecutor file_io;
     uint32_t file_handler_id = file_io.GetIoHandlerId("tcf-base-file-io");
@@ -55,6 +76,13 @@ uint32_t Write(std::string file_name, std::string data) {
     return status;
 }
 
+/**
+ * Delete a file named file_name.
+ * Return the integer status (0 is success, non-0 is failure).
+ *
+ * @param file_name Name of the file to delete
+ * @returns         Status of operation (0 on success, non-0 on failure)
+ */
 uint32_t Delete(std::string file_name) {
     FileIoExecutor file_io;
     uint32_t file_handler_id = file_io.GetIoHandlerId("tcf-base-file-io");
@@ -64,6 +92,7 @@ uint32_t Delete(std::string file_name) {
     size_t result_size = file_io.GetMaxIoResultSize();
     result.reserve(result_size);
 
-    uint32_t status = file_io.FileDelete((uint8_t *)result.c_str(), result_size);
+    uint32_t status = file_io.FileDelete((uint8_t *)result.c_str(),
+        result_size);
     return status;
 }

--- a/common/sgx_workload/iohandler/file_io_wrapper.h
+++ b/common/sgx_workload/iohandler/file_io_wrapper.h
@@ -13,6 +13,12 @@
 * limitations under the License.
 */
 
+/**
+ * @file
+ * C++ non-class wrapper definitions for Avalon Inside-Out File I/O.
+ * To use, #include "file_io_wrapper.h"
+ */
+
 #include <string>
 
 // Read from given file return file data in string format

--- a/tc/sgx/trusted_worker_manager/enclave/iohandler_enclave.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/iohandler_enclave.cpp
@@ -22,23 +22,27 @@
 #include "iohandler_enclave.h"
 #include "enclave_utils.h"
 
-/*
-  Dummy ecall (non root function) to support independent
-  interface for iohandler
-*/
+
+/**
+ * Dummy ecall (non root function) to support an independent
+ * interface for the iohandler.
+ */
 void ecall_dummy() {}
 
-/*
-  Executes given io command by invoking ocall and stores result of
-  io execution in result buffer
-  handlerId - identifier for iohandler
-  command - IO command that needs to be executed outside enclave
-  result - status of IO operation
-  resultSize - Maximum size of the result buffer
-  inBuf - buffer having input data
-  inBufSize - max size of buffer having input data
-  outBuf - placeholder for output data
-  outBufSize - max size of buffer having output data
+
+/**
+ * Executes the given I/O command by invoking ocall and stores the result of
+ * I/O execution in result buffer.
+ *
+ * @param handlerId   Identifier for iohandler
+ * @param command     IO command that needs to be executed outside enclave
+ * @param commandSize Size of the command buffer
+ * @param result      Status of IO operation
+ * @param resultSize  Maximum size of the result buffer
+ * @param inBuf       Buffer having input data
+ * @param inBufSize   Maximum size of buffer having input data
+ * @param outBuf      Placeholder for output data
+ * @param outBufSize  Maximum size of buffer having output data
 */
 uint32_t TcfExecuteIoCommand(uint32_t handlerId,
                              const uint8_t* command,
@@ -53,7 +57,8 @@ uint32_t TcfExecuteIoCommand(uint32_t handlerId,
     tcf::error::ThrowIfNull(command, "IO command is null");
     try {
         ocall_Process(&status, handlerId, (const char*) command,
-            commandSize, result, resultSize, inBuf, inBufSize, outBuf, outBufSize);
+            commandSize, result, resultSize, inBuf, inBufSize, outBuf,
+            outBufSize);
     } catch (tcf::error::Error& e) {
         ocall_SetErrorMessage(e.what());
         status = e.error_code();
@@ -64,7 +69,14 @@ uint32_t TcfExecuteIoCommand(uint32_t handlerId,
     return status;
 }
 
-// Returns iohandler id corresponding to iohandler name
+
+/**
+ * Returns iohandler ID corresponding to iohandler name.
+ *
+ * @param   handlerName Name of handler
+ * @returns I/O handler ID. That is, 1 for handler "tcf-base-file-io"
+ * @returns 0 on error
+ */
 uint32_t TcfGetIoHandlerId(const char* handlerName) {
     if (handlerName == "tcf-base-file-io") {
         return 1;


### PR DESCRIPTION
Before running Doxygen, this reformats the comments so that they can
be parsed by Doxygen, the automatic document from source generator.

For this first phase, only Inside-Out I/O is formatted.
Other source will be reformatted later.

Signed-off-by: danintel <daniel.anderson@intel.com>