### PR TITLE
Generate EncryptionKeySignature and restructure enclave signup process

### DIFF
--- a/enclave_manager/avalon_enclave_manager/avalon_enclave_bridge.py
+++ b/enclave_manager/avalon_enclave_manager/avalon_enclave_bridge.py
@@ -210,6 +210,7 @@ def create_signup_info(originator_public_key_hash, nonce):
     signup_info = {
         'verifying_key': signup_data['verifying_key'],
         'encryption_key': signup_data['encryption_key'],
+        'encryption_key_signature': signup_data['encryption_key_signature'],
         'proof_data': 'Not present',
         'enclave_persistent_id': 'Not present'
     }

--- a/enclave_manager/avalon_enclave_manager/avalon_enclave_helper.py
+++ b/enclave_manager/avalon_enclave_manager/avalon_enclave_helper.py
@@ -68,6 +68,8 @@ class EnclaveHelper(object):
         enclave_info['sealed_data'] = enclave_data.sealed_signup_data
         enclave_info['verifying_key'] = enclave_data.verifying_key
         enclave_info['encryption_key'] = enclave_data.encryption_key
+        enclave_info['encryption_key_signature'] = \
+            enclave_data.encryption_key_signature
         enclave_info['enclave_id'] = enclave_data.verifying_key
         enclave_info['proof_data'] = ''
         if not avalon_enclave.enclave.is_sgx_simulator():
@@ -87,6 +89,8 @@ class EnclaveHelper(object):
             self.sealed_data = enclave_info['sealed_data']
             self.verifying_key = enclave_info['verifying_key']
             self.encryption_key = enclave_info['encryption_key']
+            self.encryption_key_signature = \
+                enclave_info['encryption_key_signature']
             self.proof_data = enclave_info['proof_data']
             self.enclave_id = enclave_info['enclave_id']
         except KeyError as ke:
@@ -103,9 +107,7 @@ class EnclaveHelper(object):
 
         :param encrypted_request: base64 encoded encrypted workorder request
         """
-        return avalon_enclave.send_to_sgx_worker(
-            self.sealed_data,
-            encrypted_request)
+        return avalon_enclave.send_to_sgx_worker(encrypted_request)
 
     # -------------------------------------------------------
     def get_enclave_public_info(self):

--- a/enclave_manager/avalon_enclave_manager/enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/enclave_manager.py
@@ -59,7 +59,7 @@ class EnclaveManager:
         # Need to come up with a scheme to generate both for every unique
         # encryption key.
         self.encryption_key_nonce = ""
-        self.encryption_key_signature = ""
+        self.encryption_key_signature = signup_data.encryption_key_signature
         self.enclave_id = signup_data.enclave_id
         self.extended_measurements = measurements
 

--- a/tc/sgx/trusted_worker_manager/enclave/enclave_data.h
+++ b/tc/sgx/trusted_worker_manager/enclave/enclave_data.h
@@ -22,6 +22,8 @@
 #include <string>
 
 #include "crypto.h"
+#include "utils.h"
+#include "base64.h"
 
 // JSON format for private data:
 // {
@@ -42,35 +44,37 @@
 // {
 //     "SigningKey" : "",
 //     "EncryptionKey" : ""
+//     "EncryptionKeySignature" : ""
 // }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class EnclaveData {
+private:
+    EnclaveData(void);
+    ~EnclaveData(void);
+
+    static EnclaveData* instance;
+ 
 protected:
     void SerializePrivateData(void);
     void SerializePublicData(void);
-
-    void DeserializeSealedData(const std::string& inSerializedEnclaveData);
 
     tcf::crypto::sig::PublicKey public_signing_key_;
     tcf::crypto::sig::PrivateKey private_signing_key_;
     tcf::crypto::pkenc::PublicKey public_encryption_key_;
     tcf::crypto::pkenc::PrivateKey private_encryption_key_;
+    std::string encryption_key_signature_;
 
     std::string serialized_private_data_;
     std::string serialized_public_data_;
 
 public:
-    // We need some way to compute the required size so the client can
-    // allocated storage for the sealed data. There are a number of ways
-    // to do this; for now, the constant will be good enough.
-    static const size_t cMaxSealedDataSize = 8192;
-    static const size_t cMaxPublicDataSize = 4096;
-
-    EnclaveData(void);
-    EnclaveData(const uint8_t* inSealedData);
-
-    ~EnclaveData(void);
+    static EnclaveData* getInstance() {
+        if(!instance) {
+            instance = new EnclaveData;
+        }
+        return instance;
+    }
 
     ByteArray encrypt_message(const ByteArray& message) const {
         return public_encryption_key_.EncryptMessage(message);
@@ -104,9 +108,15 @@ public:
 
     size_t get_private_data_size(void) const { return serialized_private_data_.length(); }
 
+    void generate_encryption_key_signature() {
+        std::string b64_pub_encr_key = public_encryption_key_.Serialize();
+        ByteArray encr_key_sig_bytes = \
+            private_signing_key_.SignMessage(StrToByteArray(b64_pub_encr_key));
+        encryption_key_signature_ = base64_encode(encr_key_sig_bytes);
+    }
+
     size_t get_sealed_data_size(void) const {
         size_t sdsize = sgx_calc_sealed_data_size(0, get_private_data_size());
-        assert(sdsize < cMaxSealedDataSize);
         return sdsize;
     }
 };

--- a/tc/sgx/trusted_worker_manager/enclave/signup.edl
+++ b/tc/sgx/trusted_worker_manager/enclave/signup.edl
@@ -28,23 +28,23 @@ enclave {
             );
 
         public tcf_err_t ecall_CreateEnclaveData(
+            [out] size_t* outPublicEnclaveDataSize,
+            [out] size_t* outSealedEnclaveDataSize
+            );
+
+        public tcf_err_t ecall_CreateSignupData(
             [in] const sgx_target_info_t* inTargetInfo,
             [in, string] const char* inOriginatorPublicKeyHash,
             [out, size=inAllocatedPublicEnclaveDataSize] char* outPublicEnclaveData,
             size_t inAllocatedPublicEnclaveDataSize,
-            [out] size_t* outPublicEnclaveDataSize,
             [out, size=inAllocatedSealedEnclaveDataSize] uint8_t* outSealedEnclaveData,
             size_t inAllocatedSealedEnclaveDataSize,
-            [out] size_t* outSealedEnclaveDataSize,
             [out] sgx_report_t* outEnclaveReport
             );
 
         public tcf_err_t ecall_UnsealEnclaveData(
-            [in, size=inSealedEnclaveDataSize] const uint8_t* inSealedEnclaveData,
-            size_t inSealedEnclaveDataSize,
             [out, size=inAllocatedPublicEnclaveDataSize] char* outPublicEnclaveData,
-            size_t inAllocatedPublicEnclaveDataSize,
-            [out] size_t* outPublicEnclaveDataSize
+            size_t inAllocatedPublicEnclaveDataSize
             );
 
          public tcf_err_t ecall_VerifyEnclaveInfo(

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_data_handler.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_data_handler.cpp
@@ -38,7 +38,7 @@
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 namespace tcf {
 
-    void WorkOrderDataHandler::Unpack(EnclaveData& enclaveData,
+    void WorkOrderDataHandler::Unpack(EnclaveData* enclaveData,
                                       const JSON_Object* object) {
         ByteArray encrypted_input_data;
         std::string input_data_hash;
@@ -57,7 +57,7 @@ namespace tcf {
             data_iv = HexStringToBinary(iv);
             ByteArray encrypted_key = tcf::crypto::skenc::DecryptMessage(
                    session_key, enc_data_key);
-            data_encryption_key = enclaveData.decrypt_message(encrypted_key);
+            data_encryption_key = enclaveData->decrypt_message(encrypted_key);
         }
 
         std::string data_b64 = GetJsonStr(object, "data");

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_data_handler.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_data_handler.h
@@ -53,7 +53,7 @@ namespace tcf {
                 this->iv = iv;
             }
 
-            void Unpack(EnclaveData& enclaveData,
+            void Unpack(EnclaveData* enclaveData,
                         const JSON_Object* object);
 
             void Pack(JSON_Array* json_array);

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_enclave.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_enclave.cpp
@@ -43,23 +43,22 @@
 ByteArray last_result;
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-tcf_err_t ecall_HandleWorkOrderRequest(const uint8_t* inSealedSignupData,
-    size_t inSealedSignupDataSize,
-    const uint8_t* inSerializedRequest,
+tcf_err_t ecall_HandleWorkOrderRequest(const uint8_t* inSerializedRequest,
     size_t inSerializedRequestSize,
     size_t* outSerializedResponseSize) {
     tcf_err_t result = TCF_SUCCESS;
 
     try {
-        tcf::error::ThrowIfNull(inSealedSignupData, "Sealed signup data pointer is NULL");
-        tcf::error::ThrowIfNull(inSerializedRequest, "Serialized request pointer is NULL");
-        tcf::error::ThrowIfNull(outSerializedResponseSize, "Response size pointer is NULL");
+        tcf::error::ThrowIfNull(inSerializedRequest,
+            "Serialized request pointer is NULL");
+        tcf::error::ThrowIfNull(outSerializedResponseSize,
+            "Response size pointer is NULL");
 
         // Unseal the enclave persistent data
-        EnclaveData enclaveData(inSealedSignupData);
+        EnclaveData* enclaveData = EnclaveData::getInstance(); 
 
-        ByteArray request(
-               inSerializedRequest, inSerializedRequest + inSerializedRequestSize);
+        ByteArray request(inSerializedRequest,
+            inSerializedRequest + inSerializedRequestSize);
 
         tcf::WorkOrderProcessor wo_processor;
         std::string wo_string(request.begin(), request.end());
@@ -69,12 +68,13 @@ tcf_err_t ecall_HandleWorkOrderRequest(const uint8_t* inSealedSignupData,
         (*outSerializedResponseSize) = last_result.size();
     } catch (tcf::error::Error& e) {
         SAFE_LOG(TCF_LOG_ERROR,
-            "Error in worker enclave (ecall_HandleWorkOrderRequest): %04X -- %s", e.error_code(),
-            e.what());
+            "Error in worker enclave (ecall_HandleWorkOrderRequest): %04X -- %s",
+            e.error_code(), e.what());
         ocall_SetErrorMessage(e.what());
         result = e.error_code();
     } catch (...) {
-        SAFE_LOG(TCF_LOG_ERROR, "Unknown error in worker enclave (ecall_HandleWorkOrderRequest)");
+        SAFE_LOG(TCF_LOG_ERROR,
+            "Unknown error in worker enclave (ecall_HandleWorkOrderRequest)");
         result = TCF_ERR_UNKNOWN;
     }
 
@@ -82,31 +82,31 @@ tcf_err_t ecall_HandleWorkOrderRequest(const uint8_t* inSealedSignupData,
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-tcf_err_t ecall_GetSerializedResponse(const uint8_t* inSealedSignupData,
-    size_t inSealedSignupDataSize,
-    uint8_t* outSerializedResponse,
+tcf_err_t ecall_GetSerializedResponse(uint8_t* outSerializedResponse,
     size_t inSerializedResponseSize) {
     tcf_err_t result = TCF_SUCCESS;
 
     try {
-        tcf::error::ThrowIfNull(inSealedSignupData, "Sealed signup data pointer is NULL");
-        tcf::error::ThrowIfNull(outSerializedResponse, "Serialized response pointer is NULL");
+        tcf::error::ThrowIfNull(outSerializedResponse,
+            "Serialized response pointer is NULL");
         tcf::error::ThrowIf<tcf::error::ValueError>(
-            inSerializedResponseSize < last_result.size(), "Not enough space for the response");
+            inSerializedResponseSize < last_result.size(),
+            "Not enough space for the response");
 
         // Unseal the enclave persistent data
-        EnclaveData enclaveData(inSealedSignupData);
+        EnclaveData* enclaveData = EnclaveData::getInstance();
 
-        memcpy_s(outSerializedResponse, inSerializedResponseSize, last_result.data(),
-            last_result.size());
+        memcpy_s(outSerializedResponse, inSerializedResponseSize,
+            last_result.data(), last_result.size());
     } catch (tcf::error::Error& e) {
         SAFE_LOG(TCF_LOG_ERROR,
-            "Error in worker enclave(ecall_GetSerializedResponse): %04X -- %s", e.error_code(),
-            e.what());
+            "Error in worker enclave(ecall_GetSerializedResponse): %04X -- %s",
+            e.error_code(), e.what());
         ocall_SetErrorMessage(e.what());
         result = e.error_code();
     } catch (...) {
-        SAFE_LOG(TCF_LOG_ERROR, "Unknown error in worker enclave (ecall_GetSerializedResponse)");
+        SAFE_LOG(TCF_LOG_ERROR,
+            "Unknown error in worker enclave (ecall_GetSerializedResponse)");
         result = TCF_ERR_UNKNOWN;
     }
 

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_enclave.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_enclave.h
@@ -25,9 +25,7 @@ DESCRIPTION:   Function declarations for the workorder enclave
 #include "enclave_utils.h"
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-extern tcf_err_t ecall_HandleWorkOrderRequest(const uint8_t* inSealedSignupData,
-    size_t inSealedSignupDataSize,
-    const uint8_t* inSerializedRequest,
+extern tcf_err_t ecall_HandleWorkOrderRequest(const uint8_t* inSerializedRequest,
     size_t inSerializedRequestSize,
     size_t* outSerializedResponseSize);
 

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor.cpp
@@ -37,7 +37,7 @@
 #include "workload_processor.h"
 
 namespace tcf {
-    void WorkOrderProcessor::ParseJsonInput(EnclaveData& enclaveData, std::string json_str) {
+    void WorkOrderProcessor::ParseJsonInput(EnclaveData* enclaveData, std::string json_str) {
         // Parse the work order request
         JsonValue parsed(json_parse_string(json_str.c_str()));
         tcf::error::ThrowIfNull(
@@ -158,7 +158,7 @@ namespace tcf {
 
         // Decrypt Encryption key
         ByteArray encrypted_session_key_bytes = HexStringToBinary(encrypted_session_key);
-        session_key = enclaveData.decrypt_message(encrypted_session_key_bytes);
+        session_key = enclaveData->decrypt_message(encrypted_session_key_bytes);
         ByteArray session_key_iv_bytes = HexStringToBinary(session_key_iv);
         JSON_Array* data_array = json_object_get_array(params_object, "inData");
         size_t count = json_array_get_count(data_array);
@@ -414,8 +414,8 @@ namespace tcf {
         return final_hash;
     }
 
-    void WorkOrderProcessor::ComputeSignature(EnclaveData& enclave_data, ByteArray& message_hash) {
-        ByteArray sig = enclave_data.sign_message(message_hash);
+    void WorkOrderProcessor::ComputeSignature(EnclaveData* enclave_data, ByteArray& message_hash) {
+        ByteArray sig = enclave_data->sign_message(message_hash);
         worker_signature = base64_encode(sig);
     }
 
@@ -468,7 +468,7 @@ namespace tcf {
         return serialized_response;
     }
 
-    ByteArray WorkOrderProcessor::Process(EnclaveData& enclaveData, std::string json_str) {
+    ByteArray WorkOrderProcessor::Process(EnclaveData* enclaveData, std::string json_str) {
         try {
             ParseJsonInput(enclaveData, json_str);
             tcf::error::ThrowIf<tcf::error::ValueError>(VerifyEncryptedRequestHash()!= TCF_SUCCESS,

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor.h
@@ -33,17 +33,17 @@ namespace tcf {
                     session_key.clear();
                 }
                 ByteArray CreateErrorResponse(int err_code, const char* err_message);
-                ByteArray Process(EnclaveData& enclaveData, std::string json_str);
+                ByteArray Process(EnclaveData* enclaveData, std::string json_str);
 
         private:
-                void ParseJsonInput(EnclaveData& enclaveData, std::string json_str);
+                void ParseJsonInput(EnclaveData* enclaveData, std::string json_str);
                 ByteArray CreateJsonOutput();
                 std::vector<tcf::WorkOrderData> ExecuteWorkOrder();
                 ByteArray ComputeRequestHash();
                 ByteArray ResponseHashCalculate(std::vector<tcf::WorkOrderData>& wo_data);
                 tcf_err_t VerifyEncryptedRequestHash();
                 int VerifyRequesterSignature();
-                void ComputeSignature(EnclaveData& enclaveData, ByteArray& message_hash);
+                void ComputeSignature(EnclaveData* enclaveData, ByteArray& message_hash);
                 void ConcatHash(ByteArray& dst, ByteArray& src);
                 /***Required for work order processing **/
                 std::string tc_service_address;

--- a/tc/sgx/trusted_worker_manager/enclave/workload.edl
+++ b/tc/sgx/trusted_worker_manager/enclave/workload.edl
@@ -22,8 +22,6 @@ enclave {
         // inSerializedRequest is a binary encoding of the encrypted request
         // outSerializedResponseSize is the computed size of the response
         public tcf_err_t ecall_HandleWorkOrderRequest(
-            [in, size=inSealedSignupDataSize] const uint8_t* inSealedSignupData,
-            size_t inSealedSignupDataSize,
             [in, size=inSerializedRequestSize] const uint8_t* inSerializedRequest,
             size_t inSerializedRequestSize,
             [out] size_t* outSerializedResponseSize
@@ -31,8 +29,6 @@ enclave {
 
         // outSerializedResponse is a base64 encoding of a JSON object encrypted with the AES session key
         public tcf_err_t ecall_GetSerializedResponse(
-            [in, size=inSealedSignupDataSize] const uint8_t* inSealedSignupData,
-            size_t inSealedSignupDataSize,
             [out, size = inSerializedResponseSize] uint8_t* outSerializedResponse,
             size_t inSerializedResponseSize
             );

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup.h
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup.h
@@ -31,7 +31,6 @@ namespace tcf {
 
             // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
             tcf_err_t UnsealEnclaveData(
-                const Base64EncodedString& inSealedEnclaveData,
                 StringArray& outPublicEnclaveData);
 
             tcf_err_t VerifyEnclaveInfo(const std::string& enclaveInfo,

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/work_order.h
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/work_order.h
@@ -26,7 +26,6 @@ namespace tcf {
         namespace workorder {
             // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
             tcf_err_t HandleWorkOrderRequest(
-                const Base64EncodedString& inSealedEnclaveData,
                 const Base64EncodedString& inSerializedRequest,
                 uint32_t& outResponseIdentifier,
                 size_t& outSerializedResponseSize,
@@ -34,7 +33,6 @@ namespace tcf {
 
             // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
             tcf_err_t GetSerializedResponse(
-                const Base64EncodedString& inSealedEnclaveData,
                 const uint32_t inResponseIdentifier,
                 const size_t inSerializedResponseSize,
                 Base64EncodedString& outSerializedResponse,

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info.cpp
@@ -39,32 +39,46 @@ tcf_err_t SignupInfo::DeserializeSignupInfo(
 
         // Parse the incoming wait certificate
         JsonValue parsed(json_parse_string(serialized_signup_info.c_str()));
-        tcf::error::ThrowIfNull(parsed.value, "failed to parse serialized signup info; badly formed JSON");
+        tcf::error::ThrowIfNull(parsed.value,
+            "failed to parse serialized signup info; badly formed JSON");
 
         JSON_Object* data_object = json_value_get_object(parsed);
-        tcf::error::ThrowIfNull(data_object, "invalid serialized signup info; missing root object");
+        tcf::error::ThrowIfNull(data_object,
+            "invalid serialized signup info; missing root object");
 
         // --------------- verifying key ---------------
         pvalue = json_object_dotget_string(data_object, "verifying_key");
-        tcf::error::ThrowIfNull(pvalue, "invalid serialized signup info; missing verifying_key");
+        tcf::error::ThrowIfNull(pvalue,
+            "invalid serialized signup info; missing verifying_key");
 
         verifying_key.assign(pvalue);
 
         // --------------- encryption key ---------------
         pvalue = json_object_dotget_string(data_object, "encryption_key");
-        tcf::error::ThrowIfNull(pvalue, "invalid serialized signup info; missing encryption_key");
+        tcf::error::ThrowIfNull(pvalue,
+            "invalid serialized signup info; missing encryption_key");
 
         encryption_key.assign(pvalue);
 
+        // --------------- encryption key signature ---------------
+        pvalue = json_object_dotget_string(data_object,
+            "encryption_key_signature");
+        tcf::error::ThrowIfNull(pvalue,
+            "invalid serialized signup info; missing encryption_key_signature");
+
+        encryption_key_signature.assign(pvalue);
+
         // --------------- proof data ---------------
         pvalue = json_object_dotget_string(data_object, "proof_data");
-        tcf::error::ThrowIfNull(pvalue, "invalid serialized signup info; missing proof_data");
+        tcf::error::ThrowIfNull(pvalue,
+            "invalid serialized signup info; missing proof_data");
 
         proof_data.assign(pvalue);
 
         // --------------- enclave id ---------------
         pvalue = json_object_dotget_string(data_object, "enclave_persistent_id");
-        tcf::error::ThrowIfNull(pvalue, "invalid serialized signup info; missing enclave_persistent_id");
+        tcf::error::ThrowIfNull(pvalue,
+            "invalid serialized signup info; missing enclave_persistent_id");
 
         enclave_persistent_id.assign(pvalue);
     } catch (tcf::error::Error& e) {
@@ -100,7 +114,8 @@ SignupInfo* deserialize_signup_info(
 static tcf_err_t DeserializePublicEnclaveData(
     const std::string& public_enclave_data,
     std::string& verifying_key,
-    std::string& encryption_key) {
+    std::string& encryption_key,
+    std::string& encryption_key_signature) {
     tcf_err_t result = TCF_SUCCESS;
 
     try {
@@ -108,22 +123,34 @@ static tcf_err_t DeserializePublicEnclaveData(
 
         // Parse the incoming wait certificate
         JsonValue parsed(json_parse_string(public_enclave_data.c_str()));
-        tcf::error::ThrowIfNull(parsed.value, "failed to parse the public enclave data, badly formed JSON");
+        tcf::error::ThrowIfNull(parsed.value,
+            "failed to parse the public enclave data, badly formed JSON");
 
         JSON_Object* data_object = json_value_get_object(parsed);
-        tcf::error::ThrowIfNull(data_object, "invalid public enclave data; missing root object");
+        tcf::error::ThrowIfNull(data_object,
+            "invalid public enclave data; missing root object");
 
         // --------------- verifying key ---------------
         pvalue = json_object_dotget_string(data_object, "VerifyingKey");
-        tcf::error::ThrowIfNull(pvalue, "invalid public enclave data; missing VerifyingKey");
+        tcf::error::ThrowIfNull(pvalue,
+            "invalid public enclave data; missing VerifyingKey");
 
         verifying_key.assign(pvalue);
 
         // --------------- encryption key ---------------
         pvalue = json_object_dotget_string(data_object, "EncryptionKey");
-        tcf::error::ThrowIfNull(pvalue, "invalid public enclave data; missing EncryptionKey");
+        tcf::error::ThrowIfNull(pvalue,
+            "invalid public enclave data; missing EncryptionKey");
 
         encryption_key.assign(pvalue);
+
+        // --------------- encryption key signature ---------------
+        pvalue = json_object_dotget_string(data_object,
+            "EncryptionKeySignature");
+        tcf::error::ThrowIfNull(pvalue,
+            "invalid public enclave data; missing EncryptionKeySignature");
+
+        encryption_key_signature.assign(pvalue);
     } catch (tcf::error::Error& e) {
         tcf::enclave_api::base::SetLastError(e.what());
         result = e.error_code();
@@ -144,7 +171,8 @@ std::map<std::string, std::string> CreateEnclaveData(
     ) {
     tcf_err_t presult;
     // Create some buffers for receiving the output parameters
-    StringArray public_enclave_data(0);  // CreateEnclaveData will resize appropriately
+    // CreateEnclaveData will resize appropriately
+    StringArray public_enclave_data(0);
     Base64EncodedString sealed_enclave_data;
     Base64EncodedString enclave_quote;
 
@@ -156,22 +184,23 @@ std::map<std::string, std::string> CreateEnclaveData(
         enclave_quote);
     ThrowTCFError(presult);
 
-    // PyLog(TCF_LOG_DEBUG, public_enclave_data.str().c_str());
-
     // Parse the json and save the verifying and encryption keys
     std::string verifying_key;
     std::string encryption_key;
+    std::string encryption_key_signature;
 
     presult = DeserializePublicEnclaveData(
         public_enclave_data.str(),
         verifying_key,
-        encryption_key);
+        encryption_key,
+        encryption_key_signature);
     ThrowTCFError(presult);
 
     // Save the information
     std::map<std::string, std::string> result;
     result["verifying_key"] = verifying_key;
     result["encryption_key"] = encryption_key;
+    result["encryption_key_signature"] = encryption_key_signature;
     result["sealed_enclave_data"] = sealed_enclave_data;
     result["enclave_quote"] = enclave_quote;
 
@@ -179,29 +208,30 @@ std::map<std::string, std::string> CreateEnclaveData(
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-std::map<std::string, std::string> UnsealEnclaveData(
-    const std::string& sealed_enclave_data) {
+std::map<std::string, std::string> UnsealEnclaveData() {
     tcf_err_t presult;
-    StringArray public_enclave_data(0);  // UnsealEnclaveData will resize appropriately
+    // UnsealEnclaveData will resize appropriately
+    StringArray public_enclave_data(0);
 
-    presult = tcf::enclave_api::enclave_data::UnsealEnclaveData(
-        sealed_enclave_data,
-        public_enclave_data);
+    presult = tcf::enclave_api::enclave_data::UnsealEnclaveData(public_enclave_data);
     ThrowTCFError(presult);
 
     // Parse the json and save the verifying and encryption keys
     std::string verifying_key;
     std::string encryption_key;
+    std::string encryption_key_signature;
 
     presult = DeserializePublicEnclaveData(
         public_enclave_data.str(),
         verifying_key,
-        encryption_key);
+        encryption_key,
+        encryption_key_signature);
     ThrowTCFError(presult);
 
     std::map<std::string, std::string> result;
     result["verifying_key"] = verifying_key;
     result["encryption_key"] = encryption_key;
+    result["encryption_key_signature"] = encryption_key_signature;
 
     return result;
 }  // _unseal_signup_data
@@ -215,5 +245,3 @@ size_t VerifyEnclaveInfo(const std::string& enclaveInfo,
     size_t verify_status = result;
     return verify_status;
 }  // VerifyEnclaveInfo
-
-

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info.h
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info.h
@@ -35,6 +35,7 @@ public:
     // Signup info properties
     std::string verifying_key;
     std::string encryption_key;
+    std::string encryption_key_signature;
     std::string sealed_signup_data;
     std::string proof_data;
     std::string enclave_persistent_id;
@@ -60,8 +61,7 @@ SignupInfo* deserialize_signup_info(
 std::map<std::string, std::string> CreateEnclaveData(
     const std::string& originator_public_key_hash);
 
-std::map<std::string, std::string> UnsealEnclaveData(
-    const std::string& sealed_enclave_data);
+std::map<std::string, std::string> UnsealEnclaveData();
 
 size_t VerifyEnclaveInfo(const std::string& enclaveInfo,
     const std::string& mr_enclave,

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/work_order_wrap.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/work_order_wrap.cpp
@@ -29,17 +29,16 @@
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 std::string HandleWorkOrderRequest(
-    const std::string& sealed_signup_data,
     const std::string& serialized_request) {
     tcf_err_t presult;
 
     uint32_t response_identifier;
     size_t response_size;
 
-    tcf::enclave_queue::ReadyEnclave readyEnclave = tcf::enclave_api::base::GetReadyEnclave();
+    tcf::enclave_queue::ReadyEnclave readyEnclave = \
+        tcf::enclave_api::base::GetReadyEnclave();
 
     presult = tcf::enclave_api::workorder::HandleWorkOrderRequest(
-        sealed_signup_data,
         serialized_request,
         response_identifier,
         response_size,
@@ -48,7 +47,6 @@ std::string HandleWorkOrderRequest(
 
     Base64EncodedString response;
     presult = tcf::enclave_api::workorder::GetSerializedResponse(
-        sealed_signup_data,
         response_identifier,
         response_size,
         response,

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/work_order_wrap.h
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/work_order_wrap.h
@@ -18,5 +18,4 @@
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 std::string HandleWorkOrderRequest(
-    const std::string& sealedSignupData,
     const std::string& serializedRequest);


### PR DESCRIPTION
Generate EncryptionKeySignature and restructure enclave signup process

- EncryptionKeySignature is generated as part of enclave data
- EncryptionKeySignature is made as part of public enclave data
- EnclaveData class is made as singleton so that worker enclave stores the context of enclave data. 
   This avoids sealing of enclave data.
- Multiple APIs which expects sealed data are updated to remove the parameter