### PR TITLE
Initial build/setup files for worker pool

### DIFF
--- a/docker-compose-pool.yaml
+++ b/docker-compose-pool.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Intel Corporation
+# Copyright 2019-2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,12 +40,12 @@ services:
       bash -c "tail -f /dev/null"
     stop_signal: SIGKILL
     depends_on:
-      - avalon-enclave-manager
+      - avalon-kme
       - avalon-listener
 
-  avalon-enclave-manager:
-    container_name: avalon-enclave-manager
-    image: avalon-enclave-manager-dev
+  avalon-kme:
+    container_name: avalon-kme
+    image: avalon-enclave-manager-kme-dev
     build:
       context: .
       dockerfile: ./enclave_manager/Dockerfile
@@ -53,13 +53,15 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-        - ENCLAVE_TYPE=singleton
+        - ENCLAVE_TYPE=kme
     environment:
       - http_proxy
       - https_proxy
       - no_proxy
     expose:
-      # ZMQ socket port. 
+      # KME listener port
+      - 1948
+      # ZMQ socket port.
       - 5555
     command: |
       bash -c "
@@ -69,6 +71,34 @@ services:
     depends_on:
       - avalon-lmdb
       - avalon-listener
+
+  avalon-enclave-manager:
+    container_name: avalon-wpe
+    image: avalon-enclave-manager-wpe-dev
+    build:
+      context: .
+      dockerfile: ./enclave_manager/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+        - ENCLAVE_TYPE=wpe
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      # ZMQ socket port.
+      - 5555
+    command: |
+      bash -c "
+        enclave_manager --lmdb_url http://avalon-lmdb:9090 --kme_listener_url http://avalon-kme:1948
+        tail -f /dev/null
+      "
+    depends_on:
+      - avalon-lmdb
+      - avalon-listener
+      - avalon-kme
 
   avalon-lmdb:
     container_name: avalon-lmdb

--- a/enclave_manager/Dockerfile
+++ b/enclave_manager/Dockerfile
@@ -132,7 +132,7 @@ RUN echo "Building Avalon SDK\n" \
 
 
 
-#Build Avalon Listener intermediate docker image
+#Build Avalon Enclave Manager docker image
 FROM base_image as build_image
 
 RUN apt-get update \
@@ -155,6 +155,7 @@ RUN apt-get update \
     xxd \
     unzip \
     ocamlbuild \
+    python3-twisted \
     python3-pip \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
@@ -220,12 +221,13 @@ COPY --from=common_python_image /project/avalon/common/python/dist/*.whl dist/
 COPY --from=avalon_sdk_image /project/avalon/sdk/dist/*.whl dist/
 
 RUN echo "Install common/python and sdk packages\n" \
- && pip3 install dist/*.whl pyzmq
+ && pip3 install dist/*.whl json-rpc pyzmq
 
 
 ARG SGX_MODE
 ARG MAKECLEAN
 ARG TCF_DEBUG_BUILD
+ARG ENCLAVE_TYPE
 
 # Environment setup
 ENV TCF_HOME=/project/avalon

--- a/enclave_manager/Makefile
+++ b/enclave_manager/Makefile
@@ -14,21 +14,22 @@
 
 # Set SGX_MODE default (which can be overridden with an environment variable):
 SGX_MODE?=SIM
+ENCLAVE_TYPE?=singleton
 
 PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/' | tr -d .}
 MOD_VERSION=${shell ../bin/get_version}
 
-WHEEL_FILE=dist/avalon_enclave_manager-${MOD_VERSION}-cp${PY_VERSION}-cp${PY_VERSION}m-linux_x86_64.whl
+WHEEL_FILE=dist/${ENCLAVE_TYPE}_enclave_manager-${MOD_VERSION}-cp${PY_VERSION}-cp${PY_VERSION}m-linux_x86_64.whl
 
 all : $(WHEEL_FILE)
 
 $(WHEEL_FILE) : build_ext
 	@echo Build Distribution
-	python3 setup.py bdist_wheel
+	python3 setup_${ENCLAVE_TYPE}.py bdist_wheel
 
 build_ext :
 	@echo Build build_ext
-	python3 setup.py build_ext
+	python3 setup_${ENCLAVE_TYPE}.py build_ext
 
 build :
 	mkdir $@

--- a/enclave_manager/setup_kme.py
+++ b/enclave_manager/setup_kme.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018 Intel Corporation
+# Copyright 2018-2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,20 +77,16 @@ libraries = [
 ]
 
 enclave_module_files = [
-    "avalon_enclave_manager/singleton/singleton_enclave.i",
+    "avalon_enclave_manager/kme/kme_enclave.i",
     os.path.join(enclave_bridge_wrapper_path, 'swig_utils.cpp'),
     os.path.join(enclave_bridge_wrapper_path, 'work_order_wrap.cpp'),
     os.path.join(enclave_bridge_wrapper_path, 'enclave_info.cpp'),
     os.path.join(enclave_bridge_wrapper_path, 'signup_info.cpp'),
-    os.path.join(enclave_bridge_wrapper_path, 'signup_info_singleton.cpp'),
-    # TODO: Move *_kme.cpp to KME enclave manager and
-    # move *_wpe.cpp to WPE enclave manager
-    os.path.join(enclave_bridge_wrapper_path, 'signup_info_kme.cpp'),
-    os.path.join(enclave_bridge_wrapper_path, 'signup_info_wpe.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'signup_info_kme.cpp')
 ]
 
 enclave_module = Extension(
-    'avalon_enclave_manager.singleton._singleton_enclave',
+    'avalon_enclave_manager.kme._kme_enclave',
     enclave_module_files,
     swig_opts = ['-c++', '-threads'] + ['-I%s' % i for i in include_dirs],
     extra_compile_args = compile_args,
@@ -109,9 +105,9 @@ enclave_module = Extension(
 version = subprocess.check_output(
     os.path.join(tcf_root_dir, 'bin/get_version')).decode('ascii').strip()
 
-setup(name='avalon_enclave_manager',
+setup(name='kme_enclave_manager',
       version = version,
-      description = 'Avalon Intel SGX Enclave Manager',
+      description = 'Avalon Intel SGX KME Enclave Manager',
       author = 'Hyperledger Avalon',
       url = 'https://github.com/hyperledger/avalon',
       packages = find_packages(),
@@ -124,6 +120,6 @@ setup(name='avalon_enclave_manager',
       data_files = [],
       entry_points = {
         'console_scripts':
-        ['enclave_manager = avalon_enclave_manager.singleton.singleton_enclave_manager:main']
+        ['enclave_manager = avalon_enclave_manager.kme.kme_enclave_manager:main']
           }
 )

--- a/enclave_manager/setup_singleton.py
+++ b/enclave_manager/setup_singleton.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+# Copyright 2018-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import subprocess
+
+# This should only be run with python3
+import sys
+if sys.version_info[0] < 3:
+    print('ERROR: must run with python3')
+    sys.exit(1)
+
+from setuptools import setup, find_packages, Extension
+
+tcf_root_dir = os.environ.get('TCF_HOME', '../')
+
+enclave_bridge_wrapper_path = os.path.join(tcf_root_dir,
+         'tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper')
+
+enclave_bridge_path = os.path.join(tcf_root_dir,
+        'tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge')
+
+# Defaults to path '/opt/intel/sgxsdk' if SGX_SDK env variable is not passed
+sgx_sdk = os.environ.get('SGX_SDK', '/opt/intel/sgxsdk')
+
+## -----------------------------------------------------------------
+## Set up the enclave
+## -----------------------------------------------------------------
+debug_flag = os.environ.get('TCF_DEBUG_BUILD',0)
+
+compile_args = [
+    '-std=c++11',
+    '-Wno-switch',
+    '-Wno-unused-function',
+    '-Wno-unused-variable',
+]
+
+# By default the extension class adds '-O2' to the compile
+# flags, this lets us override since these are appended to
+# the compilation switches.
+if debug_flag :
+    compile_args += ['-g']
+
+include_dirs = [
+    enclave_bridge_wrapper_path,
+    enclave_bridge_path,
+    os.path.join(tcf_root_dir, 'common/cpp'),
+    os.path.join(tcf_root_dir, 'tc/sgx/trusted_worker_manager/common'),
+    os.path.join(tcf_root_dir, 'common/cpp/crypto'),
+    os.path.join(tcf_root_dir, 'common/cpp/packages/base64'),
+    os.path.join(sgx_sdk, 'include')
+]
+
+library_dirs = [
+    os.path.join(enclave_bridge_path, 'build/lib'),
+    os.path.join(tcf_root_dir, "common/cpp/build"),
+]
+
+libraries = [
+    'uavalon-parson',
+    'uavalon-verify-ias-report',
+    'avalon-enclave-bridge'
+]
+
+enclave_module_files = [
+    "avalon_enclave_manager/singleton/singleton_enclave.i",
+    os.path.join(enclave_bridge_wrapper_path, 'swig_utils.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'work_order_wrap.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'enclave_info.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'signup_info.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'signup_info_singleton.cpp'),
+]
+
+enclave_module = Extension(
+    'avalon_enclave_manager.singleton._singleton_enclave',
+    enclave_module_files,
+    swig_opts = ['-c++', '-threads'] + ['-I%s' % i for i in include_dirs],
+    extra_compile_args = compile_args,
+    libraries = libraries,
+    include_dirs = include_dirs,
+    library_dirs = library_dirs,
+    runtime_library_dirs = [os.path.join(enclave_bridge_path, 'build/lib')],
+    define_macros = [
+                        ('_UNTRUSTED_', 1),
+                        ('TCF_DEBUG_BUILD', debug_flag),
+                    ],
+    undef_macros = ['NDEBUG', 'EDEBUG']
+    )
+
+## -----------------------------------------------------------------
+version = subprocess.check_output(
+    os.path.join(tcf_root_dir, 'bin/get_version')).decode('ascii').strip()
+
+setup(name='singleton_enclave_manager',
+      version = version,
+      description = 'Avalon Intel SGX Singleton Enclave Manager',
+      author = 'Hyperledger Avalon',
+      url = 'https://github.com/hyperledger/avalon',
+      packages = find_packages(),
+      install_requires = [
+          'requests'
+          ],
+      ext_modules = [
+          enclave_module
+      ],
+      data_files = [],
+      entry_points = {
+        'console_scripts':
+        ['enclave_manager = avalon_enclave_manager.singleton.singleton_enclave_manager:main']
+          }
+)

--- a/enclave_manager/setup_wpe.py
+++ b/enclave_manager/setup_wpe.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+# Copyright 2018-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import subprocess
+
+# This should only be run with python3
+import sys
+if sys.version_info[0] < 3:
+    print('ERROR: must run with python3')
+    sys.exit(1)
+
+from setuptools import setup, find_packages, Extension
+
+tcf_root_dir = os.environ.get('TCF_HOME', '../')
+
+enclave_bridge_wrapper_path = os.path.join(tcf_root_dir,
+         'tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge_wrapper')
+
+enclave_bridge_path = os.path.join(tcf_root_dir,
+        'tc/sgx/trusted_worker_manager/enclave_untrusted/enclave_bridge')
+
+# Defaults to path '/opt/intel/sgxsdk' if SGX_SDK env variable is not passed
+sgx_sdk = os.environ.get('SGX_SDK', '/opt/intel/sgxsdk')
+
+## -----------------------------------------------------------------
+## Set up the enclave
+## -----------------------------------------------------------------
+debug_flag = os.environ.get('TCF_DEBUG_BUILD',0)
+
+compile_args = [
+    '-std=c++11',
+    '-Wno-switch',
+    '-Wno-unused-function',
+    '-Wno-unused-variable',
+]
+
+# By default the extension class adds '-O2' to the compile
+# flags, this lets us override since these are appended to
+# the compilation switches.
+if debug_flag :
+    compile_args += ['-g']
+
+include_dirs = [
+    enclave_bridge_wrapper_path,
+    enclave_bridge_path,
+    os.path.join(tcf_root_dir, 'common/cpp'),
+    os.path.join(tcf_root_dir, 'tc/sgx/trusted_worker_manager/common'),
+    os.path.join(tcf_root_dir, 'common/cpp/crypto'),
+    os.path.join(tcf_root_dir, 'common/cpp/packages/base64'),
+    os.path.join(sgx_sdk, 'include')
+]
+
+library_dirs = [
+    os.path.join(enclave_bridge_path, 'build/lib'),
+    os.path.join(tcf_root_dir, "common/cpp/build"),
+]
+
+libraries = [
+    'uavalon-parson',
+    'uavalon-verify-ias-report',
+    'avalon-enclave-bridge'
+]
+
+enclave_module_files = [
+    "avalon_enclave_manager/wpe/wpe_enclave.i",
+    os.path.join(enclave_bridge_wrapper_path, 'swig_utils.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'work_order_wrap.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'enclave_info.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'signup_info.cpp'),
+    os.path.join(enclave_bridge_wrapper_path, 'signup_info_wpe.cpp')
+]
+
+enclave_module = Extension(
+    'avalon_enclave_manager.wpe._wpe_enclave',
+    enclave_module_files,
+    swig_opts = ['-c++', '-threads'] + ['-I%s' % i for i in include_dirs],
+    extra_compile_args = compile_args,
+    libraries = libraries,
+    include_dirs = include_dirs,
+    library_dirs = library_dirs,
+    runtime_library_dirs = [os.path.join(enclave_bridge_path, 'build/lib')],
+    define_macros = [
+                        ('_UNTRUSTED_', 1),
+                        ('TCF_DEBUG_BUILD', debug_flag),
+                    ],
+    undef_macros = ['NDEBUG', 'EDEBUG']
+    )
+
+## -----------------------------------------------------------------
+version = subprocess.check_output(
+    os.path.join(tcf_root_dir, 'bin/get_version')).decode('ascii').strip()
+
+setup(name='wpe_enclave_manager',
+      version = version,
+      description = 'Avalon Intel SGX WPE Enclave Manager',
+      author = 'Hyperledger Avalon',
+      url = 'https://github.com/hyperledger/avalon',
+      packages = find_packages(),
+      install_requires = [
+          'requests'
+          ],
+      ext_modules = [
+          enclave_module
+      ],
+      data_files = [],
+      entry_points = {
+        'console_scripts':
+        ['enclave_manager = avalon_enclave_manager.wpe.wpe_enclave_manager:main']
+          }
+)


### PR DESCRIPTION
- Add docker-compose-pool.yaml which runs single KME &
  WPE in worker pool
- Introduce ENCLAVE_TYPE for build time decision making
  for different enclave types
- Replicate and customize setup files for WPE/KME/SWE

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>