### PR TITLE
Add MbedTLS Random and Digest Crypto Code as an Alternative to OpenSSL

### DIFF
--- a/common/cpp/c11_support.cpp
+++ b/common/cpp/c11_support.cpp
@@ -40,15 +40,15 @@ int memcpy_s(void *dest, size_t sizeInBytes, const void *src, size_t count) {
         return 0;
     }
 
-    if (dest == NULL) {
+    if (dest == nullptr) {
         return EINVAL;
     }
 
-    if (src == NULL || sizeInBytes < count) {
+    if (src == nullptr || sizeInBytes < count) {
         /* zero the destination buffer */
         memset(dest, 0, sizeInBytes);
 
-        if (src == NULL) {
+        if (src == nullptr) {
             return EINVAL;
         }
 
@@ -62,11 +62,11 @@ int memcpy_s(void *dest, size_t sizeInBytes, const void *src, size_t count) {
 }
 
 int strncpy_s(char *dest, size_t sizeInBytes, const char *src, size_t count) {
-    if (count == 0 && dest == NULL && sizeInBytes == 0) {
+    if (count == 0 && dest == nullptr && sizeInBytes == 0) {
         return 0;
     }
 
-    if (dest == NULL || sizeInBytes <= 0) {
+    if (dest == nullptr || sizeInBytes <= 0) {
         return EINVAL;
     }
 
@@ -75,7 +75,7 @@ int strncpy_s(char *dest, size_t sizeInBytes, const char *src, size_t count) {
         return 0;
     }
 
-    if (src == NULL) {
+    if (src == nullptr) {
         *dest = 0;
         return EINVAL;
     }
@@ -88,7 +88,7 @@ int strncpy_s(char *dest, size_t sizeInBytes, const char *src, size_t count) {
     } else {
         while ((*p++ = *src++) != 0 && --availableSize > 0 && --count > 0) {}
         if (count == 0) {
-            p = NULL;
+            p = nullptr;
         }
     }
 
@@ -104,7 +104,7 @@ int strncpy_s(char *dest, size_t sizeInBytes, const char *src, size_t count) {
 }
 
 int strnlen_s(const char *str, size_t sizeInBytes) {
-    if (str == NULL) {
+    if (str == nullptr) {
         return 0;
     }
 

--- a/common/cpp/crypto/crypto_shared.h
+++ b/common/cpp/crypto/crypto_shared.h
@@ -20,24 +20,30 @@
 
 #pragma once
 
+#if defined(CRYPTOLIB_OPENSSL) && defined(CRYPTOLIB_MBEDTLS)
+#error "CRYPTOLIB_OPENSSL and CRYPTOLIB_MBEDTLS cannot both be defined at once"
+#endif
 #if !defined(CRYPTOLIB_OPENSSL) && !defined(CRYPTOLIB_MBEDTLS)
 #define CRYPTOLIB_OPENSSL // default
 #endif
 
-#ifdef CRYPTOLIB_OPENSSL
+// These headers will be OpenSSL only when MBed TLS is implemented for RSA
+//#ifdef CRYPTOLIB_OPENSSL
 #include <openssl/obj_mac.h> // NID_*
 #include <openssl/rsa.h>
-#endif
+//#endif
 
 namespace tcf {
 namespace crypto {
     namespace constants {
+//#ifdef CRYPTOLIB_OPENSSL
         // OpenSSL: Secp256k1 elliptical curve cryptography
         const int CURVE = NID_secp256k1;
         // OpenSSL: OAEP padding or better should always be used for RSA
         const int RSA_PADDING_SCHEME = RSA_PKCS1_OAEP_PADDING;
         // OpenSSL Error string buffer size
         const int ERR_BUF_LEN = 130;
+//#endif
     }  // namespace constants
 }  // namespace crypto
 }  // namespace tcf

--- a/common/cpp/crypto/mbedtls/crypto_utils.cpp
+++ b/common/cpp/crypto/mbedtls/crypto_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018 Intel Corporation
+/* Copyright 2018-2020 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,20 @@
  * @file
  * Avalon Crypto Utilities:
  * hashing, base 64 conversion, random number generation.
- * Implemented using OpenSSL.
+ * Implemented using Mbed TLS.
  */
 
-#include <openssl/err.h>
-#include <openssl/rand.h>
-#include <openssl/sha.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/sha256.h>
 
 #include "crypto_shared.h"
 #include "crypto_utils.h"
 #include "error.h"
 #include "tcf_error.h"
 
-#ifndef CRYPTOLIB_OPENSSL
-#error "CRYPTOLIB_OPENSSL must be defined to compile source with OpenSSL."
+#ifndef CRYPTOLIB_MBEDTLS
+#error "CRYPTOLIB_MBEDTLS must be defined to compile source with Mbed TLS."
 #endif
 
 namespace pcrypto = tcf::crypto;
@@ -48,7 +48,7 @@ namespace Error = tcf::error;
  * @returns byte array with binary random bits
  */
 ByteArray pcrypto::RandomBitString(size_t length) {
-    char err[constants::ERR_BUF_LEN];
+    static mbedtls_ctr_drbg_context ctr_drbg;
     ByteArray buf(length);
     int res = 0;
 
@@ -58,13 +58,31 @@ ByteArray pcrypto::RandomBitString(size_t length) {
         throw Error::ValueError(msg);
     }
 
-    res = RAND_bytes(buf.data(), length);
+    // One-time initialization
+    static bool init = false;
+    if (!init) {
+        static const unsigned char *custom =
+            (const unsigned char *)"Hyperledger Avalon";
+        mbedtls_entropy_context  entropy;
 
-    if (res != 1) {
-        std::string msg("Crypto Error (RandomBitString): ");
-        ERR_load_crypto_strings();
-        ERR_error_string(ERR_get_error(), err);
-        msg += err;
+        mbedtls_entropy_init(&entropy);
+        mbedtls_ctr_drbg_init(&ctr_drbg);
+
+        res = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func,
+            &entropy, custom, sizeof (custom));
+        if (res != 0) {
+            std::string msg("Crypto Error (RandomBitString): "
+                "mbedtls_ctr_drbg_seed() failed");
+            throw Error::RuntimeError(msg);
+        }
+        init = true;
+    }
+
+    // Generate randomness
+    res = mbedtls_ctr_drbg_random(&ctr_drbg, buf.data(), length);
+    if (res != 0) {
+        std::string msg("Crypto Error (RandomBitString): "
+            "mbedtls_ctr_drbg_random() failed");
         throw Error::RuntimeError(msg);
     }
 
@@ -83,6 +101,7 @@ ByteArray pcrypto::RandomBitString(size_t length) {
 ByteArray pcrypto::ComputeMessageHash(const ByteArray& message) {
     ByteArray hash(constants::DIGEST_LENGTH);
 
-    SHA256((const unsigned char*)message.data(), message.size(), hash.data());
+    mbedtls_sha256_ret((const unsigned char*)message.data(), message.size(),
+        hash.data(), 0);
     return hash;
 }  // pcrypto::ComputeMessageHash

--- a/common/cpp/crypto/pkenc_private_key.cpp
+++ b/common/cpp/crypto/pkenc_private_key.cpp
@@ -58,7 +58,8 @@ RSA* deserializeRSAPrivateKey(const std::string& encoded) {
         throw Error::RuntimeError(msg);
     }
 
-    RSA* private_key = PEM_read_bio_RSAPrivateKey(bio.get(), NULL, NULL, NULL);
+    RSA* private_key = PEM_read_bio_RSAPrivateKey(bio.get(),
+        nullptr, nullptr, nullptr);
     if (!private_key) {
         std::string msg("Crypto Error (deserializeRSAPrivateKey): "
             "Could not deserialize private RSA key");
@@ -184,7 +185,7 @@ void pcrypto::pkenc::PrivateKey::Generate() {
         throw Error::RuntimeError(msg);
     }
     if (!RSA_generate_key_ex(private_key.get(), constants::RSA_KEY_SIZE,
-            exp.get(), NULL)) {
+            exp.get(), nullptr)) {
         std::string msg("Crypto  Error (pkenc::PrivateKey()): "
             "Could not generate RSA key");
         throw Error::RuntimeError(msg);
@@ -215,7 +216,7 @@ std::string pcrypto::pkenc::PrivateKey::Serialize() const {
     }
 
     int res = PEM_write_bio_RSAPrivateKey(bio.get(), private_key_,
-        NULL, NULL, 0, 0, NULL);
+        nullptr, nullptr, 0, 0, nullptr);
     if (!res) {
         std::string msg("Crypto Error (Serialize): Could not write to BIO\n");
         throw Error::RuntimeError(msg);

--- a/common/cpp/crypto/pkenc_public_key.cpp
+++ b/common/cpp/crypto/pkenc_public_key.cpp
@@ -58,7 +58,8 @@ RSA* deserializeRSAPublicKey(const std::string& encoded) {
         throw Error::RuntimeError(msg);
     }
 
-    RSA* public_key = PEM_read_bio_RSAPublicKey(bio.get(), NULL, NULL, NULL);
+    RSA* public_key = PEM_read_bio_RSAPublicKey(bio.get(),
+        nullptr, nullptr, nullptr);
     if (!public_key) {
         std::string msg(
             "Crypto Error (deserializeRSAPublicKey): Could not "

--- a/common/cpp/crypto/sig_private_key.cpp
+++ b/common/cpp/crypto/sig_private_key.cpp
@@ -69,7 +69,7 @@ EC_KEY* deserializeECDSAPrivateKey(const std::string& encoded) {
     }
 
     EC_KEY* private_key = PEM_read_bio_ECPrivateKey(bio.get(),
-        NULL, NULL, NULL);
+        nullptr, nullptr, nullptr);
     if (!private_key) {
         std::string msg(
             "Crypto Error (deserializeECDSAPrivateKey): Could not "
@@ -241,7 +241,8 @@ std::string pcrypto::sig::PrivateKey::Serialize() const {
         throw Error::RuntimeError(msg);
     }
 
-    PEM_write_bio_ECPrivateKey(bio.get(), private_key_, NULL, NULL, 0, 0, NULL);
+    PEM_write_bio_ECPrivateKey(bio.get(), private_key_,
+        nullptr, nullptr, 0, 0, nullptr);
 
     int keylen = BIO_pending(bio.get());
 
@@ -311,7 +312,7 @@ ByteArray pcrypto::sig::PrivateKey::SignMessage(
     }
 
     int res = EC_GROUP_get_order(EC_KEY_get0_group(private_key_), ord.get(),
-        NULL);
+        nullptr);
     if (!res) {
         std::string msg("Crypto Error (SignMessage): Could not get order");
         throw Error::RuntimeError(msg);

--- a/common/cpp/crypto/sig_public_key.cpp
+++ b/common/cpp/crypto/sig_public_key.cpp
@@ -62,7 +62,8 @@ EC_KEY* deserializeECDSAPublicKey(const std::string& encoded) {
         throw Error::RuntimeError(msg);
     }
 
-    EC_KEY* public_key = PEM_read_bio_EC_PUBKEY(bio.get(), NULL, NULL, NULL);
+    EC_KEY* public_key = PEM_read_bio_EC_PUBKEY(bio.get(),
+        nullptr, nullptr, nullptr);
     if (!public_key) {
         std::string msg(
             "Crypto Error (deserializeECDSAPublicKey): Could not "
@@ -126,7 +127,7 @@ pcrypto::sig::PublicKey::PublicKey(const pcrypto::sig::PrivateKey& privateKey) {
 
     if (!EC_POINT_mul(ec_group.get(), p.get(),
             EC_KEY_get0_private_key(privateKey.private_key_),
-            NULL, NULL, context.get())) {
+            nullptr, nullptr, context.get())) {
         std::string msg(
             "Crypto Error (sig::PublicKey()): Could not compute EC_POINT_mul");
         throw Error::RuntimeError(msg);
@@ -268,7 +269,7 @@ void pcrypto::sig::PublicKey::DeserializeXYFromHex(const std::string& hexXY) {
     }
 
     EC_POINT_ptr p(EC_POINT_hex2point(
-        ec_group.get(), hexXY.data(), NULL, NULL), EC_POINT_free);
+        ec_group.get(), hexXY.data(), nullptr, nullptr), EC_POINT_free);
     if (!p) {
         std::string msg("Crypto Error (sig::DeserializeXYFromHex): "
             "Could not create new EC_POINT");
@@ -351,7 +352,7 @@ std::string pcrypto::sig::PublicKey::SerializeXYToHex() const {
 
     cstring = EC_POINT_point2hex(EC_KEY_get0_group(public_key_),
         EC_KEY_get0_public_key(public_key_), POINT_CONVERSION_UNCOMPRESSED,
-        NULL);
+        nullptr);
     if (!cstring) {
         std::string msg("Crypto Error (SerializeXYToHex): "
             "Could not serialize EC public key");
@@ -376,7 +377,7 @@ int pcrypto::sig::PublicKey::VerifySignature(
     // Decode signature B64 -> DER -> ECDSA_SIG
     const unsigned char* der_SIG = (const unsigned char*)signature.data();
     ECDSA_SIG_ptr sig(
-        d2i_ECDSA_SIG(NULL, (const unsigned char**)(&der_SIG),
+        d2i_ECDSA_SIG(nullptr, (const unsigned char**)(&der_SIG),
             signature.size()), ECDSA_SIG_free);
     if (!sig) {
         return -1;

--- a/common/cpp/crypto/skenc.cpp
+++ b/common/cpp/crypto/skenc.cpp
@@ -126,14 +126,14 @@ ByteArray pcrypto::skenc::EncryptMessage(
     }
 
     if (EVP_EncryptInit_ex(context.get(), EVP_aes_256_gcm(),
-            NULL, NULL, NULL) != 1) {
+            nullptr, nullptr, nullptr) != 1) {
         std::string msg(
             "Crypto Error (EncryptMessage): OpenSSL could not "
             "initialize EVP_CIPHER_CTX with AES-GCM");
         throw Error::RuntimeError(msg);
     }
 
-    if (EVP_EncryptInit_ex(context.get(), NULL, NULL,
+    if (EVP_EncryptInit_ex(context.get(), nullptr, nullptr,
             (const unsigned char*)key.data(),
             (const unsigned char*)iv.data()) != 1) {
         std::string msg(
@@ -257,7 +257,7 @@ ByteArray pcrypto::skenc::DecryptMessage(
     }
 
     if (!EVP_DecryptInit_ex(context.get(), EVP_aes_256_gcm(),
-            NULL, NULL, NULL)) {
+            nullptr, nullptr, nullptr)) {
         std::string msg(
             "Crypto Error (DecryptMessage): OpenSSL could not "
             "initialize EVP_CIPHER_CTX with "
@@ -265,7 +265,7 @@ ByteArray pcrypto::skenc::DecryptMessage(
         throw Error::RuntimeError(msg);
     }
 
-    if (!EVP_DecryptInit_ex(context.get(), NULL, NULL,
+    if (!EVP_DecryptInit_ex(context.get(), nullptr, nullptr,
             (const unsigned char*)key.data(),
             (const unsigned char*)iv.data())) {
         std::string msg(
@@ -353,14 +353,14 @@ ByteArray pcrypto::skenc::DecryptMessage(const ByteArray& key,
     }
 
     if (!EVP_DecryptInit_ex(context.get(), EVP_aes_256_gcm(),
-            NULL, NULL, NULL)) {
+            nullptr, nullptr, nullptr)) {
         std::string msg(
             "Crypto Error (DecryptMessage): OpenSSL could not "
             "initialize EVP_CIPHER_CTX with AES-GCM");
         throw Error::RuntimeError(msg);
     }
 
-    if (!EVP_DecryptInit_ex(context.get(), NULL, NULL,
+    if (!EVP_DecryptInit_ex(context.get(), nullptr, nullptr,
             (const unsigned char*)key.data(),
             (const unsigned char*)message.data())) {
         std::string msg(

--- a/common/cpp/crypto/verify_certificate.cpp
+++ b/common/cpp/crypto/verify_certificate.cpp
@@ -37,21 +37,21 @@
 bool verify_certificate_chain(const char* cert_pem,
                               const char* ca_cert_pem)
 {
-    if (cert_pem == NULL || ca_cert_pem == NULL) // sanity check
+    if (cert_pem == nullptr || ca_cert_pem == nullptr) // sanity check
         return false;
 
     BIO* crt_bio = BIO_new_mem_buf((void*)cert_pem, -1);
-    X509* crt = PEM_read_bio_X509(crt_bio, NULL, 0, NULL);
-    assert(crt != NULL);
+    X509* crt = PEM_read_bio_X509(crt_bio, nullptr, 0, nullptr);
+    assert(crt != nullptr);
 
     BIO* cacrt_bio = BIO_new_mem_buf((void*)ca_cert_pem, -1);
-    X509* cacrt = PEM_read_bio_X509(cacrt_bio, NULL, 0, NULL);
-    assert(cacrt != NULL);
+    X509* cacrt = PEM_read_bio_X509(cacrt_bio, nullptr, 0, nullptr);
+    assert(cacrt != nullptr);
 
     X509_STORE* s = X509_STORE_new();
     X509_STORE_add_cert(s, cacrt);
     X509_STORE_CTX* ctx = X509_STORE_CTX_new();
-    X509_STORE_CTX_init(ctx, s, crt, NULL);
+    X509_STORE_CTX_init(ctx, s, crt, nullptr);
     int rc = X509_verify_cert(ctx);
 
     X509_STORE_CTX_free(ctx);

--- a/common/cpp/crypto/verify_signature.cpp
+++ b/common/cpp/crypto/verify_signature.cpp
@@ -39,7 +39,7 @@
 static unsigned int
 base64_decoded_length(const char *encoded, unsigned int encoded_len)
 {
-    if (encoded == NULL || encoded_len == 0) {
+    if (encoded == nullptr || encoded_len == 0) {
         return 0;
     }
 
@@ -75,7 +75,7 @@ bool verify_signature(const char* cert_pem,
     int ret;
 
     // Sanity checks
-    if (cert_pem == NULL || signature == NULL)
+    if (cert_pem == nullptr || signature == nullptr)
         return false;
     unsigned int decoded_len = base64_decoded_length(signature, signature_len);
     if (decoded_len > max_decoded_len)
@@ -83,14 +83,14 @@ bool verify_signature(const char* cert_pem,
 
     BIO* crt_bio = BIO_new_mem_buf((void*)cert_pem, -1);
 
-    X509* crt = PEM_read_bio_X509(crt_bio, NULL, 0, NULL);
-    assert(crt != NULL);
+    X509* crt = PEM_read_bio_X509(crt_bio, nullptr, 0, nullptr);
+    assert(crt != nullptr);
 
     EVP_PKEY* key = X509_get_pubkey(crt);
-    assert(key != NULL);
+    assert(key != nullptr);
 
     EVP_MD_CTX* ctx = EVP_MD_CTX_create();
-    ret = EVP_VerifyInit_ex(ctx, EVP_sha256(), NULL);
+    ret = EVP_VerifyInit_ex(ctx, EVP_sha256(), nullptr);
     assert(ret == 1);
 
     ret = EVP_VerifyUpdate(ctx, msg, msg_len);

--- a/common/cpp/json_utils.h
+++ b/common/cpp/json_utils.h
@@ -22,7 +22,7 @@
 
 const char* GetJsonStr(const JSON_Object* json_object,
                        const char* name,
-                       const char* err_msg = NULL);
+                       const char* err_msg = nullptr);
 
 void JsonSetStr(JSON_Object* json, const char* name, const char* value,
     const char* err);

--- a/common/cpp/tests/Makefile
+++ b/common/cpp/tests/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CPPFLAGS= -D_UNTRUSTED_ -DCRYPTOLIB_OPENSSL
+CPPFLAGS= -D_UNTRUSTED_
 CPPFLAGS+= -I..  -I../crypto -I../packages/base64
 LDFLAGS=-lcrypto
 
@@ -22,11 +22,15 @@ ifdef CRYPTOLIB_MBEDTLS
 	CPPFLAGS+= -DCRYPTOLIB_MBEDTLS
 	LDFLAGS+=-lmbedcrypto
 endif
+ifdef CRYPTOLIB_OPENSSL
+	CPPFLAGS+= -DCRYPTOLIB_OPENSSL
+endif
 
 UTILTESTOBJS= build/crypto_utils.o build/crypto_utils_encrypt.o \
 		build/skenc.o build/types.o \
 		build/hex_string.o build/utils.o build/base64.o
 
+# First matching pattern build rule found is used
 build/%: build/%.o
 	g++ -o $@ $^ $(LDFLAGS)
 
@@ -36,10 +40,40 @@ build/%.o: %.cpp
 build/%.o: ../%.cpp
 	g++ -o $@ $(CPPFLAGS) -c $^
 
-build/%.o: ../crypto/%.cpp
+build/%.o: ../packages/base64/%.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+
+# Library-specific source has precedence over generic source in ../crypto/
+
+UTILTESTOBJS= build/crypto_utils.o build/crypto_utils_encrypt.o \
+		build/skenc.o build/types.o \
+		build/hex_string.o build/utils.o build/base64.o
+
+# First matching pattern build rule found is used
+build/%: build/%.o
+	g++ -o $@ $^ $(LDFLAGS)
+
+build/%.o: %.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+
+build/%.o: ../%.cpp
 	g++ -o $@ $(CPPFLAGS) -c $^
 
 build/%.o: ../packages/base64/%.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+
+# Library-specific source has precedence over generic source in ../crypto/
+ifdef CRYPTOLIB_OPENSSL
+build/%.o: ../crypto/openssl/%.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+endif
+
+ifdef CRYPTOLIB_MBEDTLS
+build/%.o: ../crypto/mbedtls/%.cpp
+	g++ -o $@ $(CPPFLAGS) -c $^
+endif
+
+build/%.o: ../crypto/%.cpp
 	g++ -o $@ $(CPPFLAGS) -c $^
 
 

--- a/common/cpp/tests/b64test.cpp
+++ b/common/cpp/tests/b64test.cpp
@@ -88,21 +88,21 @@ main(void)
         {"H", "SA==", 1},
         {"", "", 0},
         {rsa_2048_signature_decoded, rsa_2048_signature, 256},
-        {NULL, NULL}
+        {nullptr, nullptr}
     };
     static b64_test_type negative_test_cases[] = {
-        {NULL, "`~!@#$%^&*()-_|':;?>,,.\\", 0},
-        {NULL, "===", 0},
-        {NULL, "==", 0},
-        {NULL, "=", 0},
-        {NULL, NULL, 0}
+        {nullptr, "`~!@#$%^&*()-_|':;?>,,.\\", 0},
+        {nullptr, "===", 0},
+        {nullptr, "==", 0},
+        {nullptr, "=", 0},
+        {nullptr, nullptr, 0}
     };
     char buffer[256 + 3];
     int  rc, count = 0;
     ByteArray v;
     std::string out_str;
 
-    for (b64_test_type *tp = b64_test_cases; tp->encoded != NULL; ++tp) {
+    for (b64_test_type *tp = b64_test_cases; tp->encoded != nullptr; ++tp) {
         // Test OpenSSL decode
         memset(buffer, 0, sizeof (buffer));
         rc = EVP_DecodeBlock((unsigned char *)buffer,
@@ -163,7 +163,7 @@ main(void)
     }
 
     // Negative tests
-    for (b64_test_type *ntp = negative_test_cases; ntp->encoded != NULL;
+    for (b64_test_type *ntp = negative_test_cases; ntp->encoded != nullptr;
             ++ntp) {
         // Test OpenSSL decode
         rc = EVP_DecodeBlock((unsigned char *)buffer,

--- a/common/cpp/tests/signtest.cpp
+++ b/common/cpp/tests/signtest.cpp
@@ -45,15 +45,15 @@ typedef struct ECDSA_SIG_st {
 // Get the R and S bignumber values of an ECDSA signature.
 void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **ptr_r,
         const BIGNUM **ptr_s) {
-    if (ptr_r != NULL)
+    if (ptr_r != nullptr)
         *ptr_r = sig->r;
-    if (ptr_s != NULL)
+    if (ptr_s != nullptr)
         *ptr_s = sig->s;
 }
 
 // Set the R and S bignumber values of an ECDSA signature.
 int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
-    if (r == NULL || s == NULL)
+    if (r == nullptr || s == nullptr)
         return 0;
 
     BN_clear_free(sig->r);

--- a/common/cpp/tests/utiltest.cpp
+++ b/common/cpp/tests/utiltest.cpp
@@ -50,7 +50,7 @@ main(void)
     static hash_test_type hash_test_cases[] = {
         {"Hyperledger Avalon", "22hKjT4z7yvB8D3Ros2/QykiYzXwkJIfJO89Df5xOtQ="},
         {"", "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="},
-        {NULL, NULL}
+        {nullptr, nullptr}
     };
 
     printf("Random number test: RandomBitString()\n");
@@ -75,7 +75,7 @@ main(void)
         ++count;
     }
 
-    for (hash_test_type *tp = hash_test_cases; tp->encoded != NULL; ++tp) {
+    for (hash_test_type *tp = hash_test_cases; tp->encoded != nullptr; ++tp) {
         printf("Hash SHA-256 test: ComputeMessageHash()\n");
         std::string msgStr(tp->plain);
         ByteArray msg;


### PR DESCRIPTION
This first phase adds code for random numbers and SHA-256 digests.

MBedTLS is another cryptographic implementation similar to OpenSSL
in functionality, but with a smaller TCB.
https://www.mbed.com/en/technologies/security/mbed-tls/

This will allow the possibility of using mbedtls-sgx as an alternative to
OpenSSL.

Signed-off-by: danintel <daniel.anderson@intel.com>