### PR TITLE
Bug fix for JIRA TCFH-878

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -259,7 +259,8 @@ Module names can be found [here](bin/run_lint#L205) in the codebase.
   1. `sudo rm $TCF_HOME/config/Kv*`
   2. `$TCF_HOME/scripts/tcs_startup.sh -t -s`
   3. You can re-run the test now
-
+  4. If some error still occurs then run : `$TCF_HOME/scripts/tcs_startup.sh -f`. This forcefully terminate Avalon. 
+ 
 - If you get build errors rerunning `make`, try `sudo make clean` first
 
 - If you see the message `No package 'openssl' found`, you do not have

--- a/scripts/tcs_startup.sh
+++ b/scripts/tcs_startup.sh
@@ -86,7 +86,17 @@ stop_avalon_components()
     exit
 }
 
-while getopts "l:styh" OPTCHAR ; do
+stop_avalon_components_forcefully()
+{
+    ps -ef | grep bin/$LISTENER | grep -v grep | awk '{print $2}' | xargs -r kill -9 ;
+    ps -ef | grep bin/$KV_STORAGE | grep -v grep | awk '{print $2}' | xargs -r kill -9;
+    ps -ef | grep $ENCLAVE_MANAGER | grep -v grep | awk '{print $2}' | xargs -r kill -9;
+    ps -ef | grep defunct | grep -v grep | cut -b8-20 | xargs -r kill -9
+    echo "Hyperledger Avalon forcefully terminated"
+    exit
+}
+
+while getopts "l:styhf" OPTCHAR ; do
     case $OPTCHAR in
         s )
             START_STOP_AVALON_SERVICES=1
@@ -101,15 +111,19 @@ while getopts "l:styh" OPTCHAR ; do
         t )
             stop_avalon_components
             ;;
+        f )
+            stop_avalon_components_forcefully
+            ;;
         \?|h )
             BN=$(basename $0)
             echo "$BN: Start or Stop Hyperledger Avalon" 1>&2
             echo "Usage: $BN [-l|-s|-t|-y|-h|-?]" 1>&2
             echo "Where:" 1>&2
             echo "   -l       LMDB server URL. Default is $LMDB_URL" 1>&2
-            echo "   -t       terminate the program" 1>&2
+            echo "   -t       terminate the program gracefully" 1>&2
             echo "   -y       do not prompt to end program" 1>&2
             echo "   -s       also start or stop KV storage component" 1>&2
+            echo "   -f       forcefully kill avalon" 1>&2
             echo "   -? or -h print usage information" 1>&2
             echo "Examples:" 1>&2
             echo "   $BN -s" 1>&2


### PR DESCRIPTION
Added -f option to tcs startup for forcefully terminating Avalon.
Bug fix: 
Enclave Manager fails to start, throws the lmdb error “Couldn't listen on localhost:9090: [Errno 98] Address already in use”.
Signed-off-by: Karthika Murthy <karthika.murthy@intel.com>