### PR TITLE
Nginx based Load Balancer for multiple http listeners

### DIFF
--- a/docker/lb/Dockerfile
+++ b/docker/lb/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+FROM ubuntu:bionic
+
+RUN apt update \
+ && apt install -y -q \
+    nginx
+
+RUN rm /etc/nginx/sites-available/default
+
+COPY nginx.conf /etc/nginx/sites-available/default

--- a/docker/lb/README.md
+++ b/docker/lb/README.md
@@ -1,0 +1,28 @@
+# nginx based Load Balancer for Avalon
+
+This shows how to create nginx based Load Balancer to forward the requests
+coming from clients to one of the many avalon-listeners running in backend.
+
+## Running
+
+1. Build and run Avalon components.
+    ```bash
+    docker-compose -f docker/lb/docker-compose-lb.yaml up --build
+
+    The above command is going to start nginx based service (avalon-lb) along
+    with other avalon services. The nginx load balancer configuration is
+    defined in nginx.conf file which starts the nginx server on port 9947.
+    The client is going to submit the transaction to avalon-lb Load Balancer
+    and this load balancer is going to forward the  requests to 3 instances
+    of avalon-listeners in the backend in round-robin fashion.
+    ```
+
+2. Start transaction from client.
+    ```bash
+    # Go to shell container
+    docker exec -it avalon-shell bash
+ 
+    # run the transaction
+    cd examples/apps/generic_client
+    ./generic_client.py --uri "http://avalon-lb:9947" --workload_id "echo-result" --in_data "Hello"
+     ```

--- a/docker/lb/docker-compose-lb.yaml
+++ b/docker/lb/docker-compose-lb.yaml
@@ -1,0 +1,201 @@
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.5'
+
+services:
+  avalon-shell:
+    container_name: avalon-shell
+    image: avalon-shell-dev
+    build:
+      context: ../../
+      dockerfile: ./docker/Dockerfile
+      args:
+        - DISPLAY=${DISPLAY:-}
+        - XAUTHORITY=~/.Xauthority
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - DISPLAY
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    volumes:
+      # Below volume mappings are required for DISPLAY settings by heart disease GUI client
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ~/.Xauthority:/root/.Xauthority
+    command: |
+      bash -c "tail -f /dev/null"
+    stop_signal: SIGKILL
+    depends_on:
+      - avalon-enclave-manager
+      - avalon-listener-1
+      - avalon-listener-2
+      - avalon-listener-3
+
+  avalon-enclave-manager:
+    container_name: avalon-enclave-manager
+    image: avalon-enclave-manager-dev
+    build:
+      context: ../../
+      dockerfile: ./enclave_manager/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      # ZMQ socket port. 
+      - 5555
+    command: |
+      bash -c "
+        enclave_manager --lmdb_url http://avalon-lmdb:9090
+        tail -f /dev/null
+      "
+    depends_on:
+      - avalon-lmdb
+      - avalon-listener-1
+      - avalon-listener-2
+      - avalon-listener-3
+
+  avalon-lmdb:
+    container_name: avalon-lmdb
+    image: avalon-lmdb-dev
+    build:
+      context: ../../
+      dockerfile: ./shared_kv_storage/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      # Port is where lmdb server will listen for http request.
+      # Port should be same as in bind parameter or lmdb_config.toml
+      - 9090
+    command: |
+      bash -c "
+        kv_storage --bind http://avalon-lmdb:9090
+        tail -f /dev/null
+      "
+
+  avalon-listener-1:
+    container_name: avalon-listener-1
+    image: avalon-listener-dev
+    build:
+      context: ../../
+      dockerfile: ./listener/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      - 1947
+      # ZMQ socket port.
+      - 5555
+    command: |
+      bash -c "
+        avalon_listener --bind http://avalon-listener-1:1947 --lmdb_url http://avalon-lmdb:9090
+        tail -f /dev/null
+        "
+    depends_on:
+      - avalon-lmdb
+
+  avalon-listener-2:
+    container_name: avalon-listener-2
+    image: avalon-listener-dev
+    build:
+      context: ../../
+      dockerfile: ./listener/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      - 1947
+      # ZMQ socket port.
+      - 5555
+    command: |
+      bash -c "
+        avalon_listener --bind http://avalon-listener-2:1947 --lmdb_url http://avalon-lmdb:9090
+        tail -f /dev/null
+        "
+    depends_on:
+      - avalon-lmdb
+
+  avalon-listener-3:
+    container_name: avalon-listener-3
+    image: avalon-listener-dev
+    build:
+      context: ../../
+      dockerfile: ./listener/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      - 1947
+      # ZMQ socket port.
+      - 5555
+    command: |
+      bash -c "
+        avalon_listener --bind http://avalon-listener-3:1947 --lmdb_url http://avalon-lmdb:9090
+        tail -f /dev/null
+        "
+    depends_on:
+      - avalon-lmdb
+
+  avalon-lb:
+    container_name: avalon-lb
+    image: avalon-lb-dev
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    command: |
+      bash -c "
+        service nginx start
+        tail -f /dev/null
+        "
+    stop_signal: SIGKILL
+    depends_on:
+      - avalon-listener-1
+      - avalon-listener-2
+      - avalon-listener-3 

--- a/docker/lb/nginx.conf
+++ b/docker/lb/nginx.conf
@@ -1,0 +1,13 @@
+upstream backend {
+        server avalon-listener-1:1947;
+        server avalon-listener-2:1947;
+        server avalon-listener-3:1947;
+}
+
+server {
+        listen 9947;
+
+        location / {
+                proxy_pass http://backend;
+        }
+}


### PR DESCRIPTION
This PR demostrates
- how a Load Balancer (nginx) can be used to forward the
  client requests to multiple listeners in backend to be able to
  handle multiple requests.

Signed-off-by: pankajgoyal2 <pankaj.goyal@intel.com>