### PR TITLE
Separate OpenSSL parts out of Crypto Tests

### DIFF
--- a/common/cpp/tests/Makefile
+++ b/common/cpp/tests/Makefile
@@ -104,8 +104,10 @@ build/signtest: build build/signtest.o \
 build/secrettest: build build/secrettest.o $(UTILTESTOBJS)
 	g++ -o $@ $@.o $(UTILTESTOBJS) $(LDFLAGS)
 
-build/verifytest: build build/verifytest.o build/verify_signature.o
-	g++ -o $@ $@.o build/verify_signature.o $(LDFLAGS)
+# $(UTILTESTOBJS) needed for Mbed TLS, not OpenSSL
+build/verifytest: build build/verifytest.o build/verify_signature.o \
+		$(UTILTESTOBJS)
+	g++ -o $@ $@.o build/verify_signature.o $(UTILTESTOBJS) $(LDFLAGS)
 
 build/utiltest: build build/utiltest.o $(UTILTESTOBJS)
 	g++ -o $@ $@.o $(UTILTESTOBJS) $(LDFLAGS)

--- a/common/cpp/tests/README.md
+++ b/common/cpp/tests/README.md
@@ -1,7 +1,7 @@
-<!---
+<!--
 Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/
---->
+-->
 
 Unit Tests
 ----------
@@ -31,13 +31,13 @@ To remove generated binaries type `make clean` .
 
 Example
 -------
-```                                                           
+```
  $ make
 mkdir -p build
 g++ -o build/b64test.o -D_UNTRUSTED_ -I..  -I../crypto -I../packages/base64 -c b64test.cpp
 . . .
 g++ -o build/utiltest build/utiltest.o build/crypto_utils.o build/skenc.o build/types.o build/hex_string.o build/utils.o build/base64.o -lcrypto
-$ make test 
+$ make test
 cd build; ./b64test
 /home/dano/git/avalon/common/cpp/tests/build
 EVP_DecodeBlock PASSED: SHlwZXJsZWRnZXIgQXZhbG9u --> Hyperledger Avalon
@@ -52,4 +52,4 @@ PASSED: EncryptData()/DecryptData()
 Crypto utility tests PASSED
 $ make clean
 rm -f -rf build
-```  
+```

--- a/common/cpp/tests/b64test.cpp
+++ b/common/cpp/tests/b64test.cpp
@@ -25,7 +25,11 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include "crypto_shared.h" // Sets default CRYPTOLIB_* value
+#ifdef CRYPTOLIB_OPENSSL
 #include <openssl/evp.h> // EVP_DecodeBlock()
+#endif
 #include "types.h"       // ByteArray
 #include "utils.h"       // ByteArrayToStr()
 #include "base64.h"      // base64_*code()
@@ -103,6 +107,7 @@ main(void)
     std::string out_str;
 
     for (b64_test_type *tp = b64_test_cases; tp->encoded != nullptr; ++tp) {
+#ifdef CRYPTOLIB_OPENSSL
         // Test OpenSSL decode
         memset(buffer, 0, sizeof (buffer));
         rc = EVP_DecodeBlock((unsigned char *)buffer,
@@ -124,6 +129,7 @@ main(void)
                     strlen(tp->encoded), rc);
             }
         }
+#endif
 
         // Test Avalon C++ decode
         v = base64_decode(std::string(tp->encoded));
@@ -165,6 +171,7 @@ main(void)
     // Negative tests
     for (b64_test_type *ntp = negative_test_cases; ntp->encoded != nullptr;
             ++ntp) {
+#ifdef CRYPTOLIB_OPENSSL
         // Test OpenSSL decode
         rc = EVP_DecodeBlock((unsigned char *)buffer,
             (unsigned char *)ntp->encoded, strlen(ntp->encoded));
@@ -174,6 +181,7 @@ main(void)
             printf("Negative test EVP_DecodeBlock(%s) FAILED\n", ntp->encoded);
             ++count;
         }
+#endif
 
         // Test Avalon C++ decode
         v = base64_decode(std::string(ntp->encoded));

--- a/common/cpp/tests/certtest.cpp
+++ b/common/cpp/tests/certtest.cpp
@@ -35,10 +35,13 @@
  */
 
 #include <stdio.h>
-#include "verify_certificate.h"
+
+#include "crypto_shared.h" // Sets default CRYPTOLIB_* value
 #ifdef CRYPTOLIB_OPENSSL
 #include <openssl/evp.h>
 #endif
+#include "verify_certificate.h"
+
 
 // Test X.509 certificates
 // To dump, type: openssl x509 -noout -text <mycertfilename.pem

--- a/common/cpp/tests/signtest.cpp
+++ b/common/cpp/tests/signtest.cpp
@@ -24,15 +24,21 @@
 
 #include <string.h>
 #include <stdio.h>
+
+#include "crypto_shared.h" // Sets default CRYPTOLIB_* value
+
+#ifdef CRYPTOLIB_OPENSSL
 #include <openssl/evp.h>
 #if OPENSSL_API_COMPAT < 0x10100000L
 #include <openssl/bn.h>
+#endif
 #endif
 
 #include "error.h"       // tcf::error
 #include "sig_private_key.h"
 #include "sig_public_key.h"
 
+#ifdef CRYPTOLIB_OPENSSL
 #if OPENSSL_API_COMPAT < 0x10100000L
 // For backwards compatibility with older versions of OpenSSL.
 // Needed for sig_private_key.cpp.
@@ -62,6 +68,7 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
     sig->s = s;
     return 1;
 }
+#endif
 #endif
 
 int

--- a/common/cpp/tests/verifytest.cpp
+++ b/common/cpp/tests/verifytest.cpp
@@ -33,7 +33,11 @@
 
 #include <string.h>
 #include <stdio.h>
+
+#include "crypto_shared.h" // Sets default CRYPTOLIB_* value
+#ifdef CRYPTOLIB_OPENSSL
 #include <openssl/evp.h>
+#endif
 #include "verify_signature.h"
 
 // Test X.509 certificate
@@ -113,6 +117,8 @@ static const char test_cert2[] =
     "-----END CERTIFICATE-----\n";
 
 static const char message[] = "Hyperledger Avalon";
+    // SHA256: db684a8d3e33ef2bc1f03dd1a2cdbf4329226335f090921f24ef3d0dfe713ad4
+
 static const char signature[] =
      // 512 byte, 4096 bit signature, b64 encoded in 684 bytes + NUL
     "AZzpz4BONyIclWHcOgm+GQ/dav5fyuXxl3vKXIZTXNLZX/dfVeGUQm5FBucrDLFy"
@@ -195,8 +201,10 @@ main(void)
     bool is_ok;
     int  count = 0;
 
+#ifdef CRYPTOLIB_OPENSSL
 #if OPENSSL_API_COMPAT < 0x10100000L
     OpenSSL_add_all_digests();
+#endif
 #endif
 
     printf("Verify RSA signature test . . . ");


### PR DESCRIPTION
This allows MBedTLS testing.

Signed-off-by: danintel <daniel.anderson@intel.com>

Merged with #491