### PR TITLE
Handle multiple requester clients

### DIFF
--- a/sdk/avalon_sdk/ethereum/ethereum_work_order.py
+++ b/sdk/avalon_sdk/ethereum/ethereum_work_order.py
@@ -260,15 +260,14 @@ def is_wo_id_in_event(event, *kargs, **kwargs):
         True - if the work order id matches
         False - otherwise
     """
-    response = event["args"]["workOrderResponse"]
-    if "result" in response:
-        logging.debug("Event has a valid result and no error")
-        work_order_id = kwargs.get("wo_id")
-        response_json = json.loads(response)
-        if response_json["result"]["workOrderId"] == work_order_id:
-            logging.debug("Work order response event for work "
-                          + "order id {} received".format(work_order_id))
-            return True
+    wo_id_from_event_bytes = event["args"]["workOrderId"]
+    # Work order id in event is bytes32. Convert to hex
+    wo_id_from_event = wo_id_from_event_bytes.hex()
+    work_order_id = kwargs.get("wo_id")
+    if wo_id_from_event == work_order_id:
+        logging.debug("Work order response event for work "
+                      + "order id {} received".format(work_order_id))
+        return True
     return False
 
 


### PR DESCRIPTION
- Bugfix to handle multiple work order requester for Ethereum
This commit handles multiple work order requests from multiple requesters
but not simultaneously. The 'nonce' field in any transaction needs to be
unique and equal to one more than the number of transactions submitted
with the account being used. This needs a synchronization between the
requesters by some means. In a future implementation, some central counter
generator service could be used which would also hold multiple signing
accounts and return counter for account requested. Refer https://github.com/ethereum/wiki/wiki/Glossary to
look for Account nonce.
But with the current implementation only a single account is being considered.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>