### PR TITLE
Avalon standalone mode test run script correction

### DIFF
--- a/scripts/tcs_startup.sh
+++ b/scripts/tcs_startup.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 KV_STORAGE="kv_storage"
-ENCLAVE_MANAGER="${TCF_HOME}/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py"
+ENCLAVE_MANAGER="${TCF_HOME}/enclave_manager/avalon_enclave_manager/enclave_manager.py"
 LISTENER="avalon_listener"
 VERSION="$(cat ${TCF_HOME}/VERSION)"
 # Default values


### PR DESCRIPTION
scripts/tcs_startup.sh has wrong ENCLAVE_MANAGER path. This PR
corrects it.

Signed-off-by: pankajgoyal2 <pankaj.goyal@intel.com>