### PR TITLE
Add Crypto Tests

### DIFF
--- a/common/cpp/tests/Makefile
+++ b/common/cpp/tests/Makefile
@@ -1,0 +1,78 @@
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CPPFLAGS= -D_UNTRUSTED_
+CPPFLAGS+= -I..  -I../crypto -I../packages/base64
+LDFLAGS=-lcrypto
+UTILTESTOBJS= build/crypto_utils.o build/skenc.o build/types.o \
+		build/hex_string.o build/utils.o build/base64.o
+
+build/%: build/%.o
+	g++ -o $@ $^ $(LDFLAGS)
+
+build/%.o: %.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+
+build/%.o: ../%.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+
+build/%.o: ../crypto/%.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+
+build/%.o: ../packages/base64/%.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+
+
+all: build build/b64test build/certtest build/secrettest \
+	build/signtest build/verifytest build/pktest build/utiltest
+
+build:
+	mkdir -p $@
+
+build/b64test: build/b64test.o build/base64.o build/utils.o
+	g++ -o $@ $@.o         build/base64.o build/utils.o $(LDFLAGS)
+
+build/certtest: build/certtest.o build/verify_certificate.o
+	g++ -o $@ $@.o           build/verify_certificate.o $(LDFLAGS)
+
+build/pktest: build/pktest.o build/pkenc_private_key.o build/pkenc_public_key.o
+	g++ -o $@ $@.o build/pkenc_private_key.o build/pkenc_public_key.o \
+ 		$(LDFLAGS)
+
+build/signtest: build/signtest.o build/sig_private_key.o build/sig_public_key.o
+	g++ -o $@ $@.o build/sig_private_key.o build/sig_public_key.o \
+		$(LDFLAGS)
+
+build/secrettest: build/secrettest.o $(UTILTESTOBJS)
+	g++ -o $@ $@.o $(UTILTESTOBJS) $(LDFLAGS)
+
+build/verifytest: build/verifytest.o build/verify_signature.o
+	g++ -o $@ $@.o build/verify_signature.o $(LDFLAGS)
+
+build/utiltest: build/utiltest.o $(UTILTESTOBJS)
+	g++ -o $@ $@.o $(UTILTESTOBJS) $(LDFLAGS)
+
+test:
+	cd build; ./b64test
+	cd build; ./certtest
+	cd build; ./pktest
+	cd build; ./signtest
+	cd build; ./secrettest
+	cd build; ./verifytest
+	cd build; ./utiltest
+
+clean:
+	$(RM) -rf build
+
+.PHONY: all test clean

--- a/common/cpp/tests/README.md
+++ b/common/cpp/tests/README.md
@@ -1,0 +1,55 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+
+Unit Tests
+----------
+This tst directory contains self-contained tests for C++ source files in
+`common/cpp/`, which are mostly cryptographic functions implemented with
+OpenSSL.
+
+Dependencies:
+-------------
+These tests are standalone and depend only on libcrypto from OpenSSL.
+Programs are tested in "untrusted" mode ("trusted" mode is for in-enclave
+execution).
+
+Test Build and Execution
+------------------------
+
+To build the tests type `make` .
+This builds several independent test programs, one per common
+set or class of functions in the `build/` subdirectory.
+
+To execute the tests type `make test` .
+This executes each test program.
+Each test prints an error message and exits with a 0 on success or
+non-0 on failure.
+
+To remove generated binaries type `make clean` .
+
+Example
+-------
+```                                                           
+ $ make
+mkdir -p build
+g++ -o build/b64test.o -D_UNTRUSTED_ -I..  -I../crypto -I../packages/base64 -c b64test.cpp
+. . .
+g++ -o build/utiltest build/utiltest.o build/crypto_utils.o build/skenc.o build/types.o build/hex_string.o build/utils.o build/base64.o -lcrypto
+$ make test 
+cd build; ./b64test
+/home/dano/git/avalon/common/cpp/tests/build
+EVP_DecodeBlock PASSED: SHlwZXJsZWRnZXIgQXZhbG9u --> Hyperledger Avalon
+base64_decode   PASSED: SHlwZXJsZWRnZXIgQXZhbG9u, length 24 --> len 18
+base64_encode   PASSED: length 18 --> len 24
+. . .
+Test key generation: CreateHexEncodedEncryptionKey()
+Key is: 8068670903649550CC4E2E6EA6B78345197E66F98B6D02DC5EE578BF811626E6
+PASSED: CreateHexEncodedEncryptionKey()
+Test encryption: EncryptData()/DecryptData()
+PASSED: EncryptData()/DecryptData()
+Crypto utility tests PASSED
+$ make clean
+rm -f -rf build
+```  

--- a/common/cpp/tests/b64test.cpp
+++ b/common/cpp/tests/b64test.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test base64 functions:
+ * - OpenSSL EVP_DecodeBlock() used in signature verification
+ * - Avalon base64_encode()
+ * - Avalon base64_decode()
+ * See https://tools.ietf.org/html/rfc4648
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <openssl/evp.h> // EVP_*codeBlock()
+#include "types.h"       // ByteArray
+#include "utils.h"       // ByteArrayToStr()
+#include "base64.h"      // base64_*code()
+
+static const char rsa_2048_signature[] =
+    "TuHse3QCPZtyZP436ltUAc6cVlIDzwKyjguOBDMmoou/NlGylzY0EtOEbHvVZ28H"
+    "T8U1CiCVVmZso2ut2HY3zFDfpUg5/FV7FUSw/UhDOu3xkDwicrOvd/P1C3BKWJ6v"
+    "JWghv3QLpgDItQPapFH/3OfciWs10kC3KV4UY+Irkrrck9+h3+FaltM/52AL1m1Q"
+    "WZIutMk1gDs5nz5N87gGvbc9VJKXx/RDDmvX1rLfqnPpH3owkprVLhU8iLcmPPN+"
+    "irjfH4f4GGrnbWYCYK5wfB1BBbFl8ppqxm4Gr8ekePCPLMjYYLpKYWEipvTgaYl6"
+    "3zg+C9r8g+sIA3I9Jr3Exg==";
+
+static const char rsa_2048_signature_decoded[256] = {
+    '\x4e', '\xe1', '\xec', '\x7b', '\x74', '\x02', '\x3d', '\x9b',
+    '\x72', '\x64', '\xfe', '\x37', '\xea', '\x5b', '\x54', '\x01',
+    '\xce', '\x9c', '\x56', '\x52', '\x03', '\xcf', '\x02', '\xb2',
+    '\x8e', '\x0b', '\x8e', '\x04', '\x33', '\x26', '\xa2', '\x8b',
+    '\xbf', '\x36', '\x51', '\xb2', '\x97', '\x36', '\x34', '\x12',
+    '\xd3', '\x84', '\x6c', '\x7b', '\xd5', '\x67', '\x6f', '\x07',
+    '\x4f', '\xc5', '\x35', '\x0a', '\x20', '\x95', '\x56', '\x66',
+    '\x6c', '\xa3', '\x6b', '\xad', '\xd8', '\x76', '\x37', '\xcc',
+    '\x50', '\xdf', '\xa5', '\x48', '\x39', '\xfc', '\x55', '\x7b',
+    '\x15', '\x44', '\xb0', '\xfd', '\x48', '\x43', '\x3a', '\xed',
+    '\xf1', '\x90', '\x3c', '\x22', '\x72', '\xb3', '\xaf', '\x77',
+    '\xf3', '\xf5', '\x0b', '\x70', '\x4a', '\x58', '\x9e', '\xaf',
+    '\x25', '\x68', '\x21', '\xbf', '\x74', '\x0b', '\xa6', '\x00',
+    '\xc8', '\xb5', '\x03', '\xda', '\xa4', '\x51', '\xff', '\xdc',
+    '\xe7', '\xdc', '\x89', '\x6b', '\x35', '\xd2', '\x40', '\xb7',
+    '\x29', '\x5e', '\x14', '\x63', '\xe2', '\x2b', '\x92', '\xba',
+    '\xdc', '\x93', '\xdf', '\xa1', '\xdf', '\xe1', '\x5a', '\x96',
+    '\xd3', '\x3f', '\xe7', '\x60', '\x0b', '\xd6', '\x6d', '\x50',
+    '\x59', '\x92', '\x2e', '\xb4', '\xc9', '\x35', '\x80', '\x3b',
+    '\x39', '\x9f', '\x3e', '\x4d', '\xf3', '\xb8', '\x06', '\xbd',
+    '\xb7', '\x3d', '\x54', '\x92', '\x97', '\xc7', '\xf4', '\x43',
+    '\x0e', '\x6b', '\xd7', '\xd6', '\xb2', '\xdf', '\xaa', '\x73',
+    '\xe9', '\x1f', '\x7a', '\x30', '\x92', '\x9a', '\xd5', '\x2e',
+    '\x15', '\x3c', '\x88', '\xb7', '\x26', '\x3c', '\xf3', '\x7e',
+    '\x8a', '\xb8', '\xdf', '\x1f', '\x87', '\xf8', '\x18', '\x6a',
+    '\xe7', '\x6d', '\x66', '\x02', '\x60', '\xae', '\x70', '\x7c',
+    '\x1d', '\x41', '\x05', '\xb1', '\x65', '\xf2', '\x9a', '\x6a',
+    '\xc6', '\x6e', '\x06', '\xaf', '\xc7', '\xa4', '\x78', '\xf0',
+    '\x8f', '\x2c', '\xc8', '\xd8', '\x60', '\xba', '\x4a', '\x61',
+    '\x61', '\x22', '\xa6', '\xf4', '\xe0', '\x69', '\x89', '\x7a',
+    '\xdf', '\x38', '\x3e', '\x0b', '\xda', '\xfc', '\x83', '\xeb',
+    '\x08', '\x03', '\x72', '\x3d', '\x26', '\xbd', '\xc4', '\xc6'};
+
+
+int
+main(void)
+{
+    typedef struct {
+        const char *plain;
+        const char *encoded;
+        unsigned int plain_len;
+    } b64_test_type;
+    static b64_test_type b64_test_cases[] = {
+        {"Hyperledger Avalon", "SHlwZXJsZWRnZXIgQXZhbG9u", 18},
+        {"Hyperledger", "SHlwZXJsZWRnZXI=", 11},
+        {"Hype", "SHlwZQ==", 4},
+        {"H", "SA==", 1},
+        {"", "", 0},
+        {rsa_2048_signature_decoded, rsa_2048_signature, 256},
+        {NULL, NULL}
+    };
+    static b64_test_type negative_test_cases[] = {
+        {NULL, "`~!@#$%^&*()-_|':;?>,,.\\", 0},
+        {NULL, "===", 0},
+        {NULL, "==", 0},
+        {NULL, "=", 0},
+        {NULL, NULL, 0}
+    };
+    char buffer[256 + 3];
+    int  rc, count = 0;
+    ByteArray v;
+    std::string out_str;
+
+    for (b64_test_type *tp = b64_test_cases; tp->encoded != NULL; ++tp) {
+        // Test OpenSSL decode
+        memset(buffer, 0, sizeof (buffer));
+        rc = EVP_DecodeBlock((unsigned char *)buffer,
+            (unsigned char *)tp->encoded, strlen(tp->encoded));
+        if (rc < 0 || strcmp(buffer, tp->plain) != 0) {
+            printf("\nEVP_DecodeBlock FAILED\n");
+            printf("    rc %d, expected strlen plain %ld\n",
+                rc, strlen(tp->plain));
+            printf("    encoded %s, expected plain %s\n",
+                tp->encoded, tp->plain);
+            printf("    actual result %s\n", buffer);
+            ++count;
+        } else {
+            if (rc > 0 && rc < 32) { // only print short strings
+                printf("EVP_DecodeBlock PASSED: %s --> %s\n",
+                    tp->encoded, buffer);
+            } else {
+                printf("EVP_DecodeBlock PASSED: length %lu --> rc %d\n",
+                    strlen(tp->encoded), rc);
+            }
+        }
+
+        // Test Avalon C++ decode
+        v = base64_decode(std::string(tp->encoded));
+        std::string s = ByteArrayToStr(v);
+        unsigned char *out_cstr = (unsigned char *)s.c_str();
+        unsigned int out_len = s.size();
+        if (out_len != tp->plain_len ||
+                (out_len > 0 &&
+                 strncmp((char *)out_cstr, tp->plain, tp->plain_len) != 0)) {
+            printf("\nbase64_decode FAILED\n");
+            printf("    encoded %s, expected plain %s\n",
+                tp->encoded, tp->plain);
+            printf("    actual result %s\n", out_cstr);
+            ++count;
+        } else {
+            printf("base64_decode   PASSED: %s, length %lu --> len %d\n",
+                tp->encoded, strlen(tp->encoded), out_len);
+        }
+
+        // Test Avalon C++ encode
+        ByteArray in_vec(&tp->plain[0], &tp->plain[tp->plain_len]);
+        out_str = base64_encode(in_vec);
+        if (out_str.size() != strlen(tp->encoded) ||
+                (out_str.size() > 0 &&
+                 strncmp((char *)out_str.c_str(), tp->encoded,
+                     strlen(tp->encoded)) != 0)) {
+            printf("\nbase64_encode FAILED\n");
+            printf("    plain %s, expected encoded %s\n",
+                tp->plain, tp->encoded);
+            printf("    actual result %s\n", out_str.c_str());
+            ++count;
+        } else {
+            printf("base64_encode   PASSED: length %u --> len %lu\n",
+                tp->plain_len, out_str.size());
+        }
+
+    }
+
+    // Negative tests
+    for (b64_test_type *ntp = negative_test_cases; ntp->encoded != NULL;
+            ++ntp) {
+        // Test OpenSSL decode
+        rc = EVP_DecodeBlock((unsigned char *)buffer,
+            (unsigned char *)ntp->encoded, strlen(ntp->encoded));
+        if (rc < 0) {
+            printf("Negative test EVP_DecodeBlock(%s) PASSED\n", ntp->encoded);
+        } else {
+            printf("Negative test EVP_DecodeBlock(%s) FAILED\n", ntp->encoded);
+            ++count;
+        }
+
+        // Test Avalon C++ decode
+        v = base64_decode(std::string(ntp->encoded));
+        if (v.empty()) {
+            printf("Negative test b64_decode(%s) PASSED\n", ntp->encoded);
+        } else {
+            printf("Negative test b64_decode(%s) FAILED\n", ntp->encoded);
+            ++count;
+        }
+
+    }
+
+    // Summarize
+    if (count == 0) {
+        printf("Base64 Decode tests PASSED.\n");
+    } else {
+        printf("Base64 Decode FAILED %d tests.\n", count);
+    }
+    return count;
+}

--- a/common/cpp/tests/certtest.cpp
+++ b/common/cpp/tests/certtest.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test cert chain verification in verify_certificate.cpp.
+ *
+ * # Script to generate test certs:
+ * # Create ca key
+ * openssl genrsa -des3 -out rootCA.key 4096
+ * # Sign CA
+ * openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 15000 \
+ *     -out rootCA.pem
+ * # Create key
+ * openssl genrsa -out avalon.key 4096
+ * # Create CSR
+ * openssl req -new -key avalon.key -out avalon.csr
+ * # Generate cert
+ * openssl x509 -req -in avalon.csr -CA rootCA.pem -CAkey rootCA.key
+ *     -CAcreateserial -days 14999 -sha256 -out test.pem
+ * # Verify self-signed cert
+ * openssl verify -CAfile rootCA.pem test.pem
+ */
+
+#include <stdio.h>
+#include "verify_certificate.h"
+#include <openssl/evp.h>
+
+// Test X.509 certificates
+// To dump, type: openssl x509 -noout -text <mycertfilename.pem
+// CA test cert, RSA-4096/SHA-256 2020-2061
+static const char ca_cert[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIGPTCCBCWgAwIBAgIUGjmtT+zvFaxWgQve5kc/Sn+RTZUwDQYJKoZIhvcNAQEL\n"
+    "BQAwgawxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJPUjETMBEGA1UEBwwKTGFrZSBH\n"
+    "cm92ZTEbMBkGA1UECgwSSHlwZXJsZWRnZXIgQXZhbG9uMRAwDgYDVQQLDAdUZXN0\n"
+    "IENBMSIwIAYDVQQDDBljYS5hdmFsb24uaHlwZXJsZWRnZXIub3JnMSgwJgYJKoZI\n"
+    "hvcNAQkBFhljYUBhdmFsb24uaHlwZXJsZWRnZXIub3JnMCAXDTIwMDQyODIxMjcy\n"
+    "OVoYDzIwNjEwNTIzMjEyNzI5WjCBrDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk9S\n"
+    "MRMwEQYDVQQHDApMYWtlIEdyb3ZlMRswGQYDVQQKDBJIeXBlcmxlZGdlciBBdmFs\n"
+    "b24xEDAOBgNVBAsMB1Rlc3QgQ0ExIjAgBgNVBAMMGWNhLmF2YWxvbi5oeXBlcmxl\n"
+    "ZGdlci5vcmcxKDAmBgkqhkiG9w0BCQEWGWNhQGF2YWxvbi5oeXBlcmxlZGdlci5v\n"
+    "cmcwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCaGNp8JOVeBzT5zaVx\n"
+    "wUkvRSNAuDE+a4pf3s/BUPBiW2vA/ARYdNkkb6W8KIw5DePlPsppPoMNfumNkXLL\n"
+    "PUDgd/TnR7e7OO7gSN9XvpYzmFtGNqqDu7K5NtUn5AFGb6b4/YGKd1bRrhnmoSHv\n"
+    "dRadmupfI0Nt4ABz/Yu60+1CVGES83NYGJPZtQwwA+CrUZadckS7ps4YqWNeuDxY\n"
+    "O8CC/9lYyOKg+Fa9GW65mX3WR404Y/SL2VEoKKYaW6l/fO69XKPQO9pmyJa3zFJ5\n"
+    "Hwswur0L5Pq6E+avf0hBKqkTM4OeShaVxMXGG+v5yMp5rgteRao9jiLDEGP5Im2H\n"
+    "xaIK5hl4S+0AY8pM0lM2rFlrXz49VcjDw7BwOTyUGbtnd65GyIuzk1JIyhMZ68oc\n"
+    "MkyxH7bHCJWlFEZNVwKPf4E2SlagpN5oqvwIAgXQammITKPttkhT6CpSwpyTNWYR\n"
+    "MYQfsZTtUq9T31bKS4QKoxAqmWkBiN+J1gPDqFyxLoRI1FF9hdhLWwEYXSlZjlry\n"
+    "u6XzUzJTsKrJ/rFBRL832S+32esMSlVgpWzpJvZFx3qBqLnuWdYOtjcnFg2mEbiC\n"
+    "RT3iHkP9BD10nAyeQjJNHYwpznAG952XaL2jDDmor+qYo9vZfNHLhzglXb+ucCVj\n"
+    "nJdaD/qzOt0cgRZTvfF8ZdVfcQIDAQABo1MwUTAdBgNVHQ4EFgQULQbLYP/USzHV\n"
+    "mJxG1rGPByYGWyswHwYDVR0jBBgwFoAULQbLYP/USzHVmJxG1rGPByYGWyswDwYD\n"
+    "VR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEAfi5fNkgZHGIq5IVsXLWb\n"
+    "llJZZPWbgjcbfAiJdmwCGdtq/gW+nPmTjFazCzJWzvjzt4Oc2PcRESIgsg0A5hO+\n"
+    "My7wL5JUwZqjp/1kiloXVXIezHsrjwtr1ZbhIuhEXovEsdBJ+tZ1QyDXEDMlkxf8\n"
+    "iBsbGl9XP18elfy41htzzZyncQtjPv6P8RpajSsKl5rEBmJ03rjqKnMfLvjizte8\n"
+    "wDDDW6nrx+DCYvxrCzP2cbnaTYX6IXmfjYqJ8xsPI8qE9rs/nenx4V4hNkWaA75b\n"
+    "spqLlWE9ZB/LJPc2UUqAG7wvHp7MUH2YpIeT/kWAxEilq4kbH1vea1Nd/OS6WcL7\n"
+    "TICed4wzMrveIOiCJ4jMz8XwAG6gifGf7wp+1XTW6ydVKQxozvdhn7Cb803EUztR\n"
+    "WH7Pyw3O/np0OYtrpzYDOQVj0nenysM9EDQG3MTbkYoYjDIvNVGIkD0QWbpiBSTs\n"
+    "DlozLFEJjtn2lMnGiKCSYoO89m7bxCpwB03k6dX1B+3hf255RwgfOgnKIEoxuDPw\n"
+    "YWkZtrlSzs0gsIDALv1JjP9GDq1rGHLufffps0sS578QSalIV0g4Sn5mb8e/4ENn\n"
+    "c2QVvqDBQJde2uIsObltrvZe/Q1sPvUf5Rn3iLBWPMUog4+oEp9/Vk9E4Ap7vdve\n"
+    "qu0rY0kiCKHRB5M7powyzSc=\n"
+    "-----END CERTIFICATE-----\n";
+
+// RSA-4096/SHA-256 test cert valid 2020-2061, issued by ca_cert
+static const char test_cert[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIF7TCCA9UCFDej+FNF8O5QemWV3PIDOB7wcJZmMA0GCSqGSIb3DQEBCwUAMIGs\n"
+    "MQswCQYDVQQGEwJVUzELMAkGA1UECAwCT1IxEzARBgNVBAcMCkxha2UgR3JvdmUx\n"
+    "GzAZBgNVBAoMEkh5cGVybGVkZ2VyIEF2YWxvbjEQMA4GA1UECwwHVGVzdCBDQTEi\n"
+    "MCAGA1UEAwwZY2EuYXZhbG9uLmh5cGVybGVkZ2VyLm9yZzEoMCYGCSqGSIb3DQEJ\n"
+    "ARYZY2FAYXZhbG9uLmh5cGVybGVkZ2VyLm9yZzAgFw0yMDA0MjgyMTUxNTZaGA8y\n"
+    "MDYxMDUyMjIxNTE1NlowgbYxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJPUjETMBEG\n"
+    "A1UEBwwKTGFrZSBHcm92ZTEbMBkGA1UECgwSSHlwZXJsZWRnZXIgQXZhbG9uMRAw\n"
+    "DgYDVQQLDAdUZXN0IENBMScwJQYDVQQDDB50ZXN0LmNhLmF2YWxvbi5oeXBlcmxl\n"
+    "ZGdlci5vcmcxLTArBgkqhkiG9w0BCQEWHnRlc3QuY2FAYXZhbG9uLmh5cGVybGVk\n"
+    "Z2VyLm9yZzCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAL4lzykLaFXJ\n"
+    "b39fIlg9XJusYjXouKZfpuhKTG/UTNkvvv4gtXse4qyVo2phYlrFX4fMbBYQcqv7\n"
+    "Lh9b7xlpx6DxqwjTX045beq/Zgih21TG2dHk1tk1Rian3SR1qgHeglUAdET3TeJ1\n"
+    "yf886+P4+9MJu7wqhLbCBaOsibKl+WnPABVG/azvzl5VRvWtO+icKpuy86Hd0lV9\n"
+    "BUwtiwyOiPwitG5Tl+IAD0v/I36WWDxxUG1xEQqND8IF1yWSdhFlw5YVSBWIHyoh\n"
+    "SE5V5YyKDPMadRwvRfi4bCsCtBlFX1Ow+5GBFTZle3Vh7ED1m2ntgT0pkf8PLUg0\n"
+    "A7A3n34Dn/zsV1LKlnYvNxCqnv8bApGrHro47ysbZMJvzMzIWTG9+qYsnwaB1I1K\n"
+    "sEoIdt4xCg+zY2sMRv87o4tfsPGuqrfT+Ll83OOIyBuLLWHKA/v1BeiYerXljJ1s\n"
+    "mC33E39hHIBMHV0GyQpfM9adjeXlRz2Uoe5VQ9HrjiIYSUVcDVh1Z6EeBgCyICzp\n"
+    "KhAld0Uo2YE1bgvHK3yQVLfszqYl1L/A2g/pFXQHQ3WZYBwVtivYHIr1w3oAM/OF\n"
+    "j24Q60NwjDPUidtgffQkdXhv3s/8M2NBogGTgiAd9SFpN+BIXPLUyo5vH1Z11r2C\n"
+    "Z1ysQAp2Hd4rKLnlANcdNflNBw52OWUdAgMBAAEwDQYJKoZIhvcNAQELBQADggIB\n"
+    "ABsxX94sWIyVmCSPEQoE60hTiX3G9amV/Ut1skNpwW2aCTITZK8c6ubB6W1eI/zv\n"
+    "RDHskfR1scolM5KYh8yQMmM188ASv8UOIKnbuoFPtma2bax5zBsvl18d/NnfGVbn\n"
+    "RQI6Q8bWRkzTnd9AXXpGhhJ8QOPFXk8mpFx/280TBGR/XGWrWkXggMBGSOKLceqt\n"
+    "Cqoo88u/YJWvnsmzZ6sXmd6CTUsNjJndzkElOITk0x+UQ27rbabSZfdqlQOJ2wbA\n"
+    "+pAr/hGADHm9Ah2/nYTrGdSRvShtnhmeycUhmkHQfHIj8mVZU0DdzzHGJKFmkDGY\n"
+    "mZE+iHyKl81sC21qUaBhVWK8f53OymxVlPUvnrLapmkLA31DqESAOV7ZvYD52jfJ\n"
+    "Z8t4/anYO4kYXgrUIyvyBRau0Iw5fELXmMFMTWIuOhMPJvMXZp6EqQ1PKBf1MEpf\n"
+    "ZOxF1ZFsSAAoGTPnz9c50ZU0uytvZbnt8uy5NxTJvxpn8JIGWFnzesa7D6D0KZVX\n"
+    "aS2hV9X4I7HkCpiHYNnbE8y/OudtZLGenWUC5FRN78mMKI6spFiDNTDXqG7eBTN+\n"
+    "yxcsITi2jtXJ7IOxXIifYVC/Vt8Wu7vLOFI2rR1WP7SJ204i/ilhI/p9xz7/SD+C\n"
+    "97XvEDjLQsQpqVExTiuqSWdwCf3Ml9+4PJUAFMMVa3BR\n"
+    "-----END CERTIFICATE-----\n";
+
+// RSA-4096/SHA-256 test cert valid 2020-2061, issued by ca_cert
+static const char test_cert2[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIF7TCCA9UCFDej+FNF8O5QemWV3PIDOB7wcJZnMA0GCSqGSIb3DQEBCwUAMIGs\n"
+    "MQswCQYDVQQGEwJVUzELMAkGA1UECAwCT1IxEzARBgNVBAcMCkxha2UgR3JvdmUx\n"
+    "GzAZBgNVBAoMEkh5cGVybGVkZ2VyIEF2YWxvbjEQMA4GA1UECwwHVGVzdCBDQTEi\n"
+    "MCAGA1UEAwwZY2EuYXZhbG9uLmh5cGVybGVkZ2VyLm9yZzEoMCYGCSqGSIb3DQEJ\n"
+    "ARYZY2FAYXZhbG9uLmh5cGVybGVkZ2VyLm9yZzAgFw0yMDA0MjkxNjI4NTVaGA8y\n"
+    "MDYxMDUyMzE2Mjg1NVowgbYxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJPUjETMBEG\n"
+    "A1UEBwwKTGFrZSBHcm92ZTEbMBkGA1UECgwSSHlwZXJsZWRnZXIgQXZhbG9uMRAw\n"
+    "DgYDVQQLDAdUZXN0IENBMScwJQYDVQQDDB50ZXN0LmNhLmF2YWxvbi5oeXBlcmxl\n"
+    "ZGdlci5vcmcxLTArBgkqhkiG9w0BCQEWHnRlc3QuY2FAYXZhbG9uLmh5cGVybGVk\n"
+    "Z2VyLm9yZzCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAL4lzykLaFXJ\n"
+    "b39fIlg9XJusYjXouKZfpuhKTG/UTNkvvv4gtXse4qyVo2phYlrFX4fMbBYQcqv7\n"
+    "Lh9b7xlpx6DxqwjTX045beq/Zgih21TG2dHk1tk1Rian3SR1qgHeglUAdET3TeJ1\n"
+    "yf886+P4+9MJu7wqhLbCBaOsibKl+WnPABVG/azvzl5VRvWtO+icKpuy86Hd0lV9\n"
+    "BUwtiwyOiPwitG5Tl+IAD0v/I36WWDxxUG1xEQqND8IF1yWSdhFlw5YVSBWIHyoh\n"
+    "SE5V5YyKDPMadRwvRfi4bCsCtBlFX1Ow+5GBFTZle3Vh7ED1m2ntgT0pkf8PLUg0\n"
+    "A7A3n34Dn/zsV1LKlnYvNxCqnv8bApGrHro47ysbZMJvzMzIWTG9+qYsnwaB1I1K\n"
+    "sEoIdt4xCg+zY2sMRv87o4tfsPGuqrfT+Ll83OOIyBuLLWHKA/v1BeiYerXljJ1s\n"
+    "mC33E39hHIBMHV0GyQpfM9adjeXlRz2Uoe5VQ9HrjiIYSUVcDVh1Z6EeBgCyICzp\n"
+    "KhAld0Uo2YE1bgvHK3yQVLfszqYl1L/A2g/pFXQHQ3WZYBwVtivYHIr1w3oAM/OF\n"
+    "j24Q60NwjDPUidtgffQkdXhv3s/8M2NBogGTgiAd9SFpN+BIXPLUyo5vH1Z11r2C\n"
+    "Z1ysQAp2Hd4rKLnlANcdNflNBw52OWUdAgMBAAEwDQYJKoZIhvcNAQELBQADggIB\n"
+    "AFFrbMhW+/aH6a2WaNy1MecFWIrzqJgKkGPZBjYETI/7Xu6MD7rqGPhPzGLSDvIS\n"
+    "OrpY0i90gBxag/Zk4AE47porAmn0yIYcVjUdyOusplpOo1SzzPT4dwgUpusIao2p\n"
+    "ggzZQBpMTP5r0wZj9vOZDFG9ZSA9Hteb5r2+wC0N7Nv0Vr4dEcxTtw2rnXk2WBs8\n"
+    "0PGOD8oOFLpiFqhYP8S6wocIepy6CSTZyxUcJzW7PfrM5+ZdPSuLxEMtcD4zwV6u\n"
+    "S1bvkRHHkGFJFsYjMg9WAdOEmHBZxQPak2b9F28RCUWhf9oLl87OwQw1qMf7Vzd7\n"
+    "pEt1tROQHOfkgt/6eultQkQ8YbJJqrsQ2aOnznmpJDmzLpbHfPepCxz39gnyO4et\n"
+    "YcClauIdCxNQ1ERLvdfA989HXG0yVzgjuVwIujI1ljSzyH7qVaQtbUW4xE4gBFtC\n"
+    "6HhfKoafEWmkd8CMS/bcNTosVGgNVpblAGTkeIJfEo2xBm2bbvvAyKvTT2J5fJX7\n"
+    "oKdyywleSdwQMOncovTjKSBKUvbQPY+dBlbzpxE6NNr7FBWjTaLIbaFwIhsozYTi\n"
+    "VZdruu5D583qPEgAk/Iafrd0vksr7F5/Tjzn7wlswT4KcCN8HnEDs5VACVrULSNA\n"
+    "XVfa0nrsWWrVXkBcKeSCC8ca2D/hd63h9SW4IeO2pSpa\n"
+    "-----END CERTIFICATE-----\n";
+
+// RSA-3072/SHA-256 Root CA cert valid 2016-2049
+static const char ias_root_ca[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIFSzCCA7OgAwIBAgIJANEHdl0yo7CUMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV\n"
+    "BAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwLU2FudGEgQ2xhcmExGjAYBgNV\n"
+    "BAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQDDCdJbnRlbCBTR1ggQXR0ZXN0\n"
+    "YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwIBcNMTYxMTE0MTUzNzMxWhgPMjA0OTEy\n"
+    "MzEyMzU5NTlaMH4xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwL\n"
+    "U2FudGEgQ2xhcmExGjAYBgNVBAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQD\n"
+    "DCdJbnRlbCBTR1ggQXR0ZXN0YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwggGiMA0G\n"
+    "CSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCfPGR+tXc8u1EtJzLA10Feu1Wg+p7e\n"
+    "LmSRmeaCHbkQ1TF3Nwl3RmpqXkeGzNLd69QUnWovYyVSndEMyYc3sHecGgfinEeh\n"
+    "rgBJSEdsSJ9FpaFdesjsxqzGRa20PYdnnfWcCTvFoulpbFR4VBuXnnVLVzkUvlXT\n"
+    "L/TAnd8nIZk0zZkFJ7P5LtePvykkar7LcSQO85wtcQe0R1Raf/sQ6wYKaKmFgCGe\n"
+    "NpEJUmg4ktal4qgIAxk+QHUxQE42sxViN5mqglB0QJdUot/o9a/V/mMeH8KvOAiQ\n"
+    "byinkNndn+Bgk5sSV5DFgF0DffVqmVMblt5p3jPtImzBIH0QQrXJq39AT8cRwP5H\n"
+    "afuVeLHcDsRp6hol4P+ZFIhu8mmbI1u0hH3W/0C2BuYXB5PC+5izFFh/nP0lc2Lf\n"
+    "6rELO9LZdnOhpL1ExFOq9H/B8tPQ84T3Sgb4nAifDabNt/zu6MmCGo5U8lwEFtGM\n"
+    "RoOaX4AS+909x00lYnmtwsDVWv9vBiJCXRsCAwEAAaOByTCBxjBgBgNVHR8EWTBX\n"
+    "MFWgU6BRhk9odHRwOi8vdHJ1c3RlZHNlcnZpY2VzLmludGVsLmNvbS9jb250ZW50\n"
+    "L0NSTC9TR1gvQXR0ZXN0YXRpb25SZXBvcnRTaWduaW5nQ0EuY3JsMB0GA1UdDgQW\n"
+    "BBR4Q3t2pn680K9+QjfrNXw7hwFRPDAfBgNVHSMEGDAWgBR4Q3t2pn680K9+Qjfr\n"
+    "NXw7hwFRPDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBADANBgkq\n"
+    "hkiG9w0BAQsFAAOCAYEAeF8tYMXICvQqeXYQITkV2oLJsp6J4JAqJabHWxYJHGir\n"
+    "IEqucRiJSSx+HjIJEUVaj8E0QjEud6Y5lNmXlcjqRXaCPOqK0eGRz6hi+ripMtPZ\n"
+    "sFNaBwLQVV905SDjAzDzNIDnrcnXyB4gcDFCvwDFKKgLRjOB/WAqgscDUoGq5ZVi\n"
+    "zLUzTqiQPmULAQaB9c6Oti6snEFJiCQ67JLyW/E83/frzCmO5Ru6WjU4tmsmy8Ra\n"
+    "Ud4APK0wZTGtfPXU7w+IBdG5Ez0kE1qzxGQaL4gINJ1zMyleDnbuS8UicjJijvqA\n"
+    "152Sq049ESDz+1rRGc2NVEqh1KaGXmtXvqxXcTB+Ljy5Bw2ke0v8iGngFBPqCTVB\n"
+    "3op5KBG3RjbF6RRSzwzuWfL7QErNC8WEy5yDVARzTA5+xmBc388v9Dm21HGfcC8O\n"
+    "DD+gT9sSpssq0ascmvH49MOgjt1yoysLtdCtJW/9FZpoOypaHx0R+mJTLwPXVMrv\n"
+    "DaVzWh5aiEx+idkSGMnX\n"
+    "-----END CERTIFICATE-----\n";
+
+// RSA-2048/SHA-256 CA cert valid 2016-2026, issued by ias_root_ca
+static const char ias_child_ca[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIFSzCCA7OgAwIBAgIJANEHdl0yo7CUMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV\n"
+    "BAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwLU2FudGEgQ2xhcmExGjAYBgNV\n"
+    "BAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQDDCdJbnRlbCBTR1ggQXR0ZXN0\n"
+    "YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwIBcNMTYxMTE0MTUzNzMxWhgPMjA0OTEy\n"
+    "MzEyMzU5NTlaMH4xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwL\n"
+    "U2FudGEgQ2xhcmExGjAYBgNVBAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQD\n"
+    "DCdJbnRlbCBTR1ggQXR0ZXN0YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwggGiMA0G\n"
+    "CSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCfPGR+tXc8u1EtJzLA10Feu1Wg+p7e\n"
+    "LmSRmeaCHbkQ1TF3Nwl3RmpqXkeGzNLd69QUnWovYyVSndEMyYc3sHecGgfinEeh\n"
+    "rgBJSEdsSJ9FpaFdesjsxqzGRa20PYdnnfWcCTvFoulpbFR4VBuXnnVLVzkUvlXT\n"
+    "L/TAnd8nIZk0zZkFJ7P5LtePvykkar7LcSQO85wtcQe0R1Raf/sQ6wYKaKmFgCGe\n"
+    "NpEJUmg4ktal4qgIAxk+QHUxQE42sxViN5mqglB0QJdUot/o9a/V/mMeH8KvOAiQ\n"
+    "byinkNndn+Bgk5sSV5DFgF0DffVqmVMblt5p3jPtImzBIH0QQrXJq39AT8cRwP5H\n"
+    "afuVeLHcDsRp6hol4P+ZFIhu8mmbI1u0hH3W/0C2BuYXB5PC+5izFFh/nP0lc2Lf\n"
+    "6rELO9LZdnOhpL1ExFOq9H/B8tPQ84T3Sgb4nAifDabNt/zu6MmCGo5U8lwEFtGM\n"
+    "RoOaX4AS+909x00lYnmtwsDVWv9vBiJCXRsCAwEAAaOByTCBxjBgBgNVHR8EWTBX\n"
+    "MFWgU6BRhk9odHRwOi8vdHJ1c3RlZHNlcnZpY2VzLmludGVsLmNvbS9jb250ZW50\n"
+    "L0NSTC9TR1gvQXR0ZXN0YXRpb25SZXBvcnRTaWduaW5nQ0EuY3JsMB0GA1UdDgQW\n"
+    "BBR4Q3t2pn680K9+QjfrNXw7hwFRPDAfBgNVHSMEGDAWgBR4Q3t2pn680K9+Qjfr\n"
+    "NXw7hwFRPDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBADANBgkq\n"
+    "hkiG9w0BAQsFAAOCAYEAeF8tYMXICvQqeXYQITkV2oLJsp6J4JAqJabHWxYJHGir\n"
+    "IEqucRiJSSx+HjIJEUVaj8E0QjEud6Y5lNmXlcjqRXaCPOqK0eGRz6hi+ripMtPZ\n"
+    "sFNaBwLQVV905SDjAzDzNIDnrcnXyB4gcDFCvwDFKKgLRjOB/WAqgscDUoGq5ZVi\n"
+    "zLUzTqiQPmULAQaB9c6Oti6snEFJiCQ67JLyW/E83/frzCmO5Ru6WjU4tmsmy8Ra\n"
+    "Ud4APK0wZTGtfPXU7w+IBdG5Ez0kE1qzxGQaL4gINJ1zMyleDnbuS8UicjJijvqA\n"
+    "152Sq049ESDz+1rRGc2NVEqh1KaGXmtXvqxXcTB+Ljy5Bw2ke0v8iGngFBPqCTVB\n"
+    "3op5KBG3RjbF6RRSzwzuWfL7QErNC8WEy5yDVARzTA5+xmBc388v9Dm21HGfcC8O\n"
+    "DD+gT9sSpssq0ascmvH49MOgjt1yoysLtdCtJW/9FZpoOypaHx0R+mJTLwPXVMrv\n"
+    "DaVzWh5aiEx+idkSGMnX\n"
+    "-----END CERTIFICATE-----\n";
+
+// RSA-2048/SHA-256 IAS report signing cert valid 2016-2026, by ias_root_ca
+static const char ias_report_signing_cert[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIEoTCCAwmgAwIBAgIJANEHdl0yo7CWMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV\n"
+    "BAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwLU2FudGEgQ2xhcmExGjAYBgNV\n"
+    "BAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQDDCdJbnRlbCBTR1ggQXR0ZXN0\n"
+    "YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwHhcNMTYxMTIyMDkzNjU4WhcNMjYxMTIw\n"
+    "MDkzNjU4WjB7MQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExFDASBgNVBAcMC1Nh\n"
+    "bnRhIENsYXJhMRowGAYDVQQKDBFJbnRlbCBDb3Jwb3JhdGlvbjEtMCsGA1UEAwwk\n"
+    "SW50ZWwgU0dYIEF0dGVzdGF0aW9uIFJlcG9ydCBTaWduaW5nMIIBIjANBgkqhkiG\n"
+    "9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqXot4OZuphR8nudFrAFiaGxxkgma/Es/BA+t\n"
+    "beCTUR106AL1ENcWA4FX3K+E9BBL0/7X5rj5nIgX/R/1ubhkKWw9gfqPG3KeAtId\n"
+    "cv/uTO1yXv50vqaPvE1CRChvzdS/ZEBqQ5oVvLTPZ3VEicQjlytKgN9cLnxbwtuv\n"
+    "LUK7eyRPfJW/ksddOzP8VBBniolYnRCD2jrMRZ8nBM2ZWYwnXnwYeOAHV+W9tOhA\n"
+    "ImwRwKF/95yAsVwd21ryHMJBcGH70qLagZ7Ttyt++qO/6+KAXJuKwZqjRlEtSEz8\n"
+    "gZQeFfVYgcwSfo96oSMAzVr7V0L6HSDLRnpb6xxmbPdqNol4tQIDAQABo4GkMIGh\n"
+    "MB8GA1UdIwQYMBaAFHhDe3amfrzQr35CN+s1fDuHAVE8MA4GA1UdDwEB/wQEAwIG\n"
+    "wDAMBgNVHRMBAf8EAjAAMGAGA1UdHwRZMFcwVaBToFGGT2h0dHA6Ly90cnVzdGVk\n"
+    "c2VydmljZXMuaW50ZWwuY29tL2NvbnRlbnQvQ1JML1NHWC9BdHRlc3RhdGlvblJl\n"
+    "cG9ydFNpZ25pbmdDQS5jcmwwDQYJKoZIhvcNAQELBQADggGBAGcIthtcK9IVRz4r\n"
+    "Rq+ZKE+7k50/OxUsmW8aavOzKb0iCx07YQ9rzi5nU73tME2yGRLzhSViFs/LpFa9\n"
+    "lpQL6JL1aQwmDR74TxYGBAIi5f4I5TJoCCEqRHz91kpG6Uvyn2tLmnIdJbPE4vYv\n"
+    "WLrtXXfFBSSPD4Afn7+3/XUggAlc7oCTizOfbbtOFlYA4g5KcYgS1J2ZAeMQqbUd\n"
+    "ZseZCcaZZZn65tdqee8UXZlDvx0+NdO0LR+5pFy+juM0wWbu59MvzcmTXbjsi7HY\n"
+    "6zd53Yq5K244fwFHRQ8eOB0IWB+4PfM7FeAApZvlfqlKOlLcZL2uyVmzRkyR5yW7\n"
+    "2uo9mehX44CiPJ2fse9Y6eQtcfEhMPkmHXI01sN+KwPbpA39+xOsStjhP9N1Y1a2\n"
+    "tQAVo+yVgLgV2Hws73Fc0o3wC78qPEA+v2aRs/Be3ZFDgDyghc/1fgU+7C+P6kbq\n"
+    "d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==\n"
+    "-----END CERTIFICATE-----\n";
+
+int
+main(void)
+{
+    bool is_ok;
+    int  count = 0;
+
+#if OPENSSL_API_COMPAT < 0x10100000L
+    OpenSSL_add_all_digests();
+#endif
+
+    printf("Verify CA test . . . ");
+    is_ok = verify_certificate_chain(ca_cert, ca_cert);
+    printf("%d %s\n", (int)is_ok, is_ok ? "PASSED" : "FAILED");
+    if (!is_ok)
+        ++count;
+
+    printf("Verify real CA test . . . ");
+    is_ok = verify_certificate_chain(ias_child_ca, ias_root_ca);
+    printf("%d %s\n", (int)is_ok, is_ok ? "PASSED" : "FAILED");
+    if (!is_ok)
+        ++count;
+
+    printf("Verify IAS CA test . . . ");
+    is_ok = verify_certificate_chain(ias_report_signing_cert, ias_root_ca);
+    printf("%d %s\n", (int)is_ok, is_ok ? "PASSED" : "FAILED");
+    if (!is_ok)
+        ++count;
+
+    printf("Verify cert test . . . ");
+    is_ok = verify_certificate_chain(test_cert, ca_cert);
+    printf("%d %s\n", (int)is_ok, is_ok ? "PASSED" : "FAILED");
+    if (!is_ok)
+        ++count;
+
+    printf("Verify cert negative test . . . ");
+    is_ok = verify_certificate_chain(test_cert, test_cert2);
+    printf("%d %s\n", (int)is_ok, is_ok ? "FAILED" : "PASSED");
+    if (is_ok) // should not succeed; success is failure for this test
+        ++count;
+
+    // Summarize
+    if (count == 0) {
+        printf("Verify certificate chain tests PASSED.\n");
+    } else {
+        printf("Verify certificate chain FAILED %d tests.\n", count);
+    }
+    return count;
+}

--- a/common/cpp/tests/pktest.cpp
+++ b/common/cpp/tests/pktest.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test RSA public/private key pair crypto in pkenc_*_key.cpp.
+ *
+ * Test case from /tc/sgx/trusted_worker_manager/tests/testCrypto.cpp
+ * and from upstream common/tests/testCrypto.cpp in
+ * https://github.com/hyperledger-labs/private-data-objects
+ */
+
+#include <stdexcept>
+#include <stdio.h>
+#include <openssl/evp.h> // OpenSSL_add_all_digests()
+
+#include "error.h"       // tcf::error
+#include "pkenc_private_key.h"
+#include "pkenc_public_key.h"
+
+
+int
+main(void)
+{
+    int  count = 0;
+    // A short ByteArray for testing ValueError detection
+    ByteArray empty;
+    std::string msgStr("Hyperledger Avalon");
+    ByteArray msg;
+    msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
+
+#if OPENSSL_API_COMPAT < 0x10100000L
+    OpenSSL_add_all_digests();
+#endif
+
+    printf("Test RSA key management functions.\n");
+    try {
+        // Default constructor
+        tcf::crypto::pkenc::PrivateKey privateKey_t;
+        privateKey_t.Generate();
+        // PublicKey constructor from PrivateKey
+        tcf::crypto::pkenc::PublicKey publicKey_t(privateKey_t);
+
+        publicKey_t = privateKey_t.GetPublicKey();
+
+        // Copy constructors
+        tcf::crypto::pkenc::PrivateKey privateKey_t2 = privateKey_t;
+        tcf::crypto::pkenc::PublicKey publicKey_t2 = publicKey_t;
+
+        // Assignment operators
+        privateKey_t2 = privateKey_t;
+        publicKey_t2 = publicKey_t;
+
+        // Move constructors
+        privateKey_t2 = tcf::crypto::pkenc::PrivateKey(privateKey_t);
+        publicKey_t2 = tcf::crypto::pkenc::PublicKey(privateKey_t2);
+        printf("RSA keypair constructors test PASSED\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("RSA keypair constructors test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    // Default constructor
+    tcf::crypto::pkenc::PrivateKey rprivateKey;
+    rprivateKey.Generate();
+    // PublicKey constructor from PrivateKey
+    tcf::crypto::pkenc::PublicKey rpublicKey(rprivateKey);
+
+    printf("Test key serialize functions.\n");
+    std::string rprivateKeyStr;
+    try {
+        rprivateKeyStr = rprivateKey.Serialize();
+        printf("RSA private key serialize test PASSED\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("RSA private key serialize test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    std::string rpublicKeyStr;
+    try {
+        rpublicKeyStr = rpublicKey.Serialize();
+        printf("RSA public key serialize test PASSED\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("RSA public key serialize test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    printf("Test key deserialize functions.\n");
+    tcf::crypto::pkenc::PrivateKey rprivateKey1;
+    rprivateKey1.Generate();
+    tcf::crypto::pkenc::PublicKey rpublicKey1(rprivateKey1);
+    std::string rprivateKeyStr1;
+    std::string rpublicKeyStr1;
+
+    try {
+        rprivateKey1.Deserialize("");
+        printf("FAILED: RSA invalid private key deserialize undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("PASSED: RSA invalid private key deserialize "
+            "correctly detected.\n");
+    } catch (const std::exception& e) {
+        printf("FAILED: RSA invalid private key deserialize "
+            "internal error.\n%s\n",
+            e.what());
+        ++count;
+    }
+
+    try {
+        rpublicKey1.Deserialize("");
+        printf("FAILED: RSA invalid public key deserialize undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf(
+            "PASS: RSA invalid public key deserialize correctly detected.\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf(
+            "FAILED: RSA invalid public key deserialize internal error.\n%s\n",
+            e.what());
+        ++count;
+    }
+
+    try {
+        rprivateKey1.Deserialize(rprivateKeyStr);
+        rpublicKey1.Deserialize(rpublicKeyStr);
+        rprivateKeyStr1 = rprivateKey1.Serialize();
+        rpublicKeyStr1 = rpublicKey1.Serialize();
+        printf("RSA keypair deserialize test PASSED\n");
+    } catch (const std::exception& e) {
+        printf("RSA keypair deserialize test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+
+    printf("Test RSA encryption/decryption\n");
+    ByteArray ct;
+    try {
+        ct = rpublicKey.EncryptMessage(msg);
+        printf("RSA encryption test PASSED\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("RSA encryption test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    ByteArray pt;
+    try {
+        pt = rprivateKey.DecryptMessage(empty);
+        printf("FAILED: RSA decryption invalid RSA ciphertext undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("PASSED: RSA decryption test invalid RSA ciphertext "
+            "correctly detected.\n");
+    } catch (const std::exception& e) {
+        printf("FAILED: RSA decryption internal error.\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        pt = rprivateKey.DecryptMessage(ct);
+        printf("RSA decryption test PASSED\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("RSA decryption test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    if (!std::equal(pt.begin(), pt.end(), msg.begin())) {
+        printf("RSA encryption/decryption test FAILED\n");
+        ++count;
+    } else {
+        printf("RSA encryption/decryption test PASSED\n");
+    }
+
+    // Summarize
+    if (count == 0) {
+        printf("RSA public/private key pair tests PASSED.\n");
+    } else {
+        printf("RSA public/private key pair tests FAILED %d tests.\n", count);
+    }
+
+    return count;
+}

--- a/common/cpp/tests/secrettest.cpp
+++ b/common/cpp/tests/secrettest.cpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test AES-GCM 256 secret key encryption in skenc.cpp.
+ *
+ * Test case from /tc/sgx/trusted_worker_manager/tests/testCrypto.cpp
+ * and from upstream common/tests/testCrypto.cpp in
+ * https://github.com/hyperledger-labs/private-data-objects
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <openssl/evp.h>
+
+#include "error.h"       // tcf::error
+#include "skenc.h"
+
+int
+main(void)
+{
+    bool is_ok;
+    int  count = 0;
+    // A short ByteArray for testing ValueError detection
+    ByteArray empty;
+
+    std::string msgStr("Hyperledger Avalon");
+    ByteArray msg;
+    msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
+    std::string msgStr2("Confidential Computing");
+
+#if OPENSSL_API_COMPAT < 0x10100000L
+    OpenSSL_add_all_digests();
+#endif
+
+    printf("Test symmetric encryption functions\n");
+
+    ByteArray key;
+    try {
+        key = tcf::crypto::skenc::GenerateKey();
+        printf("AES-GCM key generation test PASSED\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("AES-GCM key generation test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+    ByteArray iv;
+    try {
+        iv = tcf::crypto::skenc::GenerateIV();
+        printf("AES-GCM IV generation test PASSED\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("AES-GCM IV generation test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    ByteArray ctAES;
+    try {
+        ctAES = tcf::crypto::skenc::EncryptMessage(key, iv, empty);
+        printf("FAILED: AES-GCM empty message encryption test FAILED: "
+            "undetected.\n");
+        ++count;
+    } catch (const std::exception& e) {
+        printf("PASSED: AES-GCM empty message encryption test PASSED "
+            "(detected)\n");
+    }
+
+    try {
+        ctAES = tcf::crypto::skenc::EncryptMessage(key, empty);
+        printf("FAILED: AES-GCM (random IV) empty message encryption FAILED: "
+            "undetected.\n");
+        ++count;
+    } catch (const std::exception& e) {
+        printf(
+            "AES-GCM (random IV) empty message encryption test PASSED "
+            "(detected)!\n");
+    }
+
+    try {
+        ctAES = tcf::crypto::skenc::EncryptMessage(key, empty, msg);
+        printf("AES-GCM encryption test FAILED, bad IV undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("AES-GCM encryption PASSED; bad IV detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM encryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        ctAES = tcf::crypto::skenc::EncryptMessage(empty, iv, msg);
+        printf("AES-GCM encryption test FAILED, bad key undetected\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("AES-GCM encryption PASSED; bad key detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM encryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        ctAES = tcf::crypto::skenc::EncryptMessage(empty, msg);
+        printf("AES-GCM (random IV) encryption test FAILED; "
+            "bad key undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("PASS: AES-GCM (random IV) encryption PASSED; "
+            "bad key detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM (random IV) encryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        ctAES = tcf::crypto::skenc::EncryptMessage(key, iv, msg);
+        printf("AES-GCM encryption test PASSED\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM encryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    // TEST AES_GCM decryption
+    ByteArray ptAES;
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(key, empty, ctAES);
+        printf("AES-GCM decryption test FAILED, bad IV undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("PASS: AES-GCM decryption PASSED; bad IV detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM decryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(empty, iv, ctAES);
+        printf("AES-GCM decryption test FAILED, bad key undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("PASS: AES-GCM decryption PASSED; bad key detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM decryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(key, iv, ctAES);
+        printf("AES-GCM decryption test PASSED\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM decryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    ctAES[0]++;
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(key, iv, ctAES);
+        printf(
+            "AES-GCM decryption test FAILED; ciphertext tampering "
+            "undetected.\n");
+        ++count;
+    } catch (const tcf::error::CryptoError& e) {
+        printf("AES-GCM decryption PASSED; ciphertext tampering detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM decryption test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(key, iv, empty);
+        printf(
+            "AES-GCM decryption test FAILED, invalid ciphertext size "
+            "undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf(
+            "AES-GCM decryption PASSED; invalid ciphertext size "
+            "detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM decryption test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    // AES_GCM (random IV) encrypt
+    try {
+        ctAES = tcf::crypto::skenc::EncryptMessage(key, msg);
+        printf("AES-GCM (random IV) encryption test PASSED\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM (random IV) encryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    // TEST AES_GCM (random IV) decryption
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(empty, ctAES);
+        printf("AES-GCM (random IV) decryption test FAILED; "
+            "bad key undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("AES-GCM (random IV) decryption PASSED; bad key detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM (random IV) decryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(key, ctAES);
+        printf("AES-GCM (random IV) decryption test PASSED\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM (random IV) decryption test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    ctAES[0]++;
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(key, ctAES);
+        printf("AES-GCM (random IV) decryption test FAILED; "
+            "ciphertext tampering undetected.\n");
+        ++count;
+    } catch (const tcf::error::CryptoError& e) {
+        printf("AES-GCM (random IV) decryption PASSED; ciphertext tampering "
+            "detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM (random IV) decryption test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        ptAES = tcf::crypto::skenc::DecryptMessage(key, empty);
+        printf("AES-GCM (random IV) decryption test FAILED; "
+            "invalid ciphertext size undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) {
+        printf("AES-GCM (random IV) decryption PASSED; "
+            "invalid ciphertext size detected\n");
+    } catch (const std::exception& e) {
+        printf("AES-GCM (random IV) decryption test FAILED\n%s\n", e.what());
+        ++count;
+    }
+
+    // Test user provided IV
+    iv = tcf::crypto::skenc::GenerateIV("uniqueID123456789");
+    if (iv.size() != tcf::crypto::constants::IV_LEN) {
+        printf("AES-GCM IV generation test FAILED\n");
+        ++count;
+    } else {
+        printf("User-seeded IV generation PASSED\n");
+    }
+
+    // Summarize
+    if (count == 0) {
+        printf("Secret key encryption tests PASSED.\n");
+    } else {
+        printf("Secret key encryption tests FAILED %d tests.\n", count);
+    }
+
+    return count;
+}

--- a/common/cpp/tests/signtest.cpp
+++ b/common/cpp/tests/signtest.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test ECDSA Secp256k1 ECDSA signatures in sig_*_key.cpp.
+ *
+ * Test case from /tc/sgx/trusted_worker_manager/tests/testCrypto.cpp
+ * and from upstream common/tests/testCrypto.cpp in
+ * https://github.com/hyperledger-labs/private-data-objects
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <openssl/evp.h>
+#if OPENSSL_API_COMPAT < 0x10100000L
+#include <openssl/ecdsa.h>
+#include <openssl/bn.h>
+#endif
+
+#include "error.h"       // tcf::error
+#include "sig_private_key.h"
+#include "sig_public_key.h"
+
+#if OPENSSL_API_COMPAT < 0x10100000L
+// For backwards compatibility with older versions of OpenSSL.
+// Needed for sig_private_key.cpp.
+
+// Get the R and S bignumber values of an ECDSA signature.
+void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **ptr_r,
+        const BIGNUM **ptr_s) {
+    if (ptr_r != NULL)
+        *ptr_r = sig->r;
+    if (ptr_s != NULL)
+        *ptr_s = sig->s;
+}
+
+// Set the R and S bignumber values of an ECDSA signature.
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
+    if (r == NULL || s == NULL)
+        return 0;
+
+    BN_clear_free(sig->r);
+    sig->r = r;
+    BN_clear_free(sig->s);
+    sig->s = s;
+    return 1;
+}
+#endif
+
+int
+main(void)
+{
+    bool is_ok;
+    int  count = 0;
+
+    std::string msgStr("Hyperledger Avalon");
+    ByteArray msg;
+    msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
+    std::string msgStr2("Confidential Computing");
+    ByteArray msg2;
+    msg2.insert(msg2.end(), msgStr2.data(), msgStr2.data() + msgStr2.size());
+
+#if OPENSSL_API_COMPAT < 0x10100000L
+    OpenSSL_add_all_digests();
+#endif
+
+    // Test ECDSA key management functions
+    try {
+        // Default constructor
+        tcf::crypto::sig::PrivateKey privateKey_t;
+        privateKey_t.Generate();
+        // PublicKey constructor from PrivateKey
+        tcf::crypto::sig::PublicKey publicKey_t(privateKey_t);
+
+        publicKey_t = privateKey_t.GetPublicKey();
+
+        // Copy constructors
+        tcf::crypto::sig::PrivateKey privateKey_t2 = privateKey_t;
+        tcf::crypto::sig::PublicKey publicKey_t2 = publicKey_t;
+
+        // Assignment operators
+        privateKey_t2 = privateKey_t;
+        publicKey_t2 = publicKey_t;
+
+        // Move constructors
+        privateKey_t2 = tcf::crypto::sig::PrivateKey(privateKey_t);
+        publicKey_t2 = tcf::crypto::sig::PublicKey(privateKey_t2);
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("ECDSA keypair constructors test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    // Default constructor
+    tcf::crypto::sig::PrivateKey privateKey;
+    privateKey.Generate();
+    // PublicKey constructor from PrivateKey
+    tcf::crypto::sig::PublicKey publicKey(privateKey);
+
+    std::string privateKeyStr;
+    try {
+        privateKeyStr = privateKey.Serialize();
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("Serialize ECDSA private key test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    std::string publicKeyStr;
+    try {
+        publicKeyStr = publicKey.Serialize();
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("Serialize ECDSA public key test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    std::string privateKeyStr1;
+    std::string publicKeyStr1;
+    tcf::crypto::sig::PrivateKey privateKey1;
+    privateKey1.Generate();
+    tcf::crypto::sig::PublicKey publicKey1(privateKey1);
+
+    try {
+        privateKey1.Deserialize("");
+    } catch (const tcf::error::ValueError& e) {
+        printf("PASSED: Deserialize invalid ECDSA private key detected\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("Deserialize invalid ECDSA private key internal error:\n%s\n",
+            e.what());
+        ++count;
+    }
+
+    try {
+        publicKey1.Deserialize("");
+    } catch (const tcf::error::ValueError& e) {
+        printf("PASSED: Deserialize invalid ECDSA public key detected\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("Deserialize invalid ECDSA public key internal error:\n%s\n",
+            e.what());
+        ++count;
+    }
+
+    try {
+        std::string XYstr = publicKey1.SerializeXYToHex();
+        publicKey1.DeserializeXYFromHex(XYstr);
+    } catch (const std::exception& e) {
+        printf("Serialize/Deserialize XY test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    try {
+        privateKey1.Deserialize(privateKeyStr);
+        publicKey1.Deserialize(publicKeyStr);
+        privateKeyStr1 = privateKey1.Serialize();
+        publicKeyStr1 = publicKey1.Serialize();
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("Deserialize ECDSA keypair test FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    // Test of SignMessage and VerifySignature
+    printf("SignMessage() Test\n");
+    ByteArray sig;
+    try {
+        sig = privateKey1.SignMessage(msg);
+        printf("SignMessage test PASSED\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("SignMessage test FAILED, signature not computed:\n%s\n",
+            e.what());
+        ++count;
+    }
+
+    printf("VerifySignature() Test\n");
+    int res = publicKey1.VerifySignature(msg, sig);
+    if (res == -1) {
+        printf("VerifySignature test FAILED, internal error.\n");
+        ++count;
+    } else if (res == 0) {
+        printf("VerifySignature test FAILED, invalid signature.\n");
+        ++count;
+    } else {
+        printf("VerifySignature test PASSED\n");
+    }
+
+    printf("Negative Test: SignMessage()/VerifySignature()\n");
+    ByteArray sig2 = privateKey1.SignMessage(msg2);
+
+    res = publicKey1.VerifySignature(msg2, sig);
+    if (res == -1) {
+        printf("VerifySignature test FAILED, internal error.\n");
+        ++count;
+    } else if (res == 1) {
+        printf("VerifySignature test FAILED, invalid message not detected\n");
+        ++count;
+    }
+
+    res = publicKey1.VerifySignature(msg, sig2);
+    if (res == -1) {
+        printf("VerifySignature test FAILED, internal error.\n");
+        ++count;
+    } else if (res == 1) {
+        printf("VerifySignature negative test FAILED; "
+            "invalid signature NOT detected\n");
+        ++count;
+    } else {
+       printf("PASSED: VerifySignature negative test; "
+           "expected invalid message detected\n");
+    }
+
+    // Summarize
+    if (count == 0) {
+        printf("Signature verification tests PASSED.\n");
+    } else {
+        printf("Signature verification FAILED %d tests.\n", count);
+    }
+
+    return count;
+}

--- a/common/cpp/tests/utiltest.cpp
+++ b/common/cpp/tests/utiltest.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test crypto utilities in crypto_utils.cpp.
+ *
+ * Test case from /tc/sgx/trusted_worker_manager/tests/testCrypto.cpp
+ * and from upstream common/tests/testCrypto.cpp in
+ * https://github.com/hyperledger-labs/private-data-objects
+ *
+ * SHA-256 digest computed with:
+ * echo -n Hyperledger Avalon | openssl dgst -binary -sha256 | openssl base64
+ */
+
+#include <stdexcept>
+#include <stdio.h>
+#include <openssl/evp.h> // OpenSSL_add_all_digests()
+
+#include "crypto_utils.h"
+#include "error.h"       // tcf::error
+#include "crypto.h"
+#include "base64.h"      // base64_*code()
+
+
+int
+main(void)
+{
+    static const size_t rand_length = 32;
+    bool is_ok;
+    int  count = 0;
+    // A short ByteArray for testing ValueError detection
+    ByteArray rand;
+    typedef struct {
+        const char *plain;
+        const char *encoded;
+    } hash_test_type;
+    static hash_test_type hash_test_cases[] = {
+        {"Hyperledger Avalon", "22hKjT4z7yvB8D3Ros2/QykiYzXwkJIfJO89Df5xOtQ="},
+        {"", "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="},
+        {NULL, NULL}
+    };
+
+#if OPENSSL_API_COMPAT < 0x10100000L
+    OpenSSL_add_all_digests();
+#endif
+
+    printf("Random number test: RandomBitString()\n");
+    try {
+        rand = tcf::crypto::RandomBitString(rand_length);
+        printf("RandomBitString generation PASSED.\n");
+    } catch (const std::exception& e) {
+        printf("RandomBitString generation FAILED:\n%s\n", e.what());
+        ++count;
+    }
+
+    // RandomBitString negative test
+    try {
+        rand = tcf::crypto::RandomBitString(0);
+        printf("RandomBitString FAILED: invalid length undetected.\n");
+        ++count;
+    } catch (const tcf::error::ValueError& e) { // expected error here
+        printf("RandomBitString PASSED: invalid length detected.\n");
+    } catch (const tcf::error::RuntimeError& e) {
+        printf("RandomBitString FAILED: internal error:\n%s\n", e.what());
+        ++count;
+    }
+
+    for (hash_test_type *tp = hash_test_cases; tp->encoded != NULL; ++tp) {
+        printf("Hash SHA-256 test: ComputeMessageHash()\n");
+        std::string msgStr(tp->plain);
+        ByteArray msg;
+        msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
+        std::string msg_SHA256_B64(tp->encoded);
+        ByteArray hash = tcf::crypto::ComputeMessageHash(msg);
+        std::string hashStr_B64 = base64_encode(hash);
+        if (hashStr_B64.compare(msg_SHA256_B64) != 0) {
+            printf("FAILED: ComputeMessageHash(\"%s\"): "
+                "SHA256 digest mismatch.\n", tp->plain);
+            ++count;
+        } else {
+            printf("PASSED: ComputeMessageHash(\"%s\"): \n", tp->plain);
+        }
+    }
+
+
+    // Key generation test: CreateHexEncodedEncryptionKey()
+    // examples/apps/simple_wallet/workload/simple_wallet_execute_io.cpp
+    printf("Test key generation: CreateHexEncodedEncryptionKey()\n");
+    std::string enc_key = tcf::crypto::CreateHexEncodedEncryptionKey();
+    printf("Key is: %s\n", enc_key.c_str());
+    if (!enc_key.empty()) {
+        printf("PASSED: CreateHexEncodedEncryptionKey()\n");
+    } else {
+        printf("FAILED: CreateHexEncodedEncryptionKey()\n");
+        ++count;
+    }
+
+    printf("Test encryption: EncryptData()/DecryptData()\n");
+    std::string test_data = "Hyperledger Avalon";
+    std::string encrypted_data = tcf::crypto::EncryptData(test_data, enc_key);
+    std::string decrypted_data = tcf::crypto::DecryptData(encrypted_data,
+        enc_key);
+    if (decrypted_data == test_data) {
+        printf("PASSED: EncryptData()/DecryptData()\n");
+    } else {
+        printf("FAILED: EncryptData()/DecryptData()\n");
+        ++count;
+    }
+
+    // Summarize
+    if (count == 0) {
+        printf("Crypto utility tests PASSED.\n");
+    } else {
+        printf("Crypto utility tests FAILED %d tests.\n", count);
+    }
+
+    return count;
+}

--- a/common/cpp/tests/verifytest.cpp
+++ b/common/cpp/tests/verifytest.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test RSA digital signatures in verify_signature.cpp.
+ *
+ * Test case from /tc/sgx/trusted_worker_manager/tests/testCrypto.cpp
+ * and from upstream common/tests/testCrypto.cpp in
+ * https://github.com/hyperledger-labs/private-data-objects
+ *
+ * # Script to generate test signature
+ * # Sign a message
+ * openssl dgst -sha256 -sign avalon.key -out message.signature.raw message
+ * openssl base64 -in message.signature.raw -out message.signature
+ * # Extract public key from private key
+ * openssl rsa -in avalon.key -pubout >avalon.key.public
+ * # Verify message
+ * openssl dgst -sha256 -verify avalon.key.public -signature message.signature
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <openssl/evp.h>
+#include "verify_signature.h"
+
+// Test X.509 certificate
+// To dump, type: openssl x509 -noout -text <mycertfilename.pem
+// RSA-4096/SHA-256 test cert valid 2020-2061
+static const char test_cert[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIF7TCCA9UCFDej+FNF8O5QemWV3PIDOB7wcJZmMA0GCSqGSIb3DQEBCwUAMIGs\n"
+    "MQswCQYDVQQGEwJVUzELMAkGA1UECAwCT1IxEzARBgNVBAcMCkxha2UgR3JvdmUx\n"
+    "GzAZBgNVBAoMEkh5cGVybGVkZ2VyIEF2YWxvbjEQMA4GA1UECwwHVGVzdCBDQTEi\n"
+    "MCAGA1UEAwwZY2EuYXZhbG9uLmh5cGVybGVkZ2VyLm9yZzEoMCYGCSqGSIb3DQEJ\n"
+    "ARYZY2FAYXZhbG9uLmh5cGVybGVkZ2VyLm9yZzAgFw0yMDA0MjgyMTUxNTZaGA8y\n"
+    "MDYxMDUyMjIxNTE1NlowgbYxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJPUjETMBEG\n"
+    "A1UEBwwKTGFrZSBHcm92ZTEbMBkGA1UECgwSSHlwZXJsZWRnZXIgQXZhbG9uMRAw\n"
+    "DgYDVQQLDAdUZXN0IENBMScwJQYDVQQDDB50ZXN0LmNhLmF2YWxvbi5oeXBlcmxl\n"
+    "ZGdlci5vcmcxLTArBgkqhkiG9w0BCQEWHnRlc3QuY2FAYXZhbG9uLmh5cGVybGVk\n"
+    "Z2VyLm9yZzCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAL4lzykLaFXJ\n"
+    "b39fIlg9XJusYjXouKZfpuhKTG/UTNkvvv4gtXse4qyVo2phYlrFX4fMbBYQcqv7\n"
+    "Lh9b7xlpx6DxqwjTX045beq/Zgih21TG2dHk1tk1Rian3SR1qgHeglUAdET3TeJ1\n"
+    "yf886+P4+9MJu7wqhLbCBaOsibKl+WnPABVG/azvzl5VRvWtO+icKpuy86Hd0lV9\n"
+    "BUwtiwyOiPwitG5Tl+IAD0v/I36WWDxxUG1xEQqND8IF1yWSdhFlw5YVSBWIHyoh\n"
+    "SE5V5YyKDPMadRwvRfi4bCsCtBlFX1Ow+5GBFTZle3Vh7ED1m2ntgT0pkf8PLUg0\n"
+    "A7A3n34Dn/zsV1LKlnYvNxCqnv8bApGrHro47ysbZMJvzMzIWTG9+qYsnwaB1I1K\n"
+    "sEoIdt4xCg+zY2sMRv87o4tfsPGuqrfT+Ll83OOIyBuLLWHKA/v1BeiYerXljJ1s\n"
+    "mC33E39hHIBMHV0GyQpfM9adjeXlRz2Uoe5VQ9HrjiIYSUVcDVh1Z6EeBgCyICzp\n"
+    "KhAld0Uo2YE1bgvHK3yQVLfszqYl1L/A2g/pFXQHQ3WZYBwVtivYHIr1w3oAM/OF\n"
+    "j24Q60NwjDPUidtgffQkdXhv3s/8M2NBogGTgiAd9SFpN+BIXPLUyo5vH1Z11r2C\n"
+    "Z1ysQAp2Hd4rKLnlANcdNflNBw52OWUdAgMBAAEwDQYJKoZIhvcNAQELBQADggIB\n"
+    "ABsxX94sWIyVmCSPEQoE60hTiX3G9amV/Ut1skNpwW2aCTITZK8c6ubB6W1eI/zv\n"
+    "RDHskfR1scolM5KYh8yQMmM188ASv8UOIKnbuoFPtma2bax5zBsvl18d/NnfGVbn\n"
+    "RQI6Q8bWRkzTnd9AXXpGhhJ8QOPFXk8mpFx/280TBGR/XGWrWkXggMBGSOKLceqt\n"
+    "Cqoo88u/YJWvnsmzZ6sXmd6CTUsNjJndzkElOITk0x+UQ27rbabSZfdqlQOJ2wbA\n"
+    "+pAr/hGADHm9Ah2/nYTrGdSRvShtnhmeycUhmkHQfHIj8mVZU0DdzzHGJKFmkDGY\n"
+    "mZE+iHyKl81sC21qUaBhVWK8f53OymxVlPUvnrLapmkLA31DqESAOV7ZvYD52jfJ\n"
+    "Z8t4/anYO4kYXgrUIyvyBRau0Iw5fELXmMFMTWIuOhMPJvMXZp6EqQ1PKBf1MEpf\n"
+    "ZOxF1ZFsSAAoGTPnz9c50ZU0uytvZbnt8uy5NxTJvxpn8JIGWFnzesa7D6D0KZVX\n"
+    "aS2hV9X4I7HkCpiHYNnbE8y/OudtZLGenWUC5FRN78mMKI6spFiDNTDXqG7eBTN+\n"
+    "yxcsITi2jtXJ7IOxXIifYVC/Vt8Wu7vLOFI2rR1WP7SJ204i/ilhI/p9xz7/SD+C\n"
+    "97XvEDjLQsQpqVExTiuqSWdwCf3Ml9+4PJUAFMMVa3BR\n"
+    "-----END CERTIFICATE-----\n";
+
+// RSA-4096/SHA-256 test cert valid 2020-2061, issued by ca_cert
+static const char test_cert2[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIF7TCCA9UCFDej+FNF8O5QemWV3PIDOB7wcJZnMA0GCSqGSIb3DQEBCwUAMIGs\n"
+    "MQswCQYDVQQGEwJVUzELMAkGA1UECAwCT1IxEzARBgNVBAcMCkxha2UgR3JvdmUx\n"
+    "GzAZBgNVBAoMEkh5cGVybGVkZ2VyIEF2YWxvbjEQMA4GA1UECwwHVGVzdCBDQTEi\n"
+    "MCAGA1UEAwwZY2EuYXZhbG9uLmh5cGVybGVkZ2VyLm9yZzEoMCYGCSqGSIb3DQEJ\n"
+    "ARYZY2FAYXZhbG9uLmh5cGVybGVkZ2VyLm9yZzAgFw0yMDA0MjkxNjI4NTVaGA8y\n"
+    "MDYxMDUyMzE2Mjg1NVowgbYxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJPUjETMBEG\n"
+    "A1UEBwwKTGFrZSBHcm92ZTEbMBkGA1UECgwSSHlwZXJsZWRnZXIgQXZhbG9uMRAw\n"
+    "DgYDVQQLDAdUZXN0IENBMScwJQYDVQQDDB50ZXN0LmNhLmF2YWxvbi5oeXBlcmxl\n"
+    "ZGdlci5vcmcxLTArBgkqhkiG9w0BCQEWHnRlc3QuY2FAYXZhbG9uLmh5cGVybGVk\n"
+    "Z2VyLm9yZzCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAL4lzykLaFXJ\n"
+    "b39fIlg9XJusYjXouKZfpuhKTG/UTNkvvv4gtXse4qyVo2phYlrFX4fMbBYQcqv7\n"
+    "Lh9b7xlpx6DxqwjTX045beq/Zgih21TG2dHk1tk1Rian3SR1qgHeglUAdET3TeJ1\n"
+    "yf886+P4+9MJu7wqhLbCBaOsibKl+WnPABVG/azvzl5VRvWtO+icKpuy86Hd0lV9\n"
+    "BUwtiwyOiPwitG5Tl+IAD0v/I36WWDxxUG1xEQqND8IF1yWSdhFlw5YVSBWIHyoh\n"
+    "SE5V5YyKDPMadRwvRfi4bCsCtBlFX1Ow+5GBFTZle3Vh7ED1m2ntgT0pkf8PLUg0\n"
+    "A7A3n34Dn/zsV1LKlnYvNxCqnv8bApGrHro47ysbZMJvzMzIWTG9+qYsnwaB1I1K\n"
+    "sEoIdt4xCg+zY2sMRv87o4tfsPGuqrfT+Ll83OOIyBuLLWHKA/v1BeiYerXljJ1s\n"
+    "mC33E39hHIBMHV0GyQpfM9adjeXlRz2Uoe5VQ9HrjiIYSUVcDVh1Z6EeBgCyICzp\n"
+    "KhAld0Uo2YE1bgvHK3yQVLfszqYl1L/A2g/pFXQHQ3WZYBwVtivYHIr1w3oAM/OF\n"
+    "j24Q60NwjDPUidtgffQkdXhv3s/8M2NBogGTgiAd9SFpN+BIXPLUyo5vH1Z11r2C\n"
+    "Z1ysQAp2Hd4rKLnlANcdNflNBw52OWUdAgMBAAEwDQYJKoZIhvcNAQELBQADggIB\n"
+    "AFFrbMhW+/aH6a2WaNy1MecFWIrzqJgKkGPZBjYETI/7Xu6MD7rqGPhPzGLSDvIS\n"
+    "OrpY0i90gBxag/Zk4AE47porAmn0yIYcVjUdyOusplpOo1SzzPT4dwgUpusIao2p\n"
+    "ggzZQBpMTP5r0wZj9vOZDFG9ZSA9Hteb5r2+wC0N7Nv0Vr4dEcxTtw2rnXk2WBs8\n"
+    "0PGOD8oOFLpiFqhYP8S6wocIepy6CSTZyxUcJzW7PfrM5+ZdPSuLxEMtcD4zwV6u\n"
+    "S1bvkRHHkGFJFsYjMg9WAdOEmHBZxQPak2b9F28RCUWhf9oLl87OwQw1qMf7Vzd7\n"
+    "pEt1tROQHOfkgt/6eultQkQ8YbJJqrsQ2aOnznmpJDmzLpbHfPepCxz39gnyO4et\n"
+    "YcClauIdCxNQ1ERLvdfA989HXG0yVzgjuVwIujI1ljSzyH7qVaQtbUW4xE4gBFtC\n"
+    "6HhfKoafEWmkd8CMS/bcNTosVGgNVpblAGTkeIJfEo2xBm2bbvvAyKvTT2J5fJX7\n"
+    "oKdyywleSdwQMOncovTjKSBKUvbQPY+dBlbzpxE6NNr7FBWjTaLIbaFwIhsozYTi\n"
+    "VZdruu5D583qPEgAk/Iafrd0vksr7F5/Tjzn7wlswT4KcCN8HnEDs5VACVrULSNA\n"
+    "XVfa0nrsWWrVXkBcKeSCC8ca2D/hd63h9SW4IeO2pSpa\n"
+    "-----END CERTIFICATE-----\n";
+
+static const char message[] = "Hyperledger Avalon";
+static const char signature[] =
+     // 512 byte, 4096 bit signature, b64 encoded in 684 bytes + NUL
+    "AZzpz4BONyIclWHcOgm+GQ/dav5fyuXxl3vKXIZTXNLZX/dfVeGUQm5FBucrDLFy"
+    "mE2RZ2ZrPpCW/RRP3SgAIPKduNNeiisBXrn2yuShiFGpqua29AYuTYG2Ut5mKUb6"
+    "CNIFnWlOR3+f1eG8JXGoRefXTorwoaHkoCFttPNQG+Us4HKAeS4DifFmSkMq329M"
+    "S4fGPXUYaRzibFjXksoC1R/DYdI7RNFjNE0Owmb6BC/ntBQiWB5CPcln1Rd17E41"
+    "2MBRpVzPECId63rFQyCXEeMj9FxA1KoUgQgPGyif0msWdSBzxKMbET3YB/28Q8MD"
+    "gR4qAyUSntuV0UrTZ82GAbhXYU4Ar7ZDZtiK8YS/et6goB6tIku0oaAbJYRs4G/+"
+    "avCuLdVEy8Ndie+MeqksTuTSDYHMXW+phoKXU6qJcLs7BhZGRCqkzo+iuTcHXOjj"
+    "oAK0FApiC+rBMMirgPmESR83U853tbGbUisN8Zud6R8mOBLbZQc4erMycFD9DYbB"
+    "LqlG1EtBIzxKbSdzoT1/Gn9ha9ntjSM8ReO8GaXq08SxwB0TEFGe8K9Yp/UXsyXC"
+    "BNZYwl4EUTGNchmhzOP/HsYt8Wb4nVbXnOVgevJK81x58nWn5Ne4j/xHAYDhP0A7"
+    "cHxyJ8qv8CTlVcUZXKiYChhdZgXvrREPecK3BfT5AFM=";
+
+// RSA-2048/SHA-256 IAS report signing cert valid 2016-2026, by ias_root_ca
+static const char ias_report_signing_cert[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIEoTCCAwmgAwIBAgIJANEHdl0yo7CWMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV\n"
+    "BAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwLU2FudGEgQ2xhcmExGjAYBgNV\n"
+    "BAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQDDCdJbnRlbCBTR1ggQXR0ZXN0\n"
+    "YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwHhcNMTYxMTIyMDkzNjU4WhcNMjYxMTIw\n"
+    "MDkzNjU4WjB7MQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExFDASBgNVBAcMC1Nh\n"
+    "bnRhIENsYXJhMRowGAYDVQQKDBFJbnRlbCBDb3Jwb3JhdGlvbjEtMCsGA1UEAwwk\n"
+    "SW50ZWwgU0dYIEF0dGVzdGF0aW9uIFJlcG9ydCBTaWduaW5nMIIBIjANBgkqhkiG\n"
+    "9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqXot4OZuphR8nudFrAFiaGxxkgma/Es/BA+t\n"
+    "beCTUR106AL1ENcWA4FX3K+E9BBL0/7X5rj5nIgX/R/1ubhkKWw9gfqPG3KeAtId\n"
+    "cv/uTO1yXv50vqaPvE1CRChvzdS/ZEBqQ5oVvLTPZ3VEicQjlytKgN9cLnxbwtuv\n"
+    "LUK7eyRPfJW/ksddOzP8VBBniolYnRCD2jrMRZ8nBM2ZWYwnXnwYeOAHV+W9tOhA\n"
+    "ImwRwKF/95yAsVwd21ryHMJBcGH70qLagZ7Ttyt++qO/6+KAXJuKwZqjRlEtSEz8\n"
+    "gZQeFfVYgcwSfo96oSMAzVr7V0L6HSDLRnpb6xxmbPdqNol4tQIDAQABo4GkMIGh\n"
+    "MB8GA1UdIwQYMBaAFHhDe3amfrzQr35CN+s1fDuHAVE8MA4GA1UdDwEB/wQEAwIG\n"
+    "wDAMBgNVHRMBAf8EAjAAMGAGA1UdHwRZMFcwVaBToFGGT2h0dHA6Ly90cnVzdGVk\n"
+    "c2VydmljZXMuaW50ZWwuY29tL2NvbnRlbnQvQ1JML1NHWC9BdHRlc3RhdGlvblJl\n"
+    "cG9ydFNpZ25pbmdDQS5jcmwwDQYJKoZIhvcNAQELBQADggGBAGcIthtcK9IVRz4r\n"
+    "Rq+ZKE+7k50/OxUsmW8aavOzKb0iCx07YQ9rzi5nU73tME2yGRLzhSViFs/LpFa9\n"
+    "lpQL6JL1aQwmDR74TxYGBAIi5f4I5TJoCCEqRHz91kpG6Uvyn2tLmnIdJbPE4vYv\n"
+    "WLrtXXfFBSSPD4Afn7+3/XUggAlc7oCTizOfbbtOFlYA4g5KcYgS1J2ZAeMQqbUd\n"
+    "ZseZCcaZZZn65tdqee8UXZlDvx0+NdO0LR+5pFy+juM0wWbu59MvzcmTXbjsi7HY\n"
+    "6zd53Yq5K244fwFHRQ8eOB0IWB+4PfM7FeAApZvlfqlKOlLcZL2uyVmzRkyR5yW7\n"
+    "2uo9mehX44CiPJ2fse9Y6eQtcfEhMPkmHXI01sN+KwPbpA39+xOsStjhP9N1Y1a2\n"
+    "tQAVo+yVgLgV2Hws73Fc0o3wC78qPEA+v2aRs/Be3ZFDgDyghc/1fgU+7C+P6kbq\n"
+    "d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==\n"
+    "-----END CERTIFICATE-----\n";
+
+static const char mock_verification_report[] =
+    "{\"nonce\":\"35E8FB64ACFB4A8E\","
+    "\"id\":\"284773557701539118279755254416631834508\","
+    "\"timestamp\":\"2018-07-11T19:30:35.556996\","
+    "\"epidPseudonym\":\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/Z2nnoViIYY8W8"
+    "TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/RfhtF8"
+    "yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/CJqEkTZK7U=\","
+    "\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\","
+    "\"platformInfoBlob\":\"150200650400070000080801010101000000000000"
+    "0000000007000006000000020000000000000AE791776C1D5C169132CA96D56CC"
+    "2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33"
+    "FF511E74BC318E8E0C37483C5B08899D1B5E9F\","
+    "\"isvEnclaveQuoteBody\":\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbd"
+    "tyMgAAAAAAAAAAAAAAAAAAAAABwf///8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+UpC5HcF6MBCXsbYd"
+    "5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "Cp0uDGT8avpUCoA1LU47KLt5L/RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
+    "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAA\"}";
+
+static const char mock_signature[] =
+    "TuHse3QCPZtyZP436ltUAc6cVlIDzwKyjguOBDMmoou/NlGylzY0EtOEbHvVZ28H"
+    "T8U1CiCVVmZso2ut2HY3zFDfpUg5/FV7FUSw/UhDOu3xkDwicrOvd/P1C3BKWJ6v"
+    "JWghv3QLpgDItQPapFH/3OfciWs10kC3KV4UY+Irkrrck9+h3+FaltM/52AL1m1Q"
+    "WZIutMk1gDs5nz5N87gGvbc9VJKXx/RDDmvX1rLfqnPpH3owkprVLhU8iLcmPPN+"
+    "irjfH4f4GGrnbWYCYK5wfB1BBbFl8ppqxm4Gr8ekePCPLMjYYLpKYWEipvTgaYl6"
+    "3zg+C9r8g+sIA3I9Jr3Exg==";
+
+
+int
+main(void)
+{
+    bool is_ok;
+    int  count = 0;
+
+#if OPENSSL_API_COMPAT < 0x10100000L
+    OpenSSL_add_all_digests();
+#endif
+
+    printf("Verify RSA signature test . . . ");
+    is_ok = verify_signature(test_cert,
+        message, strlen(message),
+        signature, strlen(signature));
+    printf("rc=%d, %s\n", (int)is_ok, is_ok ? "PASSED" : "FAILED");
+    if (!is_ok)
+          ++count;
+
+    printf("Verify RSA signature IAS report test . . . ");
+    is_ok = verify_signature(ias_report_signing_cert,
+        mock_verification_report, strlen(mock_verification_report),
+        mock_signature, strlen(mock_signature));
+    printf("rc=%d, %s\n", (int)is_ok, is_ok ? "PASSED" : "FAILED");
+    if (!is_ok)
+          ++count;
+
+    printf("Verify RSA signature negative test (wrong cert) . . . ");
+    is_ok = verify_signature(test_cert,
+        mock_verification_report, strlen(mock_verification_report),
+        mock_signature, strlen(mock_signature));
+    printf("rc=%d, %s\n", (int)is_ok, is_ok ? "FAILED" : "PASSED");
+    if (is_ok) // expected to fail, but did not
+          ++count;
+
+    // Summarize
+    if (count == 0) {
+        printf("RSA signature verification tests PASSED.\n");
+    } else {
+        printf("RSA signature verification FAILED %d tests.\n", count);
+    }
+
+    return count;
+}

--- a/tools/rebuild.sh
+++ b/tools/rebuild.sh
@@ -162,6 +162,13 @@ cd build
 try cmake ..
 try make "-j$NUM_CORES"
 
+yell --------------- COMMON CPP TESTS ---------------
+cd $TCF_HOME/common/cpp/tests || error_exit "Failed to change to the directory"
+
+mkdir -p build
+try make "-j$NUM_CORES"
+try make test "-j$NUM_CORES"
+
 yell --------------- TRUSTED WORKER MANAGER COMMON ---------------
 cd $TCF_HOME/tc/sgx/trusted_worker_manager/common || error_exit "Failed to change to the directory"
 


### PR DESCRIPTION
Add standalone unit tests for source files in `common/cpp`
in a new `common/cpp/test/` directory.
These are mostly Cryptographic functions implemented with OpenSSL.

Enable in rebuild.sh and run_tests.sh.

Signed-off-by: danintel <daniel.anderson@intel.com>