### PR TITLE
OpenSSL issue resolution

### DIFF
--- a/blockchain_connector/Dockerfile
+++ b/blockchain_connector/Dockerfile
@@ -72,7 +72,7 @@ WORKDIR /tmp
 
 # Build ("Untrusted") OpenSSL
 RUN OPENSSL_VER=1.1.1d \
- && wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz \
+ && wget https://www.openssl.org/source/old/1.1.1/openssl-$OPENSSL_VER.tar.gz \
  && tar -zxf openssl-$OPENSSL_VER.tar.gz \
  && cd openssl-$OPENSSL_VER/ \
  && ./config \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,7 @@ WORKDIR /tmp
 
 # Build ("Untrusted") OpenSSL
 RUN OPENSSL_VER=1.1.1d \
- && wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz \
+ && wget https://www.openssl.org/source/old/1.1.1/openssl-$OPENSSL_VER.tar.gz \
  && tar -zxf openssl-$OPENSSL_VER.tar.gz \
  && cd openssl-$OPENSSL_VER/ \
  && ./config \

--- a/enclave_manager/Dockerfile
+++ b/enclave_manager/Dockerfile
@@ -83,7 +83,7 @@ WORKDIR /tmp
 
 # Build ("Untrusted") OpenSSL
 RUN OPENSSL_VER=1.1.1d \
- && wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz \
+ && wget https://www.openssl.org/source/old/1.1.1/openssl-$OPENSSL_VER.tar.gz \
  && tar -zxf openssl-$OPENSSL_VER.tar.gz \
  && cd openssl-$OPENSSL_VER/ \
  && ./config \

--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -73,7 +73,7 @@ WORKDIR /tmp
 
 # Build ("Untrusted") OpenSSL
 RUN OPENSSL_VER=1.1.1d \
- && wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz \
+ && wget https://www.openssl.org/source/old/1.1.1/openssl-$OPENSSL_VER.tar.gz \
  && tar -zxf openssl-$OPENSSL_VER.tar.gz \
  && cd openssl-$OPENSSL_VER/ \
  && ./config \


### PR DESCRIPTION
Avalon uses OpenSSL-1.1.1d but recently openssl have done some updates
and the download link for this package is broken. This PR targets to
resolve this issue.

Signed-off-by: pankajgoyal2 <pankaj.goyal@intel.com>