### PR TITLE
Add MbedTLS signature verification as an alternative to OpenSSL

### DIFF
--- a/common/cpp/crypto/mbedtls/verify_certificate.cpp
+++ b/common/cpp/crypto/mbedtls/verify_certificate.cpp
@@ -21,7 +21,7 @@
 // Mbed TLS library sanity test
 #if !defined(MBEDTLS_RSA_C) || !defined(MBEDTLS_X509_CRT_PARSE_C) || \
     !defined(MBEDTLS_FS_IO) || !defined(MBEDTLS_X509_CRL_PARSE_C)
-#error "All of MBEDTLS_{RSA_C,X509_CRT_PARSE_C,_IO,X509_CRL_PARSE_C undefined."
+#error "One of MBEDTLS_{RSA_C,X509_CRT_PARSE_C,_IO,X509_CRL_PARSE_C undefined."
 #endif
 
 #ifndef CRYPTOLIB_MBEDTLS

--- a/common/cpp/crypto/mbedtls/verify_signature.cpp
+++ b/common/cpp/crypto/mbedtls/verify_signature.cpp
@@ -1,0 +1,114 @@
+/* Copyright 2018-2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mbedtls/x509_crt.h> // mbedtls_x509_crt_parse(), *_info()
+#include <mbedtls/sha256.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/pk.h>       // mbedtls_pk_rsa()
+
+#include "types.h"            // ByteArray
+#include "utils.h"            // ByteArrayToStr()
+#include "base64.h"           // base64_decode()
+#include "crypto_shared.h"
+#include "verify_signature.h"
+
+// Mbed TLS library sanity test
+#if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_RSA_C) || \
+    !defined(MBEDTLS_SHA256_C) || !defined(MBEDTLS_MD_C)  || \
+    !defined(MBEDTLS_X509_CRT_PARSE_C)
+#error "One of MBEDTLS_{BIGNUM,RSA,SHA256,MD,X509_CRT_PARSE}_C undefined."
+#endif
+
+#ifndef CRYPTOLIB_MBEDTLS
+#error "CRYPTOLIB_MBEDTLS must be defined to compile source with Mbed TLS."
+#endif
+
+
+/**
+ * Verify a RSA signature given a message, signature, and cert.
+ * Use SHA-256 to hash the message.
+ * Use OAEP padding (not PKCS#1 v1.5).
+ * Use PKCS#1 v1.5 encryption scheme (not PSS).
+ *
+ * @param cert_pem X.509 Certificate to verify
+ *                 with BEGIN and END BLOCKS and new lines
+ * @param msg Message to verify
+ * @param msg_len Length of msg
+ * @param signature RSA signature to verify message, base64 encoded
+ * @param signature_len Length of signature
+ * @returns true on success and false on failure.
+ */
+bool verify_signature(const char *cert_pem,
+    const char *msg, unsigned int msg_len,
+    const char *signature, unsigned int signature_len)
+{
+    // RSA keys larger than 16384 are not in practical use in the
+    // near future. Increase buffer size if necessary.
+    static const unsigned int max_decoded_len = 2048; // <=16384 bit signatures
+    static const unsigned int SHA256_HASH_LEN = (256 / 8);
+    int rc;
+    mbedtls_x509_crt cert;
+    mbedtls_rsa_context *rsa_ptr;
+
+    // Sanity checks
+    if (cert_pem == nullptr || signature == nullptr)
+        return false;
+    unsigned int predicted_len = base64_decoded_length(
+        signature, signature_len);
+    if (predicted_len > max_decoded_len)
+        return false;
+
+    // Decode base64-encoded signature
+    ByteArray v = base64_decode(std::string(signature, signature_len));
+    std::string decoded_str = ByteArrayToStr(v);
+    unsigned char *signature_decoded = (unsigned char *)decoded_str.c_str();
+    unsigned int decoded_len = decoded_str.size();
+    if (decoded_len != predicted_len) {
+        goto error_return; // unexpected length--corrupt b64 string?
+    }
+
+    // Parse X.509 cert
+    mbedtls_x509_crt_init(&cert);
+    rc = mbedtls_x509_crt_parse(&cert, (const unsigned char *)cert_pem,
+        strlen(cert_pem) + 1);
+    if (rc != 0)
+        goto error_return;
+
+    // Extract RSA public key (with N and E) from X.509 cert context
+    rsa_ptr = mbedtls_pk_rsa(cert.pk);
+    if (rsa_ptr == nullptr)
+        goto error_return;
+    if ((rc = mbedtls_rsa_check_pubkey(rsa_ptr)) != 0)
+        goto error_return;
+
+    // Perform SHA-256 hash on message
+    unsigned char hash_result[SHA256_HASH_LEN];
+    mbedtls_sha256_ret((const unsigned char*)msg, msg_len, hash_result, 0);
+
+    // Verify the signature against the hash digest and RSA public key (N & E)
+      rc = mbedtls_rsa_pkcs1_verify(
+          rsa_ptr, nullptr, nullptr, MBEDTLS_RSA_PUBLIC,
+          MBEDTLS_MD_SHA256, SHA256_HASH_LEN, hash_result,
+          signature_decoded);
+
+    // Cleanup
+error_return:
+    mbedtls_x509_crt_free(&cert);
+
+    return (rc == 0);
+}

--- a/common/cpp/crypto/verify_signature.cpp
+++ b/common/cpp/crypto/verify_signature.cpp
@@ -21,45 +21,25 @@
 #include <openssl/evp.h>
 
 #include "crypto_shared.h"
+#include "base64.h"           // base64_decoded_length()
 #include "verify_signature.h"
 
-
-/*
- * EVP_DecodeBlock pads its output with \0 if the output length is not
- * a multiple of 3. Check if the base64 string is padded at the end with '='
- * and adjust the output length.
- * For details, see the OpenSSL EVP_EncodeInit man page.
- */
-#define ADJUST_DECODE_LENGTH(in, in_len) \
-    ((((in)[(in_len) - 1] == '=') ? -1 : 0) + \
-     (((in)[(in_len) - 2] == '=') ? -1 : 0))
-
-
-/* Calculate the length of a base 64 encoded string after decoding. */
-static unsigned int
-base64_decoded_length(const char *encoded, unsigned int encoded_len)
-{
-    if (encoded == nullptr || encoded_len == 0) {
-        return 0;
-    }
-
-    unsigned int len = (encoded_len / 4) * 3;
-
-    if (encoded_len > 3)
-        len += ADJUST_DECODE_LENGTH(encoded, encoded_len);
-    return (len);
-}
+#ifndef CRYPTOLIB_OPENSSL
+#error "CRYPTOLIB_OPENSSL must be defined to compile source with OpenSSL."
+#endif
 
 
 /**
- * Verify a signature given a message, signature, and cert.
+ * Verify a RSA signature given a message, signature, and cert.
  * Use SHA-256 to hash the message.
+ * Use OAEP padding (not PKCS#1 v1.5).
+ * Use PKCS#1 v1.5 encryption scheme (not PSS).
  *
  * @param cert_pem X.509 Certificate to verify
- *                 with BEGIN end BLOCKS and new lines
+ *                 with BEGIN and END BLOCKS and new lines
  * @param msg Message to verify
  * @param msg_len Length of msg
- * @param signature Signature to verify message, base64 encoded
+ * @param signature RSA signature to verify message, base64 encoded
  * @param signature_len Length of signature
  * @returns true on success and false on failure.
  */
@@ -67,7 +47,7 @@ bool verify_signature(const char* cert_pem,
     const char* msg, unsigned int msg_len,
     const char* signature, unsigned int signature_len)
 {
-    // DSA or RSA keys larger than 16384 are not in practical use in the
+    // RSA keys larger than 16384 are not in practical use in the
     // near future. Increase buffer size if necessary.
     static const unsigned int max_decoded_len = 2048; // <=16384 bit signatures
     // Decoded result may have 1-2 extra '\0' bytes + ending '\0' byte.
@@ -81,14 +61,17 @@ bool verify_signature(const char* cert_pem,
     if (decoded_len > max_decoded_len)
         return false;
 
+    // Parse X.509 cert
     BIO* crt_bio = BIO_new_mem_buf((void*)cert_pem, -1);
 
     X509* crt = PEM_read_bio_X509(crt_bio, nullptr, 0, nullptr);
     assert(crt != nullptr);
 
+    // Extract RSA public key (with N and E) from X.509 cert
     EVP_PKEY* key = X509_get_pubkey(crt);
     assert(key != nullptr);
 
+    // Perform SHA-256 hash on message
     EVP_MD_CTX* ctx = EVP_MD_CTX_create();
     ret = EVP_VerifyInit_ex(ctx, EVP_sha256(), nullptr);
     assert(ret == 1);
@@ -101,6 +84,7 @@ bool verify_signature(const char* cert_pem,
         (unsigned char*)signature, signature_len);
     assert(ret != -1);
 
+    // Verify the signature against the hash digest and RSA public key (N & E)
     ret = EVP_VerifyFinal(ctx, (unsigned char*)signature_decoded, decoded_len,
         key);
 

--- a/common/cpp/packages/base64/base64.cpp
+++ b/common/cpp/packages/base64/base64.cpp
@@ -6,6 +6,7 @@
    Version: 1.01.00
 
    Copyright (C) 2004-2017 René Nyffenegger
+   Copyright 2020 Intel Corporation
 
    This source code is provided 'as-is', without any express or implied
    warranty. In no event will the author be held liable for any damages
@@ -37,12 +38,21 @@
 
 /*
  * The original source code has been modified to be used with
- * Hyperledger Avalon.
+ * Hyperledger Avalon. Added function base64_decoded_length().
  */
 
 
 #include <ctype.h>
 #include "base64.h"
+
+/*
+ * Used to adjust the decoded length of a base64 string.
+ * Check if the base64 string is padded at the end with '='
+ * and adjust the output length.
+ */
+#define ADJUST_DECODE_LENGTH(in, in_len) \
+    ((((in)[(in_len) - 1] == '=') ? -1 : 0) + \
+     (((in)[(in_len) - 2] == '=') ? -1 : 0))
 
 static const std::string base64_chars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -171,4 +181,27 @@ std::vector<uint8_t> base64_decode(const std::string& encoded_string) {
     }
 
     return ret;
+}
+
+
+/**
+ * Calculate the length of a base 64 encoded string after decoding.
+ *
+ * @param encoded_string Printable string containing base64 encoded data.
+ *                       No embedded whitespace characters are present
+ * @param encoded_length Length of encoded_string
+ * @returns Length of encoded_string after decoding
+ */
+unsigned int base64_decoded_length(const char *encoded_string,
+    unsigned int encoded_len)
+{
+    if (encoded_string == nullptr || encoded_len == 0) {
+        return 0;
+    }
+
+    unsigned int len = (encoded_len / 4) * 3;
+
+    if (encoded_len > 3)
+        len += ADJUST_DECODE_LENGTH(encoded_string, encoded_len);
+    return (len);
 }

--- a/common/cpp/packages/base64/base64.h
+++ b/common/cpp/packages/base64/base64.h
@@ -1,6 +1,8 @@
 //
 //  base64 encoding and decoding with C++.
 //  Version: 1.01.00
+//  Copyright (C) 2004-2017 René Nyffenegger
+//  Copyright 2020 Intel Corporation
 //
 
 /**
@@ -11,7 +13,7 @@
 
 /*
  * The original source code has been modified to be used with
- * Hyperledger Avalon.
+ * Hyperledger Avalon. Added function base64_decoded_length().
  */
 
 #pragma once
@@ -24,3 +26,6 @@ std::string base64_encode(
 
 std::vector<uint8_t> base64_decode(
     const std::string& encoded_string);
+
+unsigned int base64_decoded_length(const char *encoded_string,
+    unsigned int encoded_len);

--- a/common/cpp/tests/Makefile
+++ b/common/cpp/tests/Makefile
@@ -104,8 +104,10 @@ build/signtest: build build/signtest.o \
 build/secrettest: build build/secrettest.o $(UTILTESTOBJS)
 	g++ -o $@ $@.o $(UTILTESTOBJS) $(LDFLAGS)
 
-build/verifytest: build build/verifytest.o build/verify_signature.o
-	g++ -o $@ $@.o build/verify_signature.o $(LDFLAGS)
+# $(UTILTESTOBJS) needed for Mbed TLS, not OpenSSL
+build/verifytest: build build/verifytest.o build/verify_signature.o \
+		$(UTILTESTOBJS)
+	g++ -o $@ $@.o build/verify_signature.o $(UTILTESTOBJS) $(LDFLAGS)
 
 build/utiltest: build build/utiltest.o $(UTILTESTOBJS)
 	g++ -o $@ $@.o $(UTILTESTOBJS) $(LDFLAGS)

--- a/common/cpp/tests/README.md
+++ b/common/cpp/tests/README.md
@@ -1,7 +1,7 @@
-<!---
+<!--
 Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/
---->
+-->
 
 Unit Tests
 ----------
@@ -31,13 +31,13 @@ To remove generated binaries type `make clean` .
 
 Example
 -------
-```                                                           
+```
  $ make
 mkdir -p build
 g++ -o build/b64test.o -D_UNTRUSTED_ -I..  -I../crypto -I../packages/base64 -c b64test.cpp
 . . .
 g++ -o build/utiltest build/utiltest.o build/crypto_utils.o build/skenc.o build/types.o build/hex_string.o build/utils.o build/base64.o -lcrypto
-$ make test 
+$ make test
 cd build; ./b64test
 /home/dano/git/avalon/common/cpp/tests/build
 EVP_DecodeBlock PASSED: SHlwZXJsZWRnZXIgQXZhbG9u --> Hyperledger Avalon
@@ -52,4 +52,4 @@ PASSED: EncryptData()/DecryptData()
 Crypto utility tests PASSED
 $ make clean
 rm -f -rf build
-```  
+```

--- a/common/cpp/tests/b64test.cpp
+++ b/common/cpp/tests/b64test.cpp
@@ -25,7 +25,11 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include "crypto_shared.h" // Sets default CRYPTOLIB_* value
+#ifdef CRYPTOLIB_OPENSSL
 #include <openssl/evp.h> // EVP_DecodeBlock()
+#endif
 #include "types.h"       // ByteArray
 #include "utils.h"       // ByteArrayToStr()
 #include "base64.h"      // base64_*code()
@@ -103,6 +107,7 @@ main(void)
     std::string out_str;
 
     for (b64_test_type *tp = b64_test_cases; tp->encoded != nullptr; ++tp) {
+#ifdef CRYPTOLIB_OPENSSL
         // Test OpenSSL decode
         memset(buffer, 0, sizeof (buffer));
         rc = EVP_DecodeBlock((unsigned char *)buffer,
@@ -124,6 +129,7 @@ main(void)
                     strlen(tp->encoded), rc);
             }
         }
+#endif
 
         // Test Avalon C++ decode
         v = base64_decode(std::string(tp->encoded));
@@ -165,6 +171,7 @@ main(void)
     // Negative tests
     for (b64_test_type *ntp = negative_test_cases; ntp->encoded != nullptr;
             ++ntp) {
+#ifdef CRYPTOLIB_OPENSSL
         // Test OpenSSL decode
         rc = EVP_DecodeBlock((unsigned char *)buffer,
             (unsigned char *)ntp->encoded, strlen(ntp->encoded));
@@ -174,6 +181,7 @@ main(void)
             printf("Negative test EVP_DecodeBlock(%s) FAILED\n", ntp->encoded);
             ++count;
         }
+#endif
 
         // Test Avalon C++ decode
         v = base64_decode(std::string(ntp->encoded));

--- a/common/cpp/tests/certtest.cpp
+++ b/common/cpp/tests/certtest.cpp
@@ -35,10 +35,13 @@
  */
 
 #include <stdio.h>
-#include "verify_certificate.h"
+
+#include "crypto_shared.h" // Sets default CRYPTOLIB_* value
 #ifdef CRYPTOLIB_OPENSSL
 #include <openssl/evp.h>
 #endif
+#include "verify_certificate.h"
+
 
 // Test X.509 certificates
 // To dump, type: openssl x509 -noout -text <mycertfilename.pem

--- a/common/cpp/tests/signtest.cpp
+++ b/common/cpp/tests/signtest.cpp
@@ -24,15 +24,21 @@
 
 #include <string.h>
 #include <stdio.h>
+
+#include "crypto_shared.h" // Sets default CRYPTOLIB_* value
+
+#ifdef CRYPTOLIB_OPENSSL
 #include <openssl/evp.h>
 #if OPENSSL_API_COMPAT < 0x10100000L
 #include <openssl/bn.h>
+#endif
 #endif
 
 #include "error.h"       // tcf::error
 #include "sig_private_key.h"
 #include "sig_public_key.h"
 
+#ifdef CRYPTOLIB_OPENSSL
 #if OPENSSL_API_COMPAT < 0x10100000L
 // For backwards compatibility with older versions of OpenSSL.
 // Needed for sig_private_key.cpp.
@@ -62,6 +68,7 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
     sig->s = s;
     return 1;
 }
+#endif
 #endif
 
 int

--- a/common/cpp/tests/verifytest.cpp
+++ b/common/cpp/tests/verifytest.cpp
@@ -33,7 +33,11 @@
 
 #include <string.h>
 #include <stdio.h>
+
+#include "crypto_shared.h" // Sets default CRYPTOLIB_* value
+#ifdef CRYPTOLIB_OPENSSL
 #include <openssl/evp.h>
+#endif
 #include "verify_signature.h"
 
 // Test X.509 certificate
@@ -113,6 +117,8 @@ static const char test_cert2[] =
     "-----END CERTIFICATE-----\n";
 
 static const char message[] = "Hyperledger Avalon";
+    // SHA256: db684a8d3e33ef2bc1f03dd1a2cdbf4329226335f090921f24ef3d0dfe713ad4
+
 static const char signature[] =
      // 512 byte, 4096 bit signature, b64 encoded in 684 bytes + NUL
     "AZzpz4BONyIclWHcOgm+GQ/dav5fyuXxl3vKXIZTXNLZX/dfVeGUQm5FBucrDLFy"
@@ -195,8 +201,10 @@ main(void)
     bool is_ok;
     int  count = 0;
 
+#ifdef CRYPTOLIB_OPENSSL
 #if OPENSSL_API_COMPAT < 0x10100000L
     OpenSSL_add_all_digests();
+#endif
 #endif
 
     printf("Verify RSA signature test . . . ");


### PR DESCRIPTION
TAdd MbedTLS signature verification as an alternative to OpenSSL

- Add code for RSA signature verification with a X.509 certificate
- Move base64_decoded_length() to base64.cpp to prevent duplicate code

Signed-off-by: danintel <daniel.anderson@intel.com>