### PR TITLE
Increase wait time in proxy model test script

### DIFF
--- a/tools/run_proxy_model_tests.sh
+++ b/tools/run_proxy_model_tests.sh
@@ -32,7 +32,7 @@ try() {
 # time, so run test will wait for about 1min.
 
 yell "Wait for fabric blockchain connector to register worker"
-sleep 60s
+sleep 90s
 
 SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 SRCDIR="$(realpath ${SCRIPTDIR}/..)"


### PR DESCRIPTION
Fresh instantiation of chaincode will take more time
and tests can't be triggered till then.

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>