### PR TITLE
Documentation Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,22 @@ Hyperledger Avalon uses the
 defined by Enterprise Ethereum Alliance (EEA) Task Force as a starting point to
 apply a consistent and compatible approach to all supported blockchains.
 
-Hyperledger Avalon architecture can be found [_avalon-arch.pdf_](docs/avalon-arch.pdf).
+For more details on Hyperledger Avalon architecture, see
+[_avalon-arch.pdf_](docs/avalon-arch.pdf).
+
+## Building
+
+To build Hyperledger Avalon, follow instructions in the
+[build document](BUILD.md).
+
+## Documentation
+
+[Hyperledger Avalon Documentation](https://hyperledger.github.io/avalon/)
+
+## Contributing
+
+See the [contributing document](CONTRIBUTING.md)
+for information on how to contribute and the guidelines for contributions.
 
 ## Initial Committers
 * Manjunath A C (manju956)
@@ -54,19 +69,6 @@ Hyperledger Avalon architecture can be found [_avalon-arch.pdf_](docs/avalon-arc
 ## Sponsor
 * Mic Bowman (cmickeyb) - TSC member
 
-## Building
-
-To build Hyperledger Avalon, follow instructions in the [build document](BUILD.md).
-
-## Documentation
-
-[Hyperledger Avalon Documentation](https://hyperledger.github.io/avalon/)
-
-## Contributing
-
-See the [contributing document](CONTRIBUTING.md)
-for information on how to contribute and the guidelines for contributions.
-
 ## License
 Hyperledger Avalon is released under the Apache License
 Version 2.0 software license. See the [license file](LICENSE) for more details.
@@ -75,4 +77,4 @@ Hyperledger Avalon documentation is licensed under the
 Creative Commons Attribution 4.0 International License. You may obtain a copy
 of the license at: http://creativecommons.org/licenses/by/4.0/.
 
-© Copyright 2019, Intel Corporation.
+© Copyright 2019-2020, Intel Corporation.

--- a/common/cpp/README.md
+++ b/common/cpp/README.md
@@ -1,12 +1,13 @@
-<!---
+<!--
 Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/
---->
+-->
 
-Purpose of Common
------------------
-The common directory contains source code shared by untrusted and trusted
-(Intel SGX Enclave) code.
+Purpose of C++ Common Hyperledger Avalon Code
+=============================================
+
+The cpp directory contains C++ source code shared by untrusted and trusted
+(Intel SGX Enclave) Hyperledger Avalon code.
 
 Dependencies:
 -------------
@@ -22,17 +23,22 @@ https://software.intel.com/en-us/sgx-sdk/download
 Source Directories
 ------------------
 
-Dir                     Content
----------------------   ------------------------------------------------------
-`crypto/`               \*.cpp,\*.h for OpenSSL based crypto functions.
-                        For more information, see
-                        [crypto/README.md](crypto/README.md)
-
-`.`                     \*.cpp,\*.h error handling and common types
-
-`packages/base64/`      \*.cpp,\*.h of Renee Nyffinger base64 encoding/decoding
-
-`packages/parson/`      \*.cpp,\*.h of Parson JSON  encoding/decoding
+* `.` <br />
+   \*.cpp,\*.h error handling, data conversion, utilities,
+   and common types
+* `crypto/` <br />
+   \*.cpp,\*.h for OpenSSL-based cryptographic functions.
+   For more information, see
+   [crypto/README.md](crypto/README.md)
+* `packages/base64/` <br />
+   \*.cpp,\*.h of Renee Nyffinger base64 encoding/decoding
+* `packages/parson/` <br />
+   \*.cpp,\*.h of Parson JSON encoding/decoding
+* `tests/` <br />
+  \*.cpp,\*.h of standalone unit test programs for these
+   common cpp source files.
+   For more information, see
+   [tests/README.md](tests/README.md)
 
 Python Wrapper
 --------------

--- a/common/cpp/crypto/README.md
+++ b/common/cpp/crypto/README.md
@@ -3,11 +3,11 @@ Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/
 -->
 
-Common Crypto library documentation
-===================================
+Hyperledger Avalon Common Crypto Library
+========================================
 
 This `common/cpp/crypto/` directory contains cryptographic code used by
-untrusted and trusted (Intel SGX Enclave) code.
+untrusted and trusted (Intel SGX Enclave) Hyperledger Avalon code.
 
 This code is written in C++, but a Python wrapper is also available
 (see [../README.md](../README.md))
@@ -29,15 +29,15 @@ OpenSSL 1.1 library and Intel SGX OpenSSL library built from OpenSSL 1.1:
 Cryptographic Primitives Used
 -----------------------------
 
-| Primitive | Algorithm | Keysize | Comments |
-| --------- | --------- | ------- | -------- |
-| Digital signature | ECDSA-SECP256K1 | 256 | (1) (2) |
-| Asymmetric encryption | RSA-OAEP | 3072 | (1) |
-| Authenticated encryption | AES-GCM | 256 | 96b IV, 128b tag |
-| Digest | SHA-256 | 256 | (2) |
-| Digest | KECCACK | 256 | (2) Differs from SHA-3 |
+| Primitive                | Algorithm       | Keysize | Comments |
+| ---------                | ---------       | ------- | -------- |
+| Digital signature        | ECDSA-SECP256K1 | 256     | (1) (2) |
+| Asymmetric encryption    | RSA-OAEP        | 3072    | (1) |
+| Authenticated encryption | AES-GCM         | 256     | 96b IV, 128b tag |
+| Digest                   | SHA-256         | 256     | (2) |
+| Digest                   | KECCACK         | 256     | (2) Differs from SHA-3 |
 
-(1) Not PQ resistant
+(1) Not post-quantum crypto (PQ) resistant
 
 (2) Blockchain legacy algorithm
 
@@ -46,20 +46,24 @@ Cryptographic Primitive Usage
 -----------------------------
 
 * **SHA-256** Computing digests of the work order request and response
-* **KECCAK-256** Computing digests of the work order request and response or Ethereum raw transactions Packet bytes
-* **AES-GCM-256** Encrypts data items within work order request and response. It also used to encrypt a request digest and custom data encryption keys
+* **KECCAK-256** Computing digests of the work order request and response
+  or Ethereum raw transactions Packet bytes
+* **AES-GCM-256** Encrypts data items within work order request and response.
+  It also used to encrypt a request digest and custom data encryption keys
 * **RSA-OAEP-3072** Encrypt symmetric data encryption keys
-* **ECSDA-SECP256K1** Signs work order response digest and worker’s encryption RSA-OAEP public key
+* **ECSDA-SECP256K1** Signs work order response digest and
+  worker’s encryption RSA-OAEP public key
 
 
 Implementation of Cryptographic Elements
 ----------------------------------------
 
-Cryptographic elements include cryptographic keys, signature, ciphertexts, plaintexts, hashes, and random bitstrings.
+Cryptographic elements include cryptographic keys, signature, ciphertexts,
+plaintexts, hashes, and random bitstrings.
 
 | Element | Implementation | Representation | Serialize/Deserialize function? |
 | ------- | -------------- | -------------- | ------------------------------- |
-| ECDSA public key | C++ class | Custom object | Yes, PEM encoding and 65-byte Bitcoin Hex format |
+| ECDSA public key       | C++ class  | Custom object | Yes, PEM encoding and 65-byte Bitcoin Hex format |
 | ECDSA private key      | C++ class  | Custom object | Yes, PEM encoding     |
 | ECDSA signature        | C++ string | DER binary    | No, user defined      |
 | RSA public key         | C++ class  | Custom object | Yes, PEM encoding     |

--- a/common/sgx_workload/README.md
+++ b/common/sgx_workload/README.md
@@ -1,12 +1,14 @@
-<!---
+<!--
 Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/
---->
+-->
 
-Purpose of Common
------------------
-The common directory contains source code shared by trusted (Intel SGX Enclave)
-code and different workloads(Example workloads).
+Purpose of Common SGX Workload Hyperledger Avalon Code
+======================================================
+
+The common/sgx_workload directory contains source code
+shared by trusted (Intel SGX Enclave) code and
+different workloads (example workloads).
 
 Dependencies:
 -------------
@@ -19,15 +21,15 @@ https://github.com/intel/intel-sgx-ssl
 Source Directories
 ------------------
 
-Dir                     Content
----------------------   ------------------------------------------------------
-`sgx/iohandler/`         \*.cpp,\*.h files are custom iohandlers which help
-                        workloads to execute IO operations from the
-                        Intel SGX enclave
+`sgx/iohandler/` <br />
+  \*.cpp,\*.h files are custom iohandlers which help
+  workloads to execute IO operations from the
+  Intel SGX enclave
 
-`sgx/workload/`         work_order_data.cpp,work_order_data.h files are wrapper
-                        files for work order data   
-                        workload_processor.cpp, workload_processor.h are
-                        workload processor which overrides function exposed
-                        by work order interface and also facilitates
-                        auto registration of workloads
+`sgx/workload/` <br />
+  - work_order_data.cpp,work_order_data.h files are wrapper
+    files for work order data
+  - workload_processor.cpp, workload_processor.h are
+    workload processor which overrides function exposed
+    by work order interface and also facilitates
+    auto registration of workloads

--- a/docker/k8s/README.md
+++ b/docker/k8s/README.md
@@ -1,19 +1,25 @@
-# Kubernetes playground for Avalon 
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
 
-This serves as a playground for developing 
+# Kubernetes playground for Hyperledger Avalon
+
+This serves as a playground for developing
 [hyperledger/avalon](https://github.com/hyperledger/avalon)
 in SGX-SIM and SGX-HW mode.
 
 ## Prerequisites
 - kubectl-v1.15.2
-- A Kubernetes cluster. [Minikube] (https://kubernetes.io/docs/setup/learning-environment/minikube/)
+- A Kubernetes cluster.
+  [Minikube] (https://kubernetes.io/docs/setup/learning-environment/minikube/)
   can be used to setup a single node Kubernetes cluster.
 - To enable Intel SGX HW mode, follow the instructions in
   [PREREQUISITES.md](../../PREREQUISITES.md#intel-sgx-in-hardware-mode)
-- To use Intel SGX HW mode, build docker image using below command  
+- To use Intel SGX HW mode, build docker image using below command
   `docker-compose -f docker-compose-sgx.yaml build`
 
-## Running 
+## Running Avalon with Kubernetes
 
 1. Start Shared KV database service.
     ```bash
@@ -29,13 +35,15 @@ in SGX-SIM and SGX-HW mode.
     ```bash
     kubectl create -f sgx-enclave-manager-deployment.yaml
     ```
-3.  Start `http jrpc Listener service` (to accept and handle http jrpc requests from clients)
+3.  Start `http jrpc Listener service`
+    (to accept and handle http jrpc requests from clients)
     ```bash
     kubectl create -f listener.yaml
     ```
 
 ## Propose a workload request to be executed
-1. Before sending a workload request check if sharedkv, enclave manager and listener pods are running
+1. Before sending a workload request check if sharedkv, enclave manager and
+   listener pods are running
     ```bash
     kubectl get pods
     ```
@@ -53,12 +61,13 @@ in SGX-SIM and SGX-HW mode.
     ```bash
     # Get the workload request pod name using command
     kubectl get pods
-    # Let's say 'propose-request-abcde' is the job pod created above. Check the logs
+    # Let's say 'propose-request-abcde' is the job pod created above.
+    # Check the logs
     kubectl logs propose-request-abcde
 
     # The partial output for the last query should be as follows
-    [23:20:36 INFO    __main__] Signature Verified
-    [23:20:36 INFO    utility.utility] Decryption Result at Client - You have a risk of 47% to have heart disease.
+    [23:20:36 INFO __main__] Signature Verified
+    [23:20:36 INFO utility.utility] Decryption Result at Client - You have a 47% risk of heart disease.
     ```
 
 ## Create Avalon shell pod
@@ -66,14 +75,17 @@ in SGX-SIM and SGX-HW mode.
     ```bash
     kubectl create -f shell.yaml
     ```
-2. After verifying avalon shell pod is running, get a shell to the running container
+2. After verifying avalon shell pod is running,
+   get a shell to the running container
     ```bash
     # Get the Avalon shell pod name using command
     kubectl get pods
-    # Let's say 'avalon-shell-abcde' is the pod created above. Get into the shell
+    # Let's say 'avalon-shell-abcde' is the pod created above.
+    # Get into the shell
     kubectl exec -it avalon-shell-abcde -- /bin/bash
     ```
-3. To execute test cases from shell, refer to testing section in [BUILD.md](../../BUILD.md#testing)
+3. To execute test cases from shell, refer to testing section in
+   [BUILD.md](../../BUILD.md#testing)
 
 # Heads up
 - All the resources specified in yaml are using the images built locally.

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -195,8 +195,15 @@ There was a PR to add Java, for example.
 
 What TCP ports does Avalon use?
 -------------------------------
-- TCP 1947: connections to Avalon listener from Avalon clients
-- TCP 9090: connections to LMDB listener for KV Storage
+- TCP 1947: connections to Avalon listener from Avalon clients.
+  The URL is ``http://localhost:1947/`` or, for Docker,
+  ``http://avalon-listener:9090/``
+- TCP 9090: connections to LMDB listener for KV Storage.
+  The URL is ``http://localhost:9090/`` or, for Docker,
+  ``http://avalon-lmdb:9090/``
+- TCP 5555: connections to Avalon Enclave Manager from Avalon Listener.
+  The URL is ``tcp://localhost:5555`` or, for Docker,
+  ``tcp://avalon-enclave-manager:5555``
 
 What cryptography does Avalon use?
 ----------------------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
 # Hyperledger Avalon Documentation
 
 ## Introduction
@@ -37,12 +41,15 @@
 * [Contributing source code](../CONTRIBUTING.md)
 
 ## SDK Reference Manual
-The [Hyperledger Avalon SDK Reference Manual](https://danintel.github.io/refman.pdf)
-(also available as a [PDF](https://danintel.github.io/refman.pdf) file)
-documents the SDK used to create worker order requestors (clients) and processors.
+The
+[Hyperledger Avalon SDK Reference Manual](https://hyperledger.github.io/avalon/)
+(also available as a [PDF](https://hyperledger.github.io/avalon/refman.pdf)
+file)
+documents the SDK used to
+create worker order requestors (clients) and processors.
 
 The Avalon SDK Reference Manual is generated with Doxygen.
-To generate the Reference Manual, type the following:
+To generate the Reference Manual using this repository, type the following:
 ```
 cd $TCF_HOME/docs # this directory
 sudo apt-get update

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -1,4 +1,9 @@
-# Avalon Example Applications
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
+
+# Hyperledger Avalon Example Applications
 
 The following Avalon example applications are available.
 They are intended as introductions to the Avalon API to learn how to
@@ -18,4 +23,3 @@ create and write new applications.
 
 - [Generic Workload Client](generic_client)
   This is a generic client for testing with any worker
-

--- a/examples/apps/echo/README.md
+++ b/examples/apps/echo/README.md
@@ -1,4 +1,9 @@
-# Echo Demo Application
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
+
+# Echo Demo Hyperledger Avalon Application
 
 This simple demo application echos back the same message sent from
 the client to the worker.

--- a/examples/apps/eea_token/README.md
+++ b/examples/apps/eea_token/README.md
@@ -1,4 +1,9 @@
-# EEA Token Execution Example Application
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
+
+# EEA Token Execution Example Hyperledger Avalon Application
 
 The EEA Token Execution application demonstrates running
 EEA execution logic based on token requests.

--- a/examples/apps/generic_client/README.md
+++ b/examples/apps/generic_client/README.md
@@ -1,4 +1,9 @@
-# Generic Workload Client
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
+
+# Generic Hyperledger Avalon Workload Client
 
 This is a generic command line client intended to work with any
 workload application. The intention is to get up to speed quickly
@@ -6,7 +11,7 @@ in application development by providing a generic client that works
 with any worker.
 
 The client application accepts only strings as input parameters and assumes
-that all outputs returned from the woorkload application are also provided
+that all outputs returned from the workload application are also provided
 as strings. If other data types are needed (such as numbers or binaries),
 then create a custom test application
 (potentially by modifying this application)

--- a/examples/apps/heart_disease_eval/README.md
+++ b/examples/apps/heart_disease_eval/README.md
@@ -1,4 +1,9 @@
-# Running the Heart Disease Evaluation Demo
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
+
+# Running the Heart Disease Evaluation Hyperledger Avalon Demo
 
 This demo performs a heart disease evaluation based on input parameters.
 Three clients are available: batch command line client,

--- a/examples/apps/inside_out_demo/README.md
+++ b/examples/apps/inside_out_demo/README.md
@@ -1,9 +1,15 @@
-# Demo Application to execute file i/o operations from the Intel SGX enclave
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
 
-This simple demo application executes file operations such as read and write
+# Inside Out File I/O Demo Hyperledger Avalon Application
+
+This simple demo application executes file I/O operations, such as read and write, from inside the Intel SGX enclave,
 based on the input from the user.
+This allows access inside the enclave to files outside the enclave, so is sometimes called Inside/Out I/O.
 
-## Using the Generic Command Line Client to execute file I/O from the Intel SGX enclave
+## Using the Generic Command Line Client to execute file I/O
 
 The generic command line client, `generic_client.py`, sends an input request
 with file operation, filepath, content to be written, etc. to the worker
@@ -24,8 +30,9 @@ To use:
 
 To read a file:
 
-5.  In Terminal 2, run `./generic_client.py --workload_id "inside-out-eval" --in_data "read <file>" -o` .
-    File parameter should point to an absolute path which can be accessed by
+5.  In Terminal 2, run
+    `./generic_client.py --workload_id "inside-out-eval" --in_data "read <file>" -o` .
+    The file parameter should point to an absolute path which can be accessed by
     the enclave manager.
     For example, if the enclave manager is running in a Docker container, the
     file path could be `/project/trusted-compute-framework/tests/read.txt` .
@@ -33,8 +40,9 @@ To read a file:
 
 To write a file:
 
-5. In Terminal 2, run `./generic_client.py --workload_id "inside-out-eval" --in_data "write <file> <content-to-be-written>" -o` .
-   File parameter should point to an absolute path which can be accessed by
+5. In Terminal 2, run
+   `./generic_client.py --workload_id "inside-out-eval" --in_data "write <file> <content-to-be-written>" -o` .
+   The file parameter should point to an absolute path which can be accessed by
    the enclave manager.
    For example, if the enclave manager is running in a Docker container, the
    file path could be `/project/trusted-compute-framework/tests/write.txt` .

--- a/examples/apps/simple_wallet/README.md
+++ b/examples/apps/simple_wallet/README.md
@@ -1,14 +1,20 @@
-# Simple Wallet Demo Application
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
+
+# Simple Wallet Demo Hyperledger Avalon Application
 
 This application demonstrates basic wallet transactions like deposit, withdraw
-and transfer by accessing encrypted wallet ledger file using inside-out API and
-applying crypto operations on the ledger data.
+and transfer. It accesses an encrypted wallet ledger file using the
+inside-out API and applying crypto operations on the ledger data.
 
 ## Using the Generic Command Line Client to execute Simple Wallet operations
 
-Generic command line client, `generic_client.py` sends an input request
-with transaction type, account identifier(s), and amount to the worker
-which stores stores wallet details in encrypted ledger using inside-out API.
+The generic command line client, `generic_client.py` sends an input request
+with transaction type, account identifier(s), and amount to the worker.
+The worker stores stores wallet details in an encrypted ledger using the
+inside-out API.
 The encrypted ledger data is then decrypted by the workload by making use of
 crypto functions. Once the balance is updated, the result is encrypted and
 written to ledger using file I/O. Both encryption and decryption of the

--- a/examples/common/java/direct/worker/README.md
+++ b/examples/common/java/direct/worker/README.md
@@ -1,3 +1,8 @@
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
+
 # eea-worker
 
 ### Overview
@@ -24,4 +29,3 @@ gradle bootRun --refresh-dependencies
 cd eea-worker
 ./gradlew bootRun --refresh-dependencies
 ```
-


### PR DESCRIPTION
-Point to New Hyperledger Avalon Documentation Website

https://hyperledger.github.io/avalon/

This is populated from the `gh-pages` branch of the Avalon repo:
    https://github.com/hyperledger/avalon/tree/gh-pages
This branch is created from Doxygen-generated source built in `docs/Makefile` .

-Add URLs for Avalon Listener, LMDB, and ZMQ

Signed-off-by: danintel <daniel.anderson@intel.com>