### PR TITLE
Change RSA-2048 to RSA-3072

### DIFF
--- a/common/cpp/crypto/pkenc.h
+++ b/common/cpp/crypto/pkenc.h
@@ -20,7 +20,7 @@ namespace crypto {
     namespace constants {
         //***RSA is not quantum resistant ***//
         //*** USE 3072 for long term security ***//
-        const int RSA_KEY_SIZE = 2048;
+        const int RSA_KEY_SIZE = 3072;
         const int RSA_PADDING_SIZE = 41;
 
         //*** OAEP or better should always be used for RSA encryption ***//


### PR DESCRIPTION
Change RSA key size from 2048 to 3072 bits.
This is as documented in common/cpp/crypto/README:

> Cryptographic Primitives Used
> -----------------------------
> | Primitive             | Algorithm | Keysize | Comments |
> | --------------------- | --------- | ------- | -------- |
> | Asymmetric encryption | RSA-OAEP  | 3072    | (1)      |
> (1) Not PQ resistant

Fixes issue #433.