### PR TITLE
Make RSA Public Keypairs Interoperate with Java, Go, Etc.

### DIFF
--- a/common/cpp/crypto/pkenc.h
+++ b/common/cpp/crypto/pkenc.h
@@ -23,10 +23,12 @@
 namespace tcf {
 namespace crypto {
     namespace constants {
-         // Use RSA-3072 for long-term security,
-         // with OAEP padding and SHA-256 digest.
-         // The 2048 byte buffer allows for future key sizes <= RSA-16384.
-         // RSA is not quantum resistant.
+         /**
+          * Use RSA-3072 for long-term security,
+          * with OAEP padding and SHA-256 digest.
+          * The 2048 byte buffer allows for future key sizes <= RSA-16384.
+          * RSA is not quantum resistant.
+          */
         const int RSA_KEY_SIZE = 2048;
         const int RSA_PADDING_SIZE = 41;
 

--- a/common/cpp/crypto/pkenc_private_key.h
+++ b/common/cpp/crypto/pkenc_private_key.h
@@ -16,6 +16,7 @@
 /**
  * @file
  * Avalon RSA public key generation, serialization, and decryption functions.
+ * Serialization reads and writes keys in PEM format strings.
  */
 
 #pragma once
@@ -43,19 +44,22 @@ namespace crypto {
             // throws RuntimeError
             PrivateKey(PrivateKey&& privateKey);
             // Deserializing constructor.
-            // throws RuntimeError, ValueError
+            // Reads PEM format string (with "BEGIN RSA PRIVATE KEY").
+            // Throws RuntimeError, ValueError
             PrivateKey(const std::string& encoded);
             ~PrivateKey();
             // throws RuntimeError
             PrivateKey& operator=(const PrivateKey& privateKey);
-            // throws RuntimeError, ValueError
+            // Reads PEM format string (with "BEGIN RSA PRIVATE KEY").
+            // Throws RuntimeError, ValueError.
             void Deserialize(const std::string& encoded);
             // Generate PrivateKey.
             // throws RuntimeError
             void Generate();
             // throws RuntimeError
             PublicKey GetPublicKey() const;
-            // throws RuntimeError
+            // Creates PEM format string (with "BEGIN RSA PRIVATE KEY").
+            // Throws RuntimeError.
             std::string Serialize() const;
             // Decrypt message.data() and return plaintext.
             // throws RuntimeError

--- a/common/cpp/crypto/pkenc_public_key.h
+++ b/common/cpp/crypto/pkenc_public_key.h
@@ -16,6 +16,7 @@
 /**
  * @file
  * Avalon RSA public key generation, serialization, and encryption functions.
+ * Serialization reads and writes keys in PEM format strings.
  */
 
 #pragma once
@@ -45,14 +46,19 @@ namespace crypto {
             // throws RuntimeError
             PublicKey(const PrivateKey& privateKey);
             // Deserializing constructor.
-            // throws RuntimeError, ValueError
+            // Reads RSA public key PEM format string.
+            // (with "BEGIN RSA PUBLIC KEY" or "BEGIN PUBLIC KEY").
+            // Throws RuntimeError, ValueError.
             PublicKey(const std::string& encoded);
             ~PublicKey();
             // throws RuntimeError
             PublicKey& operator=(const PublicKey& publicKey);
-            // throws RuntimeError, ValueError
+            // Reads RSA public key PEM format string
+            // Throws RuntimeError, ValueError.
             void Deserialize(const std::string& encoded);
-            // throws RuntimeError
+            // Creates RSA public key PEM format string
+            // (with "BEGIN PUBLIC KEY").
+            // Throws RuntimeError.
             std::string Serialize() const;
             // Encrypt message.data() and return ciphertext.
             // throws RuntimeError


### PR DESCRIPTION
- Serialize RSA:
  Use PEM_write_bio_RSA_PUBKEY() to generate "BEGIN PUBLIC KEY" PEM format strings
- Deserialize RSA:
  Use *both* PEM_read_bio_RSAPublicKey() and PEM_read_bio_RSA_PUBKEY to read
  *both* "BEGIN RSA PUBLIC KEY" and "BEGIN PUBLIC KEY"  PEM format strings

This allows interoperability with Java, Go, etc, and not just OpenSSL.

The "BEGIN PUBLIC KEY" is the same as "BEGIN RSA PUBLIC KEY" but with
additional information. That is, prefix an OID identifying it as
"rsaEncryption" (OID 1.2.840.113549.1.1.1).

This uses ideas from Issue #101 and PR #434 from Kuba Siemion.

- Add tests to deserialize static examples of the above.
- Use comparison operators (== and !=) for non-boolean types
- Expand Doxygen comments

Signed-off-by: danintel <daniel.anderson@intel.com>