### PR TITLE
Update Stable Branch to pre-release-v0.5

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -16,7 +16,7 @@ version
 
 - To use the current stable branch (recommended), run this command:
   ```bash
-  git clone https://github.com/hyperledger/avalon --branch v0.5-pre-release.4
+  git clone https://github.com/hyperledger/avalon --branch pre-release-v0.5
   ```
 
 - Or, to use the latest branch, run this command:


### PR DESCRIPTION
Update stable branch to `pre-release-v0.5`,
which uses the new OpenSSL 1.1.1d download URL.

Signed-off-by: danintel <daniel.anderson@intel.com>