### PR TITLE
Add container dependency among Besu nodes

### DIFF
--- a/docs/dev-environments/ethereum/besu/docker-compose.yaml
+++ b/docs/dev-environments/ethereum/besu/docker-compose.yaml
@@ -58,6 +58,8 @@ services:
       - 23002:8546
     volumes:
       - './besu/node2:/var/lib/besu'
+    depends_on:
+      - node1.avalon.local
     networks:
       local_net:
         ipv4_address: '172.13.0.4'


### PR DESCRIPTION
- Make node 2 of besu network to depend on node 1.
  Startup dependency absence causes race condition
  where if the 1st block is produced/published before
  the Synchronizer starts on the other node, the chain
  does not progess.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>