### PR TITLE
Disable fabric proxy model tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,11 +80,11 @@ pipeline {
                             sh 'docker-compose -f ci/docker-compose-proxy-model-build.yaml build'
                         }
                     },
-                    "Start fabric network": {
-                        script {
-                            sh './scripts/start_fabric.sh -w ./ -u'
-                        }
-                    }
+                //    "Start fabric network": {
+                //        script {
+                //            sh './scripts/start_fabric.sh -w ./ -u'
+                //        }
+                //    }
                 )
             }
         }
@@ -95,11 +95,11 @@ pipeline {
             }
         }
 
-        stage('Run Avalon proxy Model Tests') {
-            steps {
-                sh 'INSTALL_TYPE="" ./bin/run_tests -p'
-            }
-        }
+        //stage('Run Avalon proxy Model Tests') {
+        //    steps {
+        //        sh 'INSTALL_TYPE="" ./bin/run_tests -p'
+        //    }
+        //}
 
         stage('Create git archive') {
             steps {
@@ -114,10 +114,10 @@ pipeline {
     }
 
     post {
-        always {
-            echo 'Cleaning up fabric network'
-            sh './scripts/start_fabric.sh -w ./ -c'
-        }
+        //always {
+        //    echo 'Cleaning up fabric network'
+        //    sh './scripts/start_fabric.sh -w ./ -c'
+        //}
         success {
             archiveArtifacts '*.tgz, *.zip'
         }


### PR DESCRIPTION
Since adding worker to fabric chain on a fresh network
taking more time and until we find concrete fix for it disabling proxy runs.

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>