### PR TITLE
Cleanup redundant solc installation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -153,7 +153,7 @@ The steps below will set up a Python virtual environment to run Avalon.
 10. Install PIP3 packages into your Python virtual environment:
 
     ```bash
-    pip3 install --upgrade setuptools json-rpc py-solc py-solc-x web3 colorlog twisted wheel
+    pip3 install --upgrade setuptools json-rpc py-solc-x web3 colorlog twisted wheel
     ```
 
 11. Build and install Avalon components:

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -90,7 +90,8 @@ sudo apt-get install -y python3-venv
 
 Also, install the following pip3 packages:
 ```bash
-pip3 install --upgrade setuptools json-rpc py-solc web3 colorlog twisted wheel
+pip3 install --upgrade setuptools json-rpc py-solc-x web3 colorlog twisted wheel
+python3 -m solcx.install v0.5.15
 ```
 
 # <a name="docker"></a>Docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,11 +46,6 @@ RUN apt-get update \
 
 # Make Python3 default
 RUN ln -sf /usr/bin/python3 /usr/bin/python
-
-# Installing solidity compiler
-RUN add-apt-repository ppa:ethereum/ethereum \
-   && apt-get update \
-   && apt-get install solc
    
 # Install py-solc-x and web3 packages using pip because
 # these are not available in apt repository.

--- a/examples/apps/generic_client/README.md
+++ b/examples/apps/generic_client/README.md
@@ -63,12 +63,8 @@ worker requests on the command line.
 3. Install the Solidity compiler:
     ```bash
     pip3 install --upgrade py-solc-x
-    python3 -m solc.install v0.4.25
     python3 -m solcx.install v0.5.15
-    export SOLC_BINARY=~/.py-solc/solc-v0.4.25/bin/solc
     ```
-    The `SOLC_BINARY` environment variable makes `solc` accessible
-    from Python to compile Solidity contracts
 4. Change to the Generic Client directory
    ```bash
    cd $TCF_HOME/examples/apps/generic_client

--- a/examples/apps/heart_disease_eval/README.md
+++ b/examples/apps/heart_disease_eval/README.md
@@ -83,12 +83,8 @@ supports X Windows.
 7.  In Terminal 2 install the Solidity compiler:
     ```bash
     pip3 install --upgrade py-solc-x
-    python3 -m solc.install v0.4.25
     python3 -m solcx.install v0.5.15
-    export SOLC_BINARY=~/.py-solc/solc-v0.4.25/bin/solc
     ```
-    The `SOLC_BINARY` environment variable makes `solc` accessible
-    from Python to compile Solidity contracts
 8.  If your DISPLAY is not the local console, `:0`, you need to give access to
     your display from the GUI.
     Open a new terminal, Terminal 3, and run `xhost +`

--- a/sdk/TestingContracts.md
+++ b/sdk/TestingContracts.md
@@ -31,16 +31,12 @@
     make sure
     ```
 
-4.  (Standalone builds only) Install the Solicity compiler to compile
+4.  (Standalone builds only) Install the Solidity compiler to compile
     Solidity contracts from Python:
     ```bash
     pip3 install --upgrade py-solc-x
-    python3 -m solc.install v0.4.25
     python3 -m solcx.install v0.5.15
-    export SOLC_BINARY=~/.py-solc/solc-v0.4.25/bin/solc
     ```
-    The `SOLC_BINARY` environment variable makes `solc` accessible
-    from Python to compile Solidity contracts
 
 5.  (Standalone builds only) To run smart contracts using a
     Ropsten network account, first install the MetaMask Chrome plugin


### PR DESCRIPTION
- Remove solc apt-get installation
- Rely only py-solc-x which suffices for Solidity handling
  in Python
- Update documentations

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>