### PR TITLE
Add WPE code to generate Nonce

### DIFF
--- a/tc/sgx/trusted_worker_manager/enclave/base_enclave.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/base_enclave.cpp
@@ -33,6 +33,7 @@
 #include "zero.h"
 
 #include "base_enclave.h"
+#include "signup_enclave_common.h"
 #include "enclave_utils.h"
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -48,6 +49,8 @@ tcf_err_t ecall_Initialize() {
     // since it can break confidentiality of workorder execution.
     SAFE_LOG(TCF_LOG_CRITICAL, "enclave initialized with debugging turned on");
 
+    // Initialize Enclave data
+    result = CreateEnclaveData();
     return result;
 }  // ecall_Initialize
 

--- a/tc/sgx/trusted_worker_manager/enclave/enclave_data.h
+++ b/tc/sgx/trusted_worker_manager/enclave/enclave_data.h
@@ -71,6 +71,7 @@ protected:
     std::string encryption_key_signature_;
 
     std::string extended_data_;
+    std::string nonce_;
 
     std::string serialized_private_data_;
     std::string serialized_public_data_;
@@ -101,6 +102,14 @@ public:
 
     void set_extended_data(std::string in_ex_data) {
         extended_data_ = in_ex_data;
+    }
+
+    void set_nonce(std::string nonce) {
+        nonce_ = nonce;
+    }
+
+    std::string get_nonce() {
+        return nonce_;
     }
     std::string get_serialized_signing_key(void) const { return public_signing_key_.Serialize(); }
 

--- a/tc/sgx/trusted_worker_manager/enclave/signup.edl
+++ b/tc/sgx/trusted_worker_manager/enclave/signup.edl
@@ -27,11 +27,6 @@ enclave {
             [out] size_t* pPublicEnclaveDataSize
             );
 
-        public tcf_err_t ecall_CreateEnclaveData(
-            [out] size_t* outPublicEnclaveDataSize,
-            [out] size_t* outSealedEnclaveDataSize
-            );
-
         public tcf_err_t ecall_CreateSignupData(
             [in] const sgx_target_info_t* inTargetInfo,
             [out, size=inAllocatedPublicEnclaveDataSize] char* outPublicEnclaveData,

--- a/tc/sgx/trusted_worker_manager/enclave/signup_enclave_common.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/signup_enclave_common.cpp
@@ -29,6 +29,20 @@
 EnclaveData* EnclaveData::instance = 0;
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+tcf_err_t CreateEnclaveData() {
+    tcf_err_t result = TCF_SUCCESS;
+    try {
+        // Initialize Enclave data
+        EnclaveData* enclaveData = EnclaveData::getInstance();
+    } catch (...) {
+        SAFE_LOG(TCF_LOG_ERROR,
+            "Unknown error in while creating enclave data");
+        result = TCF_ERR_UNKNOWN;
+    }
+    return result;
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 tcf_err_t ecall_CalculateSealedEnclaveDataSize(size_t* pSealedEnclaveDataSize) {
     tcf_err_t result = TCF_SUCCESS;
 
@@ -74,40 +88,6 @@ tcf_err_t ecall_CalculatePublicEnclaveDataSize(size_t* pPublicEnclaveDataSize) {
 
     return result;
 }  // ecall_CalculatePublicEnclaveDataSize
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-tcf_err_t ecall_CreateEnclaveData(size_t* outPublicEnclaveDataSize,
-    size_t* outSealedEnclaveDataSize) {
-    tcf_err_t result = TCF_SUCCESS;
-    try {
-        tcf::error::ThrowIfNull(outPublicEnclaveDataSize,
-            "Public data size pointer is NULL");
-        tcf::error::ThrowIfNull(outSealedEnclaveDataSize,
-            "Sealed data size pointer is NULL");
-
-        (*outPublicEnclaveDataSize) = 0;
-        (*outSealedEnclaveDataSize) = 0;
-
-        // Create the enclave data
-        EnclaveData* enclaveData = EnclaveData::getInstance();
-
-        // Pass back the actual size of the enclave data
-        (*outPublicEnclaveDataSize) = enclaveData->get_public_data_size();
-        (*outSealedEnclaveDataSize) = enclaveData->get_sealed_data_size();
-    } catch (tcf::error::Error& e) {
-        SAFE_LOG(TCF_LOG_ERROR,
-            "Error in Avalon enclave(ecall_CreateEnclaveData): %04X -- %s",
-            e.error_code(), e.what());
-        ocall_SetErrorMessage(e.what());
-        result = e.error_code();
-    } catch (...) {
-        SAFE_LOG(TCF_LOG_ERROR,
-            "Unknown error in Avalon enclave(ecall_CreateEnclaveData)");
-        result = TCF_ERR_UNKNOWN;
-    }
-
-    return result;
-}  // ecall_CreateEnclaveData
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 tcf_err_t ecall_UnsealEnclaveData(char* outPublicEnclaveData,

--- a/tc/sgx/trusted_worker_manager/enclave/signup_enclave_common.h
+++ b/tc/sgx/trusted_worker_manager/enclave/signup_enclave_common.h
@@ -17,12 +17,11 @@
 #include <string.h>
 #include "tcf_error.h"
 
+tcf_err_t CreateEnclaveData();
+
 tcf_err_t ecall_CalculateSealedEnclaveDataSize(size_t* pSealedEnclaveDataSize);
 
 tcf_err_t ecall_CalculatePublicEnclaveDataSize(size_t* pPublicEnclaveDataSize);
-
-tcf_err_t ecall_CreateEnclaveData(size_t* outPublicEnclaveDataSize,
-    size_t* outSealedEnclaveDataSize);
 
 tcf_err_t ecall_UnsealEnclaveData(char* outPublicEnclaveData,
     size_t inAllocatedPublicEnclaveDataSize);

--- a/tc/sgx/trusted_worker_manager/enclave/signup_wpe.edl
+++ b/tc/sgx/trusted_worker_manager/enclave/signup_wpe.edl
@@ -18,6 +18,10 @@ enclave {
     include "tcf_error.h"
 
     trusted {
+        public tcf_err_t ecall_GenerateNonce(
+           [out, size=in_nonce_size] uint8_t* out_nonce,
+           size_t in_nonce_size
+        );
         public tcf_err_t ecall_CreateSignupDataWPE(
             [in] const sgx_target_info_t* inTargetInfo,
             [in] const uint8_t* inExtData,

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_kme.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_kme.cpp
@@ -38,31 +38,13 @@ tcf_err_t SignupDataKME::CreateEnclaveData(
         tcf_err_t presult = TCF_SUCCESS;
         sgx_status_t sresult;
 
-        size_t computed_public_enclave_data_size = 0;
-        size_t computed_sealed_enclave_data_size = 0;
-
         // Get the enclave id for passing into the ecall
         sgx_enclave_id_t enclaveid = g_Enclave[0].GetEnclaveId();
 
-        // Create enclave signature key and encryption key pair
-        sresult = g_Enclave[0].CallSgx(
-            [enclaveid,
-             &presult,
-             &computed_public_enclave_data_size,
-             &computed_sealed_enclave_data_size] () {
-                sgx_status_t ret = ecall_CreateEnclaveData(
-                    enclaveid,
-                    &presult,
-                    &computed_public_enclave_data_size,
-                    &computed_sealed_enclave_data_size);
-                return tcf::error::ConvertErrorStatus(ret, presult);
-            });
-        tcf::error::ThrowSgxError(sresult,
-            "SGX enclave call failed (ecall_CreateEnclaveData), failed to create signup data");
-        g_Enclave[0].ThrowTCFError(presult);
-
-        outPublicEnclaveData.resize(computed_public_enclave_data_size);
-        ByteArray sealed_enclave_data_buffer(computed_sealed_enclave_data_size);
+        outPublicEnclaveData.resize(
+            SignupData::CalculatePublicEnclaveDataSize());
+        ByteArray sealed_enclave_data_buffer(
+            SignupData::CalculateSealedEnclaveDataSize());
     
         // We need target info in order to create signup data report
         sgx_target_info_t target_info = { 0 };

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_singleton.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_singleton.cpp
@@ -35,31 +35,13 @@ tcf_err_t SignupDataSingleton::CreateEnclaveData(
         tcf_err_t presult = TCF_SUCCESS;
         sgx_status_t sresult;
 
-        size_t computed_public_enclave_data_size = 0;
-        size_t computed_sealed_enclave_data_size = 0;
-
         // Get the enclave id for passing into the ecall
         sgx_enclave_id_t enclaveid = g_Enclave[0].GetEnclaveId();
 
-        // Create enclave signature key and encryption key pair
-        sresult = g_Enclave[0].CallSgx(
-            [enclaveid,
-             &presult,
-             &computed_public_enclave_data_size,
-             &computed_sealed_enclave_data_size] () {
-                sgx_status_t ret = ecall_CreateEnclaveData(
-                    enclaveid,
-                    &presult,
-                    &computed_public_enclave_data_size,
-                    &computed_sealed_enclave_data_size);
-                return tcf::error::ConvertErrorStatus(ret, presult);
-            });
-        tcf::error::ThrowSgxError(sresult,
-            "SGX enclave call failed (ecall_CreateEnclaveData), failed to create signup data");
-        g_Enclave[0].ThrowTCFError(presult);
-
-        outPublicEnclaveData.resize(computed_public_enclave_data_size);
-        ByteArray sealed_enclave_data_buffer(computed_sealed_enclave_data_size);
+        outPublicEnclaveData.resize(
+            SignupData::CalculatePublicEnclaveDataSize());
+        ByteArray sealed_enclave_data_buffer(
+            SignupData::CalculateSealedEnclaveDataSize());
 
         // We need target info in order to create signup data report
         sgx_target_info_t target_info = { 0 };

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_wpe.h
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_wpe.h
@@ -22,6 +22,8 @@
 
 class SignupDataWPE : public SignupData {
 public:
+    tcf_err_t GenerateNonce(std::string& out_nonce, size_t out_nonce_size);
+
     tcf_err_t CreateEnclaveData(
         const std::string& inExtData,
         const std::string& inExtDataSignature,

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info_wpe.cpp
@@ -29,6 +29,17 @@ SignupInfo* SignupInfoWPE::DeserializeSignupInfo(
     return signup_info;
 }  // SignupInfoWPE::DeserializeSignupInfo
 
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+std::string SignupInfoWPE::GenerateNonce(size_t nonce_size) {
+    tcf_err_t presult;
+
+    std::string nonce;
+    SignupDataWPE signup_data_wpe;
+    presult = signup_data_wpe.GenerateNonce(nonce, nonce_size);
+    ThrowTCFError(presult);
+
+    return nonce;
+}  // SignupInfoWPE::GenerateNonce
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 std::map<std::string, std::string> SignupInfoWPE::CreateEnclaveData(

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info_wpe.h
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info_wpe.h
@@ -22,6 +22,8 @@ public:
 
     SignupInfoWPE() {}
 
+    std::string GenerateNonce(size_t nonce_size);
+
     std::map<std::string, std::string> CreateEnclaveData(
         const std::string& in_ext_data,
         const std::string& in_ext_data_signature,


### PR DESCRIPTION
- Generates trusted nonce to be used by WPE to get unique id from KME.
- Persist the nonce in EnclaveData class to use it while verifying the signature of unique id.
- Initialize EnclaveData during enclave initialzation

Signed-off-by: manju956 <manjunath.a.c@intel.com>