### PR TITLE
Split OpenSSL and non-OpenSSL parts of Public Key Crypto (RSA)

### DIFF
--- a/common/cpp/crypto/pkenc_private_key.h
+++ b/common/cpp/crypto/pkenc_private_key.h
@@ -15,15 +15,19 @@
 
 /**
  * @file
- * Avalon RSA public key generation, serialization, and decryption functions.
+ * Avalon RSA private key generation, serialization, and decryption functions.
  * Serialization reads and writes keys in PEM format strings.
  */
 
 #pragma once
-#include <openssl/rsa.h>
 #include <string>
 #include <vector>
 #include "types.h"
+
+#include "crypto_shared.h"
+#if defined(CRYPTOLIB_OPENSSL)
+#include <openssl/rsa.h>
+#endif
 
 namespace tcf {
 namespace crypto {
@@ -67,6 +71,7 @@ namespace crypto {
 
         private:
             RSA* private_key_;
+            RSA* deserializeRSAPrivateKey(const std::string& encoded);
         };
     }  // namespace pkenc
 }  // namespace crypto

--- a/common/cpp/crypto/pkenc_private_key_common.cpp
+++ b/common/cpp/crypto/pkenc_private_key_common.cpp
@@ -1,0 +1,70 @@
+/* Copyright 2018-2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file
+ * Avalon RSA private key generation, serialization, and decryption functions.
+ * Serialization reads and writes keys in PEM format strings.
+ *
+ * No OpenSSL/Mbed TLS-dependent code is present.
+ * See pkenc_private_key.cpp for OpenSSL/Mbed TLS-dependent code.
+ */
+
+#include "crypto_shared.h"
+#include "error.h"
+#include "hex_string.h"
+#include "pkenc.h"
+#include "pkenc_public_key.h"
+#include "pkenc_private_key.h"
+
+namespace pcrypto = tcf::crypto;
+namespace constants = tcf::crypto::constants;
+namespace Error = tcf::error; // Error handling.
+
+
+/**
+ * Constructor from PEM encoded string.
+ * Throws RuntimeError, ValueError.
+ *
+ * @param PEM encoded serialized RSA private key
+ */
+pcrypto::pkenc::PrivateKey::PrivateKey(const std::string& encoded) {
+    private_key_ = deserializeRSAPrivateKey(encoded);
+}  // pcrypto::pkenc::PrivateKey::PrivateKey
+
+
+/**
+ * Move constructor.
+ * Throws RuntimeError.
+ */
+pcrypto::pkenc::PrivateKey::PrivateKey(pcrypto::pkenc::PrivateKey&& privateKey) {
+    private_key_ = privateKey.private_key_;
+    privateKey.private_key_ = nullptr;
+    if (private_key_ == nullptr) {
+        std::string msg("Crypto Error (pkenc::PrivateKey() move): "
+            "Cannot move null private key");
+        throw Error::RuntimeError(msg);
+    }
+}  // pcrypto::pkenc::PrivateKey::PrivateKey (move constructor)
+
+
+/**
+ * Get Public encryption from PrivateKey.
+ * Throws RuntimeError.
+ */
+pcrypto::pkenc::PublicKey pcrypto::pkenc::PrivateKey::GetPublicKey() const {
+    PublicKey publicKey(*this);
+    return publicKey;
+}  // pcrypto::pkenc::GetPublicKey

--- a/common/cpp/crypto/pkenc_public_key.h
+++ b/common/cpp/crypto/pkenc_public_key.h
@@ -15,15 +15,19 @@
 
 /**
  * @file
- * Avalon RSA public key generation, serialization, and encryption functions.
+ * Avalon RSA public key serialization and encryption functions.
  * Serialization reads and writes keys in PEM format strings.
  */
 
 #pragma once
-#include <openssl/rsa.h>
 #include <string>
 #include <vector>
 #include "types.h"
+
+#include "crypto_shared.h"
+#if defined(CRYPTOLIB_OPENSSL)
+#include <openssl/rsa.h>
+#endif
 
 namespace tcf {
 namespace crypto {
@@ -66,6 +70,7 @@ namespace crypto {
 
         private:
             RSA* public_key_;
+            RSA* deserializeRSAPublicKey(const std::string& encoded);
         };
     }  // namespace pkenc
 }  // namespace crypto

--- a/common/cpp/crypto/pkenc_public_key_common.cpp
+++ b/common/cpp/crypto/pkenc_public_key_common.cpp
@@ -1,0 +1,56 @@
+/* Copyright 2018-2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file
+ * Avalon RSA public key serialization and encryption functions.
+ * Serialization reads and writes keys in PEM format strings.
+ *
+ * No OpenSSL/Mbed TLS-dependent code is present.
+ * See pkenc_public_key.cpp for OpenSSL/Mbed TLS-dependent code.
+ */
+
+#include "crypto_shared.h"
+#include "error.h"
+#include "hex_string.h"
+#include "pkenc.h"
+#include "pkenc_public_key.h"
+
+namespace pcrypto = tcf::crypto;
+namespace constants = tcf::crypto::constants;
+namespace Error = tcf::error; // Error handling
+
+
+/**
+ * PublicKey constructor.
+ */
+pcrypto::pkenc::PublicKey::PublicKey() {
+    public_key_ = nullptr;
+}  // pcrypto::sig::PublicKey::PublicKey
+
+
+/**
+ * Move constructor.
+ * Throws RuntimeError.
+ */
+pcrypto::pkenc::PublicKey::PublicKey(pcrypto::pkenc::PublicKey&& publicKey) {
+    public_key_ = publicKey.public_key_;
+    publicKey.public_key_ = nullptr;
+    if (public_key_ == nullptr) {
+        std::string msg("Crypto Error (pkenc::PublicKey() move): "
+            "Cannot move null public key");
+        throw Error::RuntimeError(msg);
+    }
+}  // pcrypto::pkenc::PublicKey::PublicKey (move constructor)

--- a/common/cpp/tests/Makefile
+++ b/common/cpp/tests/Makefile
@@ -73,9 +73,11 @@ build/b64test: build build/b64test.o build/base64.o build/utils.o
 build/certtest: build build/certtest.o build/verify_certificate.o
 	g++ -o $@ $@.o           build/verify_certificate.o $(LDFLAGS)
 
-build/pktest: build build/pktest.o build/pkenc_private_key.o \
-		build/pkenc_public_key.o
-	g++ -o $@ $@.o build/pkenc_private_key.o build/pkenc_public_key.o \
+build/pktest: build build/pktest.o \
+		build/pkenc_private_key.o build/pkenc_private_key_common.o \
+		build/pkenc_public_key.o build/pkenc_public_key_common.o
+	g++ -o $@ $@.o build/pkenc_private_key.o build/pkenc_private_key_common.o \
+		build/pkenc_public_key.o build/pkenc_public_key_common.o \
  		$(LDFLAGS)
 
 build/signtest: build build/signtest.o \

--- a/common/cpp/tests/pktest.cpp
+++ b/common/cpp/tests/pktest.cpp
@@ -194,6 +194,15 @@ main(void)
         ++count;
     }
 
+    // Must begin with BEGIN PUBLIC KEY (not BEGIN RSA PUBLIC KEY) line
+    std::string public_key_hdr("-----BEGIN PUBLIC KEY-----");
+    if (rpublicKeyStr.compare(0, public_key_hdr.size(), public_key_hdr) == 0) {
+        printf("BEGIN PUBLIC KEY header line test PASSED\n");
+    } else {
+        printf("BEGIN PUBLIC KEY header line test FAILED\n");
+        ++count;
+    }
+
     printf("Test key deserialize functions.\n");
     tcf::crypto::pkenc::PrivateKey rprivateKey1;
     rprivateKey1.Generate();


### PR DESCRIPTION
- pkenc_private_key_common.cpp split from pkenc_private_key.cpp
- pkenc_public_key_common.cpp  split from pkenc_public_key.cpp

This will allow other implementations, such as MBed TLS, in the future.

pkenc_*_key.cpp
- Set private_key_ and public_key_ to nullptr after freeing to prevent double frees
- Add #ifndef CRYPTOLIB_OPENSSL checks for OpenSSL-only code
- Fix incorrect comments and error messages

pktest.cpp
- Add test for BEGIN PUBLIC KEY header (instead of BEGIN RSA PUBLIC KEY header)

Signed-off-by: danintel <daniel.anderson@intel.com>