### PR TITLE
C++ Crypto Library Function Generate Must Generate RSA-3072 Keys

### DIFF
--- a/common/cpp/crypto/pkenc.h
+++ b/common/cpp/crypto/pkenc.h
@@ -24,14 +24,19 @@ namespace tcf {
 namespace crypto {
     namespace constants {
          /**
+          * RSA key size, in bits.
           * Use RSA-3072 for long-term security,
           * with OAEP padding and SHA-256 digest.
-          * The 2048 byte buffer allows for future key sizes <= RSA-16384.
           * RSA is not quantum resistant.
           */
-        const int RSA_KEY_SIZE = 2048;
+        const int RSA_KEY_SIZE = 3072;
+        /** Padding required, in bits, for OAEP padding. */
         const int RSA_PADDING_SIZE = 41;
-
+        /**
+         * Maxinum amount, in bytes, of plain text that can
+         * be encrypted with RSA. For longer lengths
+         * use symmetric encryption or a larger key size.
+         */
         constexpr int RSA_PLAINTEXT_LEN =
             ((RSA_KEY_SIZE - RSA_PADDING_SIZE) >> 3);
     }  // namespace constants


### PR DESCRIPTION
- The C++ common Crypto function tcf::crypto::PrivateKey::Generate()
  should generate RSA-3072 keys not RSA-2048 keys for Avalon:
  From https://github.com/hyperledger/avalon/blob/master/common/cpp/crypto/README.md :

  > Asymmetric encryption	RSA-OAEP	3072	(1)

- Distinguish between bit and byte size in RSA constants
- Expand comments on RSA constants

Signed-off-by: danintel <daniel.anderson@intel.com>