### PR TITLE
BUILD.md: Add `git clone` Instruction for Docker Builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,6 +2,7 @@
 Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/
 -->
+
 # Building Hyperledger Avalon
 
 In order to build, install, and run Hyperledger Avalon
@@ -9,9 +10,23 @@ a number of additional components must be installed and configured.
 The following instructions will guide you through the installation and build
 process for Hyperledger Avalon.
 
+If you have not done so already, clone the Avalon source repository.
+Choose whether you want the stable version (recommended) or the most recent
+version
+
+- To use the current stable branch (recommended), run this command:
+  ```bash
+  git clone https://github.com/hyperledger/avalon --branch v0.5-pre-release.4
+  ```
+
+- Or, to use the latest branch, run this command:
+  ```bash
+  git clone https://github.com/hyperledger/avalon
+  ```
+
 You have a choice of [Docker-based build](#dockerbuild)
 or a [Standalone-based build](#standalonebuild).
-The Docker-based build is recommended.
+We recommend the Docker-based build since it is automated and requires fewer steps.
 
 ## Table of Contents
 
@@ -71,25 +86,12 @@ The steps below will set up a Python virtual environment to run Avalon.
 1. Make sure environment variables are set as described in the
    [PREREQUISITES document](PREREQUISITES.md)
 
-2. Choose whether you want the stable version (recommended) or the most recent
-   version
-
-   - To use the current stable branch (recommended), run this command:
-     ```bash
-     git clone https://github.com/hyperledger/avalon --branch v0.5-pre-release.4
-     ```
-
-   - Or, to use the latest branch, run this command:
-     ```bash
-     git clone https://github.com/hyperledger/avalon
-     ```
-
-3. Change to the Avalon source directory
+2. Change to your Avalon source repository cloned above:
    ```bash
    cd avalon
    ```
 
-4. Set `TCF_HOME` to the top level directory of your
+3. Set `TCF_HOME` to the top level directory of your
    `avalon` source repository.
    You will need these environment variables set in every shell session
    where you interact with Avalon.
@@ -100,13 +102,13 @@ The steps below will set up a Python virtual environment to run Avalon.
    echo "export TCF_HOME=$TCF_HOME" >> ~/.bashrc
    ```
 
-5. If you are using Intel SGX hardware, check that `SGX_MODE=HW` before
+4. If you are using Intel SGX hardware, check that `SGX_MODE=HW` before
    building the code.
    If you are not using Intel SGX hardware, check that `SGX_MODE` is not
    set or set to `SGX_MODE=SIM` .
    By default `SGX_MODE=SIM` , indicating use the Intel SGX simulator.
 
-6. If you are not using Intel SGX hardware, go to the next step.
+5. If you are not using Intel SGX hardware, go to the next step.
    Check that `TCF_ENCLAVE_CODE_SIGN_PEM` is set.
    Refer to the [PREREQUISITES document](PREREQUISITES.md)
    for more details on these variables.
@@ -123,7 +125,7 @@ The steps below will set up a Python virtual environment to run Avalon.
    ias_api_key = '<ias subscription key obtained from portal>'
    ```
 
-7. If you are behind a corporate proxy, then in file
+6. If you are behind a corporate proxy, then in file
    `$TCF_HOME/config/tcs_config.toml` uncomment and update the
    `https_proxy` line:
 
@@ -134,14 +136,14 @@ The steps below will set up a Python virtual environment to run Avalon.
    If you are not behind a corporate proxy (the usual case),
    then leave this line commented out.
 
-8. Create a Python virtual environment:
+7. Create a Python virtual environment:
 
    ```bash
    cd $TCF_HOME/tools/build
    python3 -m venv _dev
    ```
 
-9. Activate the new Python virtual environment for the current shell session.
+8. Activate the new Python virtual environment for the current shell session.
    You will need to do this in each new shell session (in addition to
    exporting environment variables).
    ```bash
@@ -151,41 +153,17 @@ The steps below will set up a Python virtual environment to run Avalon.
    If the virtual environment for the current shell session is activated,
    you will the see this prompt: `(_dev)`
 
-10. Install PIP3 packages into your Python virtual environment:
+9. Install PIP3 packages into your Python virtual environment:
 
-    ```bash
-    pip3 install --upgrade setuptools json-rpc py-solc-x web3 colorlog twisted wheel toml
-    ```
+   ```bash
+   pip3 install --upgrade setuptools json-rpc py-solc-x web3 colorlog twisted wheel toml
+   ```
 
-11. Build and install Avalon components:
+10. Build Avalon components:
 
     ```bash
     make clean
     make
-    ```
-
-12. Build the Avalon SDK Python module:
-
-    ```bash
-    cd $TCF_HOME/sdk
-    make
-    make install
-    ```
-
-13. Build the shared key/value storage modules:
-
-    ```bash
-    cd $TCF_HOME/shared_kv_storage
-    make
-    make install
-    ```
-
-14. Build the Avalon Listener module:
-
-    ```bash
-    cd $TCF_HOME/listener
-    make
-    make install
     ```
 
 # <a name="testing"></a>Testing


### PR DESCRIPTION
A `git clone` is needed for Docker builds, not just
standalone builds.

Signed-off-by: danintel <daniel.anderson@intel.com>