### PR TITLE
Add validation in listener to fix following bugs

### DIFF
--- a/listener/avalon_listener/tcs_listener.py
+++ b/listener/avalon_listener/tcs_listener.py
@@ -114,12 +114,7 @@ class TCSListener(resource.Resource):
             input_json = json.loads(input_json_str)
         except Exception as err:
             logger.exception("exception loading Json: %s", str(err))
-            response = {
-                "error": {
-                    "code": WorkOrderStatus.INVALID_PARAMETER_FORMAT_OR_VALUE,
-                    "message": "Error: Improper Json. Unable to load",
-                },
-            }
+            response["error"]["message"] = "Improper Json request"
             return response
 
         logger.info("Received request: %s", input_json['method'])

--- a/sdk/avalon_sdk/direct/jrpc/jrpc_util.py
+++ b/sdk/avalon_sdk/direct/jrpc/jrpc_util.py
@@ -13,11 +13,11 @@ from enum import Enum, unique
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum, unique
+from enum import unique, IntEnum
 
 
 @unique
-class JsonRpcErrorCode(Enum):
+class JsonRpcErrorCode(IntEnum):
     """
     JSON RPC error code values:
     0 – SUCCESS
@@ -39,4 +39,3 @@ class JsonRpcErrorCode(Enum):
     INVALID_SIGNATURE = 4
     NO_LOOKUP_RESULTS = 5
     UNSUPPORTED_MODE = 6
-    KEY_EXISTS = 9

--- a/sdk/avalon_sdk/work_order/work_order_request_validator.py
+++ b/sdk/avalon_sdk/work_order/work_order_request_validator.py
@@ -30,7 +30,7 @@ class WorkOrderRequestValidator():
         """
         self.__param_key_map = {
             "responseTimeoutMSecs": True,
-            "payloadFormat": False,
+            "payloadFormat": True,
             "resultUri": False,
             "notifyUri": False,
             "workOrderId": True,
@@ -75,6 +75,14 @@ class WorkOrderRequestValidator():
         for k, v in self.__param_key_map.items():
             if v is True and k not in key_list:
                 return False, "Missing parameter {}".format(k)
+
+        if "responseTimeoutMSecs" in params:
+            return type(params["responseTimeoutMSecs"]) == int, \
+                "Invalid data format for responseTimeoutMSecs"
+
+        if "payloadFormat" in params:
+            if params["payloadFormat"] != "JSON-RPC":
+                return False, "Invalid payload format"
 
         if not is_valid_hex_str(params["workerId"]):
             return False, "Invalid data format for Worker id"

--- a/sdk/avalon_sdk/worker/worker_details.py
+++ b/sdk/avalon_sdk/worker/worker_details.py
@@ -18,6 +18,8 @@ Perform worker-related functions based on EEA Spec 1.0.
 
 import logging
 import json
+import hashlib
+
 import avalon_crypto_utils.crypto_utility as crypto_utility
 import config.config as pconfig
 from enum import Enum, unique
@@ -223,9 +225,12 @@ class SGXWorkerDetails(WorkerDetails):
             self.proof_data = json.loads(
                 worker_data['workerTypeData']['proofData'])
 
-        self.worker_id = crypto_utility.strip_begin_end_public_key(
+        w_id = crypto_utility.strip_begin_end_public_key(
             worker_data['workerTypeData']['verificationKey']) \
-            .encode("UTF-8").hex()
+            .encode("UTF-8")
+        # Calculate sha256 of worker id to get 32 bytes. The TC spec proxy
+        # model contracts expect byte32. Then take a hexdigest for hex str.
+        self.worker_id = hashlib.sha256(w_id).hexdigest()
         ''' worker_id - newline, BEGIN PUB KEY and END PUB KEY are removed
                         from worker's verification key and converted to hex '''
         logger.info("Hashing Algorithm : %s", self.hashing_algorithm)


### PR DESCRIPTION
1. TCFH-733 - Avalon is processing the null data and data hash input request in the indata section and giving incorrect results
2. TCFH-734 - WorkOrderGetResult fails with server error with the removal of WorkOrderid
3. TCFH-736 - responseTimeoutMSecs parameter in WorkOrderSubmit API is not working with special/ alphanumeric characters
4. TCFH-735 - WorkOrderSubmit fails with server error with the removal of requesterId
5. TCFH-703 - Direct model workOrderSubmit request is working without payload format in params field


Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>