### PR TITLE
Change the RSA Public Key serialization to FC2437

### DIFF
--- a/common/cpp/crypto/pkenc_public_key.cpp
+++ b/common/cpp/crypto/pkenc_public_key.cpp
@@ -59,7 +59,7 @@ RSA* deserializeRSAPublicKey(const std::string& encoded) {
         throw Error::RuntimeError(msg);
     }
 
-    RSA* public_key = PEM_read_bio_RSAPublicKey(bio.get(), NULL, NULL, NULL);
+    RSA* public_key = PEM_read_bio_RSA_PUBKEY(bio.get(), NULL, NULL, NULL);
     if (!public_key) {
         std::string msg(
             "Crypto Error (deserializeRSAPublicKey): Could not "
@@ -163,7 +163,7 @@ std::string pcrypto::pkenc::PublicKey::Serialize() const {
         throw Error::RuntimeError(msg);
     }
 
-    int res = PEM_write_bio_RSAPublicKey(bio.get(), public_key_);
+    int res = PEM_write_bio_RSA_PUBKEY(bio.get(), public_key_);
     if (!res) {
         std::string msg("Crypto Error (Serialize): Could not write to BIO");
         throw Error::RuntimeError(msg);


### PR DESCRIPTION
I recommend a small change in the code to make the "encryptionKey"  json field comply with PKCS 1. This is achieved by using PEM_..._bio_RSA_PUBKEY methods instead of PEM_..._bio_RSAPublicKey ones. 
This would make interop with Java, Go, etc., actually working.
Currently the encoded format is something like:
0  135: SEQUENCE {
   3  129:   INTEGER
         :     00 C6 E9 382 [...]
 135    1:   INTEGER 3
         :   }

The new structure (with the standard RSA OID) would be:

0  157: SEQUENCE {
   3   13:   SEQUENCE {
   5    9:     OBJECT IDENTIFIER rsaEncryption (1 2 840 113549 1 1 1)
  16    0:     NULL
         :     }
  18  139:   BIT STRING, encapsulates {
  22  135:     SEQUENCE {
  25  129:       INTEGER
         :         00 C7 6F [..] 
   157    1:       INTEGER 3
         :       }
         :     }
         :   }