### PR TITLE
Update CreateEnclaveData to accept hex mrenclave

### DIFF
--- a/enclave_manager/avalon_enclave_manager/kme/kme_enclave.i
+++ b/enclave_manager/avalon_enclave_manager/kme/kme_enclave.i
@@ -83,6 +83,7 @@ namespace std {
 #include "swig_utils.h"
 #include "signup_info.h"
 #include "signup_info_kme.h"
+#include "work_order_wrap_kme.h"
 %}
 
 %{

--- a/tc/sgx/trusted_worker_manager/enclave/signup_enclave.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/signup_enclave.cpp
@@ -113,8 +113,7 @@ tcf_err_t ecall_CreateSignupData(const sgx_target_info_t* inTargetInfo,
         tcf::error::ThrowSgxError(ret, "Failed to seal signup data");
 
         // Give the caller a copy of the signing and encryption keys
-        // inAllocatedPublicEnclaveDataSize + 1 is to consider NULL character
-        strncpy_s(outPublicEnclaveData, inAllocatedPublicEnclaveDataSize+1,
+        strncpy_s(outPublicEnclaveData, inAllocatedPublicEnclaveDataSize,
             enclaveData->get_public_data().c_str(),
             enclaveData->get_public_data_size());
     } catch (tcf::error::Error& e) {

--- a/tc/sgx/trusted_worker_manager/enclave/signup_enclave_kme.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/signup_enclave_kme.cpp
@@ -112,8 +112,7 @@ tcf_err_t ecall_CreateSignupDataKME(const sgx_target_info_t* inTargetInfo,
         tcf::error::ThrowSgxError(ret, "Failed to seal signup data");
 
         // Give the caller a copy of the signing and encryption keys
-        // inAllocatedPublicEnclaveDataSize + 1 is to consider NULL character
-        strncpy_s(outPublicEnclaveData, inAllocatedPublicEnclaveDataSize+1,
+        strncpy_s(outPublicEnclaveData, inAllocatedPublicEnclaveDataSize,
             enclaveData->get_public_data().c_str(),
             enclaveData->get_public_data_size());
     } catch (tcf::error::Error& e) {

--- a/tc/sgx/trusted_worker_manager/enclave/signup_enclave_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/signup_enclave_wpe.cpp
@@ -120,6 +120,10 @@ tcf_err_t ecall_CreateSignupDataWPE(const sgx_target_info_t* inTargetInfo,
         sgx_status_t ret = sgx_create_report(
             inTargetInfo, &reportData, outEnclaveReport);
         tcf::error::ThrowSgxError(ret, "Failed to create enclave report");
+        // Give the caller a copy of the signing and encryption keys
+        strncpy_s(outPublicEnclaveData, inAllocatedPublicEnclaveDataSize,
+            enclaveData->get_public_data().c_str(),
+            enclaveData->get_public_data_size());
 
     } catch (tcf::error::Error& e) {
         SAFE_LOG(TCF_LOG_ERROR,

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_kme.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_kme.cpp
@@ -41,8 +41,9 @@ tcf_err_t SignupDataKME::CreateEnclaveData(
         // Get the enclave id for passing into the ecall
         sgx_enclave_id_t enclaveid = g_Enclave[0].GetEnclaveId();
 
+        // +1 for null character which is not included in std::string length()
         outPublicEnclaveData.resize(
-            SignupData::CalculatePublicEnclaveDataSize());
+            SignupData::CalculatePublicEnclaveDataSize() + 1);
         ByteArray sealed_enclave_data_buffer(
             SignupData::CalculateSealedEnclaveDataSize());
     
@@ -63,11 +64,12 @@ tcf_err_t SignupDataKME::CreateEnclaveData(
         // and call into the enclave to create the signup data
         sgx_report_t enclave_report = { 0 };
 
+        ByteArray ext_data = HexEncodedStringToByteArray(inExtData);
         sresult = g_Enclave[0].CallSgx(
             [enclaveid,
              &presult,
              target_info,
-             inExtData,
+             ext_data,
              inExtDataSignature,
              &outPublicEnclaveData,
              &sealed_enclave_data_buffer,
@@ -76,8 +78,8 @@ tcf_err_t SignupDataKME::CreateEnclaveData(
                     enclaveid,
                     &presult,
                     &target_info,
-                    (const uint8_t*) inExtData.c_str(),
-                    inExtData.length(),
+                    ext_data.data(),
+                    ext_data.size(),
                     (const uint8_t*) inExtDataSignature.c_str(),
                     inExtDataSignature.length(),
                     outPublicEnclaveData.data(),

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_singleton.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_singleton.cpp
@@ -38,8 +38,9 @@ tcf_err_t SignupDataSingleton::CreateEnclaveData(
         // Get the enclave id for passing into the ecall
         sgx_enclave_id_t enclaveid = g_Enclave[0].GetEnclaveId();
 
+        // +1 for null character which is not included in std::string length()
         outPublicEnclaveData.resize(
-            SignupData::CalculatePublicEnclaveDataSize());
+            SignupData::CalculatePublicEnclaveDataSize() + 1);
         ByteArray sealed_enclave_data_buffer(
             SignupData::CalculateSealedEnclaveDataSize());
 

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge/signup_wpe.cpp
@@ -88,8 +88,9 @@ tcf_err_t SignupDataWPE::CreateEnclaveData(
         // Get the enclave id for passing into the ecall
         sgx_enclave_id_t enclaveid = g_Enclave[0].GetEnclaveId();
 
+        // +1 for null character which is not included in std::string length()
         outPublicEnclaveData.resize(
-            SignupData::CalculatePublicEnclaveDataSize());
+            SignupData::CalculatePublicEnclaveDataSize() + 1);
     
         // We need target info in order to create signup data report
         sgx_target_info_t target_info = { 0 };

--- a/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper/signup_info.cpp
@@ -34,7 +34,6 @@ tcf_err_t SignupInfo::DeserializeSignupInfo(
     try {
         const char* pvalue = nullptr;
 
-        // Parse the incoming wait certificate
         JsonValue parsed(json_parse_string(serialized_signup_info.c_str()));
         tcf::error::ThrowIfNull(parsed.value,
             "failed to parse serialized signup info; badly formed JSON");
@@ -105,7 +104,6 @@ tcf_err_t SignupInfo::DeserializePublicEnclaveData(
     try {
         const char* pvalue = nullptr;
 
-        // Parse the incoming wait certificate
         JsonValue parsed(json_parse_string(public_enclave_data.c_str()));
         tcf::error::ThrowIfNull(parsed.value,
             "failed to parse the public enclave data, badly formed JSON");


### PR DESCRIPTION
- Update kme untrusted code to accept 64 byte hex string.
  Let the conversion to bytes be done in untrusted code.
- Update wpe trusted code to write back public enclave
  data after signup.
- Minor redundant comment cleanup

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>