### PR TITLE
Cleanup Base64 Decoding

### DIFF
--- a/common/cpp/crypto/crypto_utils.cpp
+++ b/common/cpp/crypto/crypto_utils.cpp
@@ -39,8 +39,6 @@
 #include <openssl/crypto.h>
 #include <stdio.h>
 
-// memcpy_s definition is not present in std C library, hence mapping to memcpy
-#define memcpy_s(dest, dest_size, src, count) memcpy(dest, src, count)
 #else
 #include "tSgxSSL_api.h"
 #endif
@@ -89,36 +87,6 @@ ByteArray pcrypto::ComputeMessageHash(const ByteArray& message) {
     SHA256((const unsigned char*)message.data(), message.size(), hash.data());
     return hash;
 }  // pcrypto::ComputeMessageHash
-
-
-int pcrypto::EVP_DecodeBlock_wrapper(unsigned char* out,
-                                     int out_len,
-                                     const unsigned char* in,
-                                     int in_len) {
-    /* Use a temporary output buffer. We do not want to disturb the
-       original output buffer with extraneous \0 bytes. */
-    unsigned char buf[in_len];
-
-    int ret = EVP_DecodeBlock(buf, in, in_len);
-    assert(ret != -1);
-    if (in[in_len - 1] == '=' && in[in_len - 2] == '=')
-    {
-        ret -= 2;
-    }
-    else if (in[in_len - 1] == '=')
-    {
-        ret -= 1;
-    }
-
-    memcpy_s(out, out_len, buf, ret);
-    return ret;
-}
-
-int pcrypto::decode_base64_block(unsigned char *decoded_data,
-                                 const unsigned char *base64_data,
-                                 int num_of_blocks) {
-    return EVP_DecodeBlock(decoded_data, base64_data, num_of_blocks);
-}
 
 
 /** Create symmetric encryption key and return hex encoded key string. */

--- a/common/cpp/crypto/crypto_utils.h
+++ b/common/cpp/crypto/crypto_utils.h
@@ -34,18 +34,6 @@ namespace crypto {
     // throws RuntimeError
     ByteArray RandomBitString(size_t length);
 
-    /** Wrapper function for EVP_DecodeBlock.
-     * EVP_DecodeBlock pads its output with \0 if the output length
-     * is not a multiple of 3. Check if the base64 string is padded at the end
-     * and adjust the output length.
-     */
-    int EVP_DecodeBlock_wrapper(unsigned char* out, int out_len,
-        const unsigned char* in, int in_len);
-
-    /** Decodes specified number of blocks of base64 encoded data. */
-    int decode_base64_block(unsigned char *decoded_data,
-        const unsigned char *base64_data, int num_of_blocks);
-
     /** Create symmetric encryption key and return hex encoded key string. */
     std::string CreateHexEncodedEncryptionKey();
 

--- a/common/cpp/packages/base64/base64.cpp
+++ b/common/cpp/packages/base64/base64.cpp
@@ -30,8 +30,9 @@
 */
 
 /*
-    The original source code has been modified to be used with Trusted Compute Framework (TCFs).
-*/
+ * The original source code has been modified to be used with
+ * Hyperledger Avalon.
+ */
 
 
 #include "base64.h"

--- a/common/cpp/packages/base64/base64.h
+++ b/common/cpp/packages/base64/base64.h
@@ -4,8 +4,9 @@
 //
 
 /*
-    The original source code has been modified to be used with Trusted Compute Framework (TCFs).
-*/
+ * The original source code has been modified to be used with
+ * Hyperledger Avalon.
+ */
 
 #pragma once
 


### PR DESCRIPTION
In verify_signature(), replace call to EVP_DecodeBlock_wrapper()
with EVP_DecodeBlock.

Remove redundant and unused functions
decode_base64_block() and EVP_DecodeBlock_wrapper().

Signed-off-by: danintel <daniel.anderson@intel.com>