### PR TITLE
Add Fabic proxy model test to ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,12 @@ pipeline {
             }
         }
 
+        stage('Setup fabric network') {
+            steps {
+                sh './scripts/start_fabric.sh -u'
+            }
+        }
+
         stage('Run Avalon Tests') {
             steps {
                 sh 'INSTALL_TYPE="" ./bin/run_tests'

--- a/ci/avalon-tests.yaml
+++ b/ci/avalon-tests.yaml
@@ -17,13 +17,10 @@ version: '3.5'
 services:
   avalon-tests:
     image: avalon-shell:${ISOLATION_ID}
-    build:
-      context: .
-    environment:
-      - http_proxy
-      - https_proxy
-      - no_proxy
     working_dir: "/project/avalon/"
+    volumes:
+      - ~/mywork/vars/keyfiles:/keyfiles
+      - ~/mywork/vars/profiles/mychannel_network_for_pysdk.json:/project/avalon/sdk/avalon_sdk/fabric/network.json
     entrypoint: "bash -c \"\
         ./tools/run_tests.sh -l avalon-listener \""
     depends_on:
@@ -32,11 +29,6 @@ services:
 
   avalon-enclave-manager:
     image: avalon-enclave-manager:${ISOLATION_ID}
-    build:
-      context: .
-      dockerfile: ./enclave_manager/Dockerfile
-      args:
-        - TCF_DEBUG_BUILD=${TCF_DEBUG_BUILD:-}
     environment:
       - http_proxy
       - https_proxy
@@ -51,8 +43,6 @@ services:
 
   avalon-lmdb:
     image: avalon-lmdb:${ISOLATION_ID}
-    build:
-      context: .
     environment:
       - http_proxy
       - https_proxy
@@ -67,8 +57,6 @@ services:
 
   avalon-listener:
     image: avalon-listener:${ISOLATION_ID}
-    build:
-      context: .
     environment:
       - http_proxy
       - https_proxy
@@ -82,3 +70,29 @@ services:
       "
     depends_on:
       - avalon-lmdb
+
+  avalon-blockchain-connector:
+    image: avalon-blockchain-connector:${ISOLATION_ID}
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    command: |
+      bash -c "
+        avalon_blockchain_connector -b fabric -u http://avalon-listener:1947
+        tail -f /dev/null
+        "
+    volumes:
+      # Fabric crypto materials has to be shared to connector to
+      # interact with fabric blockchain
+      - ~/mywork/vars/keyfiles:/keyfiles
+      - ~/mywork/vars/profiles/mychannel_network_for_pysdk.json:/project/avalon/sdk/avalon_sdk/fabric/network.json
+      - ~/mywork/vars/blockmark:/project/avalon/blockchain_connector/blockmark
+    depends_on:
+      - avalon-listener
+      - avalon-enclave-manager
+
+networks:
+  default:
+    external:
+      name: minifab

--- a/ci/docker-compose-build.yaml
+++ b/ci/docker-compose-build.yaml
@@ -57,3 +57,13 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
+
+  avalon-blockchain-connector:
+    image: avalon-blockchain-connector:${ISOLATION_ID}
+    build:
+      context: ..
+      dockerfile: ./blockchain_connector/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -116,6 +116,18 @@ try $generic_client_path/generic_client.py --uri "http://$LISTENER_URL:1947" \
     --workload_id "heart-disease-eval" \
     --in_data "Data: 25 10 1 67  102 125 1 95 5 10 1 11 36 1"
 
+yell "Start testing fabric generic client for echo result workload ................"
+yell "#------------------------------------------------------------------------------------------------"
+try $generic_client_path/fabric_generic_client.py --blockchain fabric \
+    --workload_id "echo-result" \
+    --in_data "Hello Fabric proxy model"
+
+yell "Start testing fabric generic client for heart disease eval workload ................"
+yell "#------------------------------------------------------------------------------------------------"
+try $generic_client_path/fabric_generic_client.py --blockchain fabric \
+    --workload_id "heart-disease-eval" \
+    --in_data "Data: 25 10 1 67  102 125 1 95 5 10 1 11 36 1"
+
 yell "#------------------------------------------------------------------------------------------------"
 yell "#------------------------------------------------------------------------------------------------"
 sleep 10s


### PR DESCRIPTION
1. Added a stage in Jenkin to start the fabric network
2. Add fabric generic client commands to run tests script

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>