### PR TITLE
Fix Example Documentation

### DIFF
--- a/examples/apps/echo/README.md
+++ b/examples/apps/echo/README.md
@@ -10,7 +10,41 @@ which echos back the same message back to the client.
 For command line options, type `./echo_client.py -h` from the
 `client` directory.
 
-To use:
+```
+usage: echo_client.py [-h] [-c CONFIG]
+                      [-r REGISTRY_LIST | -s SERVICE_URI | -o] [-w WORKER_ID]
+                      [-m MESSAGE] [-rs] [-dh]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CONFIG, --config CONFIG
+                        the config file containing the Ethereum contract
+                        information
+  -r REGISTRY_LIST, --registry-list REGISTRY_LIST
+                        the Ethereum address of the registry list
+  -s SERVICE_URI, --service-uri SERVICE_URI
+                        skip URI lookup and send to specified URI
+  -o, --off-chain       skip URI lookup and use the registry in the config
+                        file
+  -w WORKER_ID, --worker-id WORKER_ID
+                        skip worker lookup and retrieve specified worker
+  -m MESSAGE, --message MESSAGE
+                        text message to be included in the JSON request
+                        payload
+  -rs, --requester-signature
+                        Enable requester signature for work order requests
+  -dh, --data-hash      Enable input data hash for work order requests
+```
+
+The Avalon Listener uses TCP port 1947, so the default URI is
+`http://localhost:1947` .
+If you are using Docker, add `-s "http://avalon-listener:1947"`
+to the command line.
+
+## Using the Echo Client
+
+The echo client client `echo_client.py` allows you to submit
+echo requests to the echo worker on the command line.
 
 1.  If needed, update the Ethereum account and direct registry contract
     information in `sdk/avalon_sdk/tcf_connector.toml`
@@ -19,9 +53,17 @@ To use:
     (activating a virtual environment)
 3.  Terminal 1 is running the Avalon Enclave Manager and Listener with
     `docker-compose` . Terminal 2 is running the Docker container shell
-4.  In Terminal 2 run `cd $TCF_HOME/examples/apps/echo/client`
-5.  In Terminal 2, run `./echo_client.py -m "Hello world"` .
-    Use the `-h` option to see other available options.
+4.  In Terminal 2 change to the echo client directory
+    ```bash
+    cd $TCF_HOME/examples/apps/echo/client
+    ```
+5.  In Terminal 2, run
+    ```bash
+    ./echo_client.py -s "http://avalon-listener:1947" -m "Hello world"
+    ```
+
+    If running in Standalone mode (without Docker), omit the `-s` option,
+    so the client uses the default listener at `http://localhost:1947`
 6.  You will see output showing the following:
     1. The client searches the registry for an "echo" worker
     2. The client sends a request to the worker

--- a/examples/apps/generic_client/README.md
+++ b/examples/apps/generic_client/README.md
@@ -40,9 +40,9 @@ optional arguments:
 ```
 
 The `--mode` option is used only with an Ethereum smart contract address.
-Currently only “listing” mode is supported.
-This will fetch the uri from ethereum blockchain, do a worker lookup to fetch
-worker details of first worker in the list, and submit work order.
+Currently only "listing" mode is supported.
+This will fetch the URI from the Ethereum blockchain, do a worker lookup to fetch
+worker details of first worker in the list, and submit the work order.
 
 If `--uri` is passed, `--mode` is not used. It will fetch the worker details
 from the LMDB database and submit work order to the first available worker.
@@ -53,11 +53,11 @@ to the command line.
 
 ## Using the Generic Client
 
-The command line client `generic_client.py` allows you to submit
+Running `generic_client.py` allows you to submit
 worker requests on the command line.
 
 1. If needed, update the Ethereum account and direct registry contract
-   information in `sdk/avalon_sdk/tcf_connector.toml`
+   information in `$TCF_HOME/sdk/avalon_sdk/tcf_connector.toml`
 2. Follow the build instructions in the
    [build document](../../../BUILD.md)
 3. Install the Solidity compiler:
@@ -76,40 +76,39 @@ worker requests on the command line.
 
 ### Echo workload using a URI
 ```bash
-./generic_client.py --uri "http://localhost:1947" \
+./generic_client.py -o --uri "http://localhost:1947" \
     --workload_id "echo-result" --in_data "Hello"
 ```
 
 Add or change the `--uri` parameter if using Docker:
 ```bash
-./generic_client.py --uri "http://avalon-listener:1947" \
+./generic_client.py -o --uri "http://avalon-listener:1947" \
     --workload_id "echo-result" --in_data "Hello"
 ```
 
 Or omit the URI if you use the default URI (standalone mode) :
 ```bash
-./generic_client.py --workload_id "echo-result" --in_data "Hello"
+./generic_client.py -o --workload_id "echo-result" --in_data "Hello"
 ```
 
 ### Heart disease eval workload using a URI
 Standalone mode (no Docker):
 ```bash
-./generic_client.py --uri "http://localhost:1947" \
+./generic_client.py -o --uri "http://localhost:1947" \
     --workload_id "heart-disease-eval" \
     --in_data "Data: 25 10 1 67  102 125 1 95 5 10 1 11 36 1"
 ```
 
 With Docker:
 ```bash
-./generic_client.py --uri "http://avalon-listener:1947" \
+./generic_client.py -o --uri "http://avalon-listener:1947" \
     --workload_id "heart-disease-eval" \
     --in_data "Data: 25 10 1 67  102 125 1 95 5 10 1 11 36 1"
 ```
 
 ### Echo workload using registry listing smart contract address
 ```bash
-./generic_client.py \
+./generic_client.py -o \
     --address "0x9Be28B132aeE1b2c5A1C50529a636cEd807842cd" --mode "listing" \
     --workload_id "echo-result" --in_data "Hello"
 ```
-


### PR DESCRIPTION
- generic_client: Add `-o` option to examples to show decrypted results
- echo: add usage
- echo: add `-s` option for use with Docker

Signed-off-by: danintel <daniel.anderson@intel.com>