### PR TITLE
WPE work order processing changes

### DIFF
--- a/common/cpp/enclave_types.h
+++ b/common/cpp/enclave_types.h
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 /** Avalon worker enclave Type (singleton, KME, WPE) */
 enum EnclaveType {
     /** SINGLETON_ENCLAVE does both Key management and workload processing */

--- a/common/cpp/json_utils.cpp
+++ b/common/cpp/json_utils.cpp
@@ -13,10 +13,8 @@
 * limitations under the License.
 */
 
-#include "parson.h"
 #include "error.h"
 #include "tcf_error.h"
-#include "types.h"
 #include "json_utils.h"
 
 const char* GetJsonStr(const JSON_Object* json_object,

--- a/common/cpp/json_utils.h
+++ b/common/cpp/json_utils.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include "types.h"
+#include "parson.h"
+
 const char* GetJsonStr(const JSON_Object* json_object,
                        const char* name,
                        const char* err_msg = nullptr);

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_data_handler.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_data_handler.h
@@ -24,7 +24,7 @@
 #include "parson.h"
 #include "types.h"
 #include "work_order_data.h"
-
+#include "enclave_types.h"
 
 namespace tcf {
         class WorkOrderDataHandler {
@@ -53,8 +53,13 @@ namespace tcf {
                 this->iv = iv;
             }
 
-            void Unpack(EnclaveData* enclaveData,
-                        const JSON_Object* object);
+            void Unpack(EnclaveData* enclaveData, const JSON_Object* object);
+
+            // Below overloaded function will be used by only WPE to unpack
+            // TODO: Remove this function after adding WPE
+            // specific WorkOrderDataHandler
+            void Unpack(EnclaveData* enclaveData, const JSON_Object* object,
+                ByteArray data_encryption_key_from_pre_processing);
 
             void Pack(JSON_Array* json_array);
 

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_enclave_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_enclave_wpe.cpp
@@ -27,7 +27,7 @@
 #include "enclave_utils.h"
 #include "base_enclave.h"
 #include "enclave_data.h"
-#include "work_order_processor.h"
+#include "work_order_processor_wpe.h"
 
 ByteArray last_serialized_response_wpe;
 
@@ -53,8 +53,7 @@ tcf_err_t ecall_HandleWorkOrderRequestWPE(const uint8_t* inSerializedRequest,
         ByteArray request(inSerializedRequest,
             inSerializedRequest + inSerializedRequestSize);
 
-        // Persist enclave type info in WorkOrderProcessor instance
-        tcf::WorkOrderProcessor wo_processor;
+        tcf::WorkOrderProcessorWPE wo_processor;
 
         // Persist Extended work order data in WorkOrderProcessor instance
         wo_processor.ext_work_order_data = \
@@ -116,4 +115,3 @@ tcf_err_t ecall_GetSerializedResponseWPE(uint8_t* outSerializedResponse,
 
     return result;
 }  // ecall_GetSerializedResponseWPE
-

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.cpp
@@ -1,0 +1,227 @@
+/* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "crypto.h"
+#include "tcf_error.h"
+#include "error.h"
+#include "jsonvalue.h"
+#include "parson.h"
+#include "json_utils.h"
+#include "enclave_utils.h"
+#include "work_order_preprocessed_keys_wpe.h"
+
+/*
+ * Unpack Work order key info JSON object to extract index
+ * and encrypted-data-key from input-data-keys or output-data-keys
+ * 
+ * @param keys_object - JSON object which has index and encrypted_in_data
+ * @param data_keys [out] - WorkOrder data object placeholder to store
+ *               index and encrypted-data-key from JSON object
+ * @param encrypted_data_key [out] - Placeholder to store encrypted version
+ *               of encrypted-data-key which will be used for hash calculation
+*/
+void WorkOrderPreProcessedKeys::Unpack(const JSON_Object* keys_object,
+    tcf::WorkOrderData& data_keys, std::string& encrypted_data_key) {
+
+    data_keys.index = GetJsonNumber(keys_object, "index");
+    encrypted_data_key = GetJsonStr(keys_object, "encrypted-data-key");
+    // Decrypt base64 encoded data key using symmetric key(after decryption)
+    // from work_order_key_info json
+    data_keys.decrypted_data = DecryptKey(this->sym_key,
+        Base64EncodedStringToByteArray(encrypted_data_key));
+}  // WorkOrderPreProcessedKeys::Unpack
+
+/*
+ * Decrypt the encrypted key using decryption key supplied.
+ * 
+ * @param decryption_key - Decryption key using which plain key is encrypted.
+ * @param key_to_decrypt - encrypted key which is to be decrypted.
+*/
+ByteArray WorkOrderPreProcessedKeys::DecryptKey(
+    const ByteArray& decryption_key, const ByteArray& key_to_decrypt) {
+
+    return tcf::crypto::skenc::DecryptMessage(decryption_key, key_to_decrypt);
+}  // WorkOrderPreProcessedKeys::DecryptKey
+
+/*
+ * Parse preprocessed work order key info json
+ * 
+ * @param work_order_keys_data_json - Serialized work order key json
+ *                    obtained after preprocessing.
+ * @param enclave_data - Instance of EnclaveData
+*/
+tcf_err_t WorkOrderPreProcessedKeys::ParsePreProcessingJson(
+    std::string work_order_keys_data_json, EnclaveData* enclave_data) {
+
+    JSON_Status jret;
+    // Parse the preprocessed work order keys json
+    JsonValue parsed(json_parse_string(work_order_keys_data_json.c_str()));
+    tcf::error::ThrowIfNull(parsed.value,
+        "Failed to parse the preprocessed work order keys data");
+
+    JSON_Object* wo_keys_obj = json_value_get_object(parsed);
+    tcf::error::ThrowIfNull(wo_keys_obj,
+        "Missing JSON object in preprocessed work order keys data");
+    this->encrypted_sym_key = GetJsonStr(wo_keys_obj,
+        "encrypted-sym-key",
+        "failed to retrieve encrypted symmetric key from preprocessed keys");
+    // Decrypt base64 encoded symmetric key using WPE private encryption key
+    this->sym_key = enclave_data->decrypt_message(
+        Base64EncodedStringToByteArray(this->encrypted_sym_key));
+    this->encrypted_work_order_session_key = GetJsonStr(wo_keys_obj,
+        "encrypted-wo-key",
+        "failed to retrieve encrypted work order session key "
+        "from preprocessed keys");
+    // Decrypt base64 encoded work order session key using
+    // symmetric key decrypted above
+    this->work_order_session_key = DecryptKey(this->sym_key,
+        Base64EncodedStringToByteArray(this->encrypted_work_order_session_key));
+
+    this->encrypted_signing_key = GetJsonStr(wo_keys_obj,
+        "encrypted-wo-signing-key",
+        "failed to retrieve encrypted work order session key "
+        "from preprocessed keys");
+    // Decrypt base64 encoded work order signing key using
+    // symmetric key decrypted above
+    this->signing_key = DecryptKey(this->sym_key,
+        Base64EncodedStringToByteArray(encrypted_signing_key));
+
+    std::string wo_verification_key = GetJsonStr(wo_keys_obj,
+        "wo-verification-key",
+        "failed to retrieve work order verification key "
+        "from preprocessed keys");
+    this->verification_key = \
+        Base64EncodedStringToByteArray(wo_verification_key);
+
+    std::string wo_verification_key_sig = GetJsonStr(wo_keys_obj,
+        "wo-verification-key-sig",
+        "failed to retrieve work order verification key signature "
+        "from preprocessed keys");
+    this->verification_key_signature = \
+        Base64EncodedStringToByteArray(wo_verification_key_sig);
+
+    std::string signature_str = GetJsonStr(wo_keys_obj,
+        "signature",
+        "failed to retrieve signature from preprocessed keys");
+    this->signature = Base64EncodedStringToByteArray(signature_str);
+
+    JSON_Array* in_data_keys_arr = json_object_get_array(
+        wo_keys_obj, "input-data-keys");
+    size_t count = json_array_get_count(in_data_keys_arr);
+
+    if (count > 0) {
+        in_data_keys.resize(count);
+        encrypted_in_data_keys.resize(count);
+        for (int i=0; i<count; i++) {
+            JSON_Object* keys_object = json_array_get_object(
+                in_data_keys_arr, i);
+            Unpack(keys_object, in_data_keys[i], encrypted_in_data_keys[i]);
+        }
+    }
+
+    JSON_Array* out_data_keys_arr = json_object_get_array(
+        wo_keys_obj, "output-data-keys");
+    count = json_array_get_count(out_data_keys_arr);
+
+    if (count > 0) {
+        out_data_keys.resize(count);
+        encrypted_out_data_keys.resize(count);
+        for (int i=0; i<count; i++) {
+            JSON_Object* keys_object = json_array_get_object(
+                out_data_keys_arr, i);
+            Unpack(keys_object, out_data_keys[i], encrypted_out_data_keys[i]);
+        }
+    }
+}  // WorkOrderPreProcessedKeys::ParsePreProcessingJson
+
+/*
+ * Calculates hash of work order key info fields
+*/
+ByteArray WorkOrderPreProcessedKeys::CalculateWorkOrderKeyInfoHash() {
+    std::string concat_str = this->encrypted_sym_key +
+        this->encrypted_work_order_session_key +
+        this->encrypted_signing_key;
+    std::string hash1_str = ByteArrayToBase64EncodedString(
+        tcf::crypto::ComputeMessageHash(StrToByteArray(concat_str)));
+
+    // Compute hash on encrypted_in_data_keys
+    std::string enc_in_data_hash_str;
+    for (auto d: encrypted_in_data_keys) {
+        enc_in_data_hash_str += ByteArrayToBase64EncodedString(
+            tcf::crypto::ComputeMessageHash(
+                Base64EncodedStringToByteArray(d)));
+    }
+
+    // Compute hash on encrypted_out_data_keys
+    std::string enc_out_data_hash_str;
+    for (auto d: encrypted_out_data_keys) {
+        enc_out_data_hash_str += ByteArrayToBase64EncodedString(
+            tcf::crypto::ComputeMessageHash(
+                Base64EncodedStringToByteArray(d)));
+    }
+
+    std::string final_hash_str = \
+        hash1_str + enc_in_data_hash_str + enc_out_data_hash_str;
+    return tcf::crypto::ComputeMessageHash(StrToByteArray(final_hash_str));
+}
+
+/*
+ * Verifies signature of work order key json by comparing hash values.
+ * 
+ * @param enclave_data - Instance of EnclaveData
+ * 
+ * @returns status of signature verification.
+ * passed = 1
+ * failed = other values
+*/
+tcf_err_t WorkOrderPreProcessedKeys::VerifySignatureOfWorkOrderKeys(
+    EnclaveData* enclave_data) {
+
+    ByteArray hash = CalculateWorkOrderKeyInfoHash();
+    ByteArray verify_key_hex_bytes = HexEncodedStringToByteArray(
+        ByteArrayToStr(enclave_data->get_extended_data()));
+    tcf::crypto::sig::PublicKey public_key(
+        ByteArrayToStr(verify_key_hex_bytes));
+    size_t result = public_key.VerifySignature(hash, this->signature);
+    tcf::error::ThrowIf<tcf::error::ValueError>(result != 1,
+        "Failed to verify signature of work order key info");
+}  // WorkOrderPreProcessedKeys::VerifySignatureOfPreProcessedJson
+
+
+/*
+ * Process work order key info json obtainer after preprocessing
+ * 
+ * @param work_order_keys_data_json - Serialized work order key json
+ *                    obtained after preprocessing.
+ * @param enclave_data - Instance of EnclaveData
+*/
+tcf_err_t WorkOrderPreProcessedKeys::ProcessPreProcessedWorkOrderKeys(
+    std::string work_order_keys_data_json, EnclaveData* enclave_data) {
+
+    try {
+        ParsePreProcessingJson(work_order_keys_data_json, enclave_data);
+        Log(TCF_LOG_INFO, "parsed preprocessed work order keys.....");
+        VerifySignatureOfWorkOrderKeys(enclave_data);
+        Log(TCF_LOG_INFO, "verified signature of preprocessed work order keys.....");
+    } catch (tcf::error::ValueError& e) {
+        Log(TCF_LOG_ERROR, "Failed to process pre-processed "
+            "work order key info json - %s", e.what());
+        return TCF_ERR_VALUE;
+    } catch (...) {
+        Log(TCF_LOG_ERROR, "Unknown error while processing preprocessed "
+            "work order key info json");
+        return TCF_ERR_UNKNOWN;
+    }
+}  // WorkOrderPreProcessedKeys::ProcessPreProcessedWorkOrderKeys

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.h
@@ -1,0 +1,79 @@
+/* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+#include "types.h"
+#include "work_order_data.h"
+#include "enclave_data.h"
+
+/*
+    This WPE specific class processes work order key info json which KME
+    returns after pre-process. Also, does integrity check of the
+    work order key info json, decrypts requester (client) specific keys
+    so that they can be made use by WPE for work order processing.
+*/
+
+class WorkOrderPreProcessedKeys {
+public:
+    WorkOrderPreProcessedKeys() {
+        sym_key = {};
+        work_order_session_key = {};
+        signing_key = {};
+        verification_key = {};
+        verification_key_signature = {};
+        signature = {};
+        in_data_keys = {};
+        out_data_keys = {};
+        encrypted_in_data_keys = {};
+        encrypted_out_data_keys = {};
+    }
+
+    tcf_err_t ProcessPreProcessedWorkOrderKeys(
+        std::string work_order_keys_data_json, EnclaveData* enclave_data);
+
+    ByteArray DecryptKey(const ByteArray& decryption_key,
+        const ByteArray& key_to_decrypt);
+
+    ByteArray sym_key;
+    ByteArray work_order_session_key;
+    ByteArray signing_key;
+    ByteArray verification_key;
+    ByteArray verification_key_signature;
+    ByteArray signature;
+    std::vector<tcf::WorkOrderData> in_data_keys;
+    std::vector<tcf::WorkOrderData> out_data_keys;
+
+private:
+    tcf_err_t ParsePreProcessingJson(
+        std::string work_order_keys_data_json, EnclaveData* enclave_data);
+
+    void Unpack(const JSON_Object* keys_object,
+        tcf::WorkOrderData& data_keys, std::string& encrypted_data_key);
+
+    ByteArray CalculateWorkOrderKeyInfoHash();
+
+    tcf_err_t VerifySignatureOfWorkOrderKeys(EnclaveData* enclave_data);
+
+    // Below encrypted keys are used to verify integrity of
+    // pre-processed work order key info json
+    std::string encrypted_sym_key;
+    std::string encrypted_work_order_session_key;
+    std::string encrypted_signing_key;
+    std::vector<std::string> encrypted_in_data_keys;
+    std::vector<std::string> encrypted_out_data_keys;
+};

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor.h
@@ -20,8 +20,8 @@
 #include "enclave_data.h"
 
 #include "parson.h"
+#include "jsonvalue.h"
 #include "types.h"
-#include "enclave_types.h"
 #include "work_order_data_handler.h"
 
 namespace tcf {
@@ -33,13 +33,14 @@ namespace tcf {
         ~WorkOrderProcessor();
         ByteArray CreateErrorResponse(int err_code, const char* err_message);
         ByteArray Process(EnclaveData* enclaveData, std::string json_str);
-        // In case of Singleton enclave, ext_work_order_data is empty
-        // and it contains additional data in case of KME and WPE
         std::string ext_work_order_data;
 
     protected:
-        void ParseJsonInput(EnclaveData* enclaveData, std::string json_str);
-        ByteArray CreateJsonOutput();
+        JsonValue ParseJsonInput(std::string json_str);
+        virtual void DecryptWorkOrderKeys(EnclaveData* enclave_data,
+            const JsonValue& wo_req_json_obj);
+        virtual JsonValue CreateJsonOutput();
+        ByteArray SerializeJson(JsonValue& json_value);
         virtual std::vector<tcf::WorkOrderData> ExecuteWorkOrder(
             EnclaveData* enclave_data);
         ByteArray ComputeRequestHash();
@@ -47,13 +48,8 @@ namespace tcf {
             std::vector<tcf::WorkOrderData>& wo_data);
         tcf_err_t VerifyEncryptedRequestHash();
         int VerifyRequesterSignature();
-        void ComputeSignature(EnclaveData* enclaveData,
-            ByteArray& message_hash);
+        virtual void ComputeSignature(ByteArray& message_hash);
         void ConcatHash(ByteArray& dst, ByteArray& src);
-        /***Required for work order processing **/
-        std::string tc_service_address;
-        std::string participant_address;
-        /***************************************/
 
         std::vector<WorkOrderDataHandler> data_items_in;
         std::vector<WorkOrderDataHandler> data_items_out;

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor_kme.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor_kme.cpp
@@ -117,7 +117,9 @@ namespace tcf {
                 std::string ext_data = ByteArrayToStr(
                     data_items_in[1].workorder_data.decrypted_data);
                 WorkOrderProcessorKME kme_wo_proc;
-                kme_wo_proc.ParseJsonInput(enclave_data, orig_wo_req);
+                JsonValue wo_req_json_val = \
+                    kme_wo_proc.ParseJsonInput(orig_wo_req);
+                kme_wo_proc.DecryptWorkOrderKeys(enclave_data, wo_req_json_val);
                 ExtWorkOrderInfoKME* ext_wo_info_kme = \
                     (ExtWorkOrderInfoKME*) processor->ext_work_order_info;
                 kme_wo_proc.PopulateExtWorkOrderInfoData(ext_data,

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor_wpe.cpp
@@ -1,0 +1,153 @@
+/* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "enclave_t.h"
+#include <algorithm>
+#include <vector>
+#include <string>
+
+#include "crypto.h"
+#include "jsonvalue.h"
+#include "parson.h"
+#include "json_utils.h"
+#include "error.h"
+#include "tcf_error.h"
+#include "types.h"
+#include "hex_string.h"
+#include "utils.h"
+#include "enclave_utils.h"
+
+#include "work_order_processor_wpe.h"
+#include "work_order_preprocessed_keys_wpe.h"
+
+namespace tcf {
+
+    WorkOrderProcessorWPE::~WorkOrderProcessorWPE() {
+        // Sanitize class members storing secrets
+        worker_encryption_key.clear();
+        session_key.clear();
+    }
+
+    /*
+     * Decrypt work order request keys by using keys from preprocessed
+     * work order key info json
+     *
+     * @param enclave_data - Instance of EnclaveData class
+     * @param wo_req_json_val - Work order request json value
+     */
+    void WorkOrderProcessorWPE::DecryptWorkOrderKeys(
+        EnclaveData* enclave_data, const JsonValue& wo_req_json_val) {
+        
+        // Decrypt Encryption key
+        ByteArray encrypted_session_key_bytes = \
+            HexStringToBinary(encrypted_session_key);
+
+        // Use keys from pre-processing json structure
+        // passed as ext_work_order_data
+        tcf_err_t status = \
+            wo_pre_proc_keys.ProcessPreProcessedWorkOrderKeys(
+                this->ext_work_order_data, enclave_data);
+        tcf::error::ThrowIf<tcf::error::ValueError>(status != TCF_SUCCESS,
+            "Failed to process pre-processed work order keys");
+
+        // Decrypt work order encrypted session key using symmetric key
+        // from pre-processing json
+        session_key = wo_pre_proc_keys.work_order_session_key;
+        ByteArray session_key_iv_bytes = HexStringToBinary(session_key_iv);
+
+        JSON_Object* request_object = json_value_get_object(wo_req_json_val);
+        tcf::error::ThrowIfNull(request_object,
+            "Missing JSON object in work order request");
+
+        JSON_Object* params_object = json_object_dotget_object(request_object, "params");
+        tcf::error::ThrowIfNull(params_object,
+            "Missing params object in work order request");
+
+	JSON_Array* data_array = json_object_get_array(
+            params_object, "inData");
+        size_t count = json_array_get_count(data_array);
+        tcf::error::ThrowIf<tcf::error::ValueError>(count == 0,
+            "Indata is empty");
+
+        size_t i;
+        for (i = 0; i < count; i++) {
+            JSON_Object* data_object = json_array_get_object(data_array, i);
+            WorkOrderDataHandler wo_data(session_key, session_key_iv_bytes);
+            // Use in-data key from preprocessed json
+            wo_data.Unpack(enclave_data, data_object,
+                wo_pre_proc_keys.in_data_keys[i].decrypted_data);
+            data_items_in.emplace_back(wo_data);
+        }
+        data_array = json_object_get_array(params_object, "outData");
+
+        count = json_array_get_count(data_array);
+        for (i = 0; i < count; i++) {
+            JSON_Object* data_object = json_array_get_object(data_array, i);
+            WorkOrderDataHandler wo_data(session_key, session_key_iv_bytes);
+            // Use out-data key from preprocessed json
+            wo_data.Unpack(enclave_data, data_object,
+                wo_pre_proc_keys.out_data_keys[i].decrypted_data);
+            data_items_out.emplace_back(wo_data);
+        }
+    }
+
+    /*
+     * Creates Work order response in json format
+     */
+    JsonValue WorkOrderProcessorWPE::CreateJsonOutput() {
+        // Calling base class method to create json response
+        JsonValue response = WorkOrderProcessor::CreateJsonOutput();
+
+        JSON_Object* resp_obj = json_value_get_object(response);
+        tcf::error::ThrowIfNull(resp_obj,
+            "failed to get json object for result");
+
+        JSON_Object* result = json_object_get_object(resp_obj, "result");
+        tcf::error::ThrowIfNull(result, "failed to serialize the result");
+
+        // Pack additional parameters extVerificationKey and
+        // extVerificationKeySignature from preprocessed json used at client
+        // to do 2 step signing verification.
+        //
+        // extVerificationKey - needs to be used by client to verify signature
+        //                of the output
+        // extVerificationKeySignature - client needs to verify using
+        //                Worker's(KME) public verification key
+        JsonSetStr(result, "extVerificationKey",
+            ByteArrayToBase64EncodedString(
+                wo_pre_proc_keys.verification_key).c_str(),
+            "failed to serialize verification key");
+        JsonSetStr(result, "extVerificationKeySignature",
+            ByteArrayToBase64EncodedString(
+                wo_pre_proc_keys.verification_key_signature).c_str(),
+            "failed to serialize verification key signature");
+        return response;
+    }  // WorkOrderProcessorWPE::CreateJsonOutput
+
+    /*
+     * Computes signature on the hash by using signing key
+     * from work order key info json
+     *
+     * @param msg_hash - Hash of the message on which signature
+     *                   is to be computed
+     */
+    void WorkOrderProcessorWPE::ComputeSignature(ByteArray& message_hash) {
+        // Use signing key from preprocessed json to sign hash
+        tcf::crypto::sig::PrivateKey priv_sig_key(
+            ByteArrayToStr(wo_pre_proc_keys.signing_key));
+        ByteArray sig = priv_sig_key.SignMessage(message_hash);
+        worker_signature = base64_encode(sig);
+    }  // WorkOrderProcessorWPE::ComputeSignature
+}  // namespace tcf

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor_wpe.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor_wpe.h
@@ -1,0 +1,46 @@
+/* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "enclave_data.h"
+
+#include "parson.h"
+#include "types.h"
+#include "enclave_types.h"
+#include "work_order_data_handler.h"
+#include "work_order_processor.h"
+#include "work_order_preprocessed_keys_wpe.h"
+
+namespace tcf {
+    class WorkOrderProcessorWPE : public WorkOrderProcessor{
+    public:
+        WorkOrderProcessorWPE() {
+            ext_work_order_data = "";
+        }
+        ~WorkOrderProcessorWPE();
+        std::string ext_work_order_data;
+    private:
+        WorkOrderPreProcessedKeys wo_pre_proc_keys;
+
+        void DecryptWorkOrderKeys(EnclaveData* enclave_data,
+            const JsonValue& wo_req_json_val) override;
+        JsonValue CreateJsonOutput() override;
+        void ComputeSignature(ByteArray& message_hash) override;
+    };  // WorkOrderProcessorWPE
+}  // namespace tcf
+


### PR DESCRIPTION
- Changes to process work order requests
- Changes to parse preprocessed keys json and verify integrity
- Use keys from preprocessed keys json to decrypt work order requestersession key and data encryption keys.
- Create Separate WorkOrderProcessor class for WPE
- Break down base WorkOrderProcessor class methods into multiple so that it can be reused by derived classes


Signed-off-by: manju956 <manjunath.a.c@intel.com>