### PR TITLE
2 step verification changes

### DIFF
--- a/docker-compose-pool.yaml
+++ b/docker-compose-pool.yaml
@@ -63,8 +63,11 @@ services:
     expose:
       # ZMQ socket port.
       - 5555
+      # sleep is required to wait WPE until KME starts and register worker.
+      # This is temporary work around.
     command: |
       bash -c "
+        sleep 5s
         enclave_manager --lmdb_url http://avalon-lmdb:9090 --kme_listener_url http://avalon-kme:1948
         tail -f /dev/null
       "

--- a/enclave_manager/avalon_enclave_manager/wpe/wpe_requester.py
+++ b/enclave_manager/avalon_enclave_manager/wpe/wpe_requester.py
@@ -98,7 +98,8 @@ class WPERequester():
         if "result" in response:
             wo_response_json = response["result"]
             if self._verify_res_signature(wo_response_json,
-                                          self._worker.verification_key):
+                                          self._worker.verification_key,
+                                          wo_req["params"]["requesterNonce"]):
                 decrypted_res = crypto_utils.decrypted_response(
                     wo_response_json, session_key, session_iv)
                 # Response contains an array of results. In this case, the
@@ -149,7 +150,8 @@ class WPERequester():
         if "result" in response:
             wo_response_json = response["result"]
             if self._verify_res_signature(wo_response_json,
-                                          self._worker.verification_key):
+                                          self._worker.verification_key,
+                                          wo_req["params"]["requesterNonce"]):
                 decrypted_res = crypto_utils.decrypted_response(
                     wo_response_json, session_key, session_iv)
                 # Response contains an array of results. In this case, the
@@ -189,7 +191,8 @@ class WPERequester():
         if "result" in response:
             wo_response_json = response["result"]
             if self._verify_res_signature(wo_response_json,
-                                          self._worker.verification_key):
+                                          self._worker.verification_key,
+                                          wo_req["params"]["requesterNonce"]):
                 decrypted_res = crypto_utils.decrypted_response(
                     wo_response_json, session_key, session_iv)
                 # Response contains an array of results. In this case, the
@@ -244,20 +247,26 @@ class WPERequester():
             "method": self._jrpc_methods[workload_id]
         }
 
-    def _verify_res_signature(self, work_order_res, worker_verification_key):
+    def _verify_res_signature(self, work_order_res,
+                              worker_verification_key,
+                              requester_nonce):
         """
         Verify work order result signature
 
         Parameters :
             @param work_order_res - Result from work order response
             @param worker_verification_key - Worker verification key
+            @param requester_nonce - requester generated nonce in work
+            order request
         Returns :
             @returns True - If verification succeeds
                     False - If verification fails
         """
         sig_obj = signature.ClientSignature()
         status = sig_obj.verify_signature(
-            work_order_res, worker_verification_key)
+            work_order_res,
+            worker_verification_key,
+            requester_nonce)
         if status == SignatureStatus.PASSED:
             logger.info("Signature verification successful")
         else:

--- a/examples/apps/echo/client/echo_client.py
+++ b/examples/apps/echo/client/echo_client.py
@@ -308,7 +308,9 @@ def Main(args=None):
     sig_obj = signature.ClientSignature()
     if "result" in res:
         status = sig_obj.verify_signature(
-            res['result'], worker_obj.verification_key)
+            res['result'],
+            worker_obj.verification_key,
+            wo_params.get_requester_nonce())
         try:
             if status == SignatureStatus.PASSED:
                 logger.info(

--- a/examples/apps/generic_client/fabric_generic_client.py
+++ b/examples/apps/generic_client/fabric_generic_client.py
@@ -314,11 +314,13 @@ class GenericClient():
         return True
 
     def verify_wo_res_signature(self, work_order_res,
-                                worker_verification_key):
+                                worker_verification_key,
+                                requester_nonce):
         # Verify work order result signature
         sig_obj = signature.ClientSignature()
         status = sig_obj.verify_signature(
-            work_order_res, worker_verification_key)
+            work_order_res, worker_verification_key,
+            requester_nonce)
         if status == SignatureStatus.PASSED:
             logger.info("Signature verification Successful")
         else:
@@ -584,7 +586,9 @@ def Main(args=None):
     if "result" in res:
         # Verify work order response signature
         if generic_client.verify_wo_res_signature(
-                res['result'], worker_obj.verification_key) is False:
+                res['result'],
+                worker_obj.verification_key,
+                wo_params.get_requester_nonce()) is False:
             logger.error(
                 "Work order response signature verification Failed")
             sys.exit(1)

--- a/examples/apps/generic_client/generic_client.py
+++ b/examples/apps/generic_client/generic_client.py
@@ -313,10 +313,13 @@ def _verify_receipt_signature(receipt_update_retrieve):
 
 
 def _verify_wo_res_signature(work_order_res,
-                             worker_verification_key):
+                             worker_verification_key,
+                             requester_nonce):
     # Verify work order result signature
     sig_obj = signature.ClientSignature()
-    status = sig_obj.verify_signature(work_order_res, worker_verification_key)
+    status = sig_obj.verify_signature(work_order_res,
+                                      worker_verification_key,
+                                      requester_nonce)
     if status == SignatureStatus.PASSED:
         logger.info("Signature verification Successful")
     else:
@@ -508,7 +511,8 @@ def Main(args=None):
     if "result" in res:
         # Verify work order response signature
         if _verify_wo_res_signature(res['result'],
-                                    worker_obj.verification_key) is False:
+                                    worker_obj.verification_key,
+                                    wo_params.get_requester_nonce()) is False:
             logger.error("Work order response signature verification Failed")
             sys.exit(1)
         # Decrypt work order response

--- a/examples/apps/heart_disease_eval/client/heart_gui.py
+++ b/examples/apps/heart_disease_eval/client/heart_gui.py
@@ -378,7 +378,9 @@ class resultWindow(tk.Toplevel):
         if "result" in res:
             sig_obj = signature.ClientSignature()
             status = sig_obj.verify_signature(
-                res['result'], worker_obj.verification_key)
+                res['result'],
+                worker_obj.verification_key,
+                wo_params.get_requester_nonce())
             try:
                 if status == SignatureStatus.PASSED:
                     logger.info("Signature verification Successful")

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor_wpe.cpp
@@ -126,7 +126,7 @@ namespace tcf {
         // extVerificationKeySignature - client needs to verify using
         //                Worker's(KME) public verification key
         JsonSetStr(result, "extVerificationKey",
-            ByteArrayToBase64EncodedString(
+            ByteArrayToStr(
                 wo_pre_proc_keys.verification_key).c_str(),
             "failed to serialize verification key");
         JsonSetStr(result, "extVerificationKeySignature",

--- a/tests/Demo.py
+++ b/tests/Demo.py
@@ -71,6 +71,7 @@ def local_main(config):
                 wo_id = hex(random.randint(1, 2**64 - 1))
                 input_json_obj["params"]["workOrderId"] = wo_id
                 input_json_obj["params"]["workerId"] = worker_obj.worker_id
+
                 # Convert workloadId to a hex string and update the request
                 workload_id = input_json_obj["params"]["workloadId"]
                 workload_id_hex = workload_id.encode("UTF-8").hex()
@@ -89,6 +90,8 @@ def local_main(config):
                 if status != SignatureStatus.PASSED:
                     LOGGER.info("Generate signature failed\n")
                     exit(1)
+                requester_nonce = json.loads(
+                    input_json_str1)["params"]["requesterNonce"]
                 if input_json_str1 is None:
                     continue
             # -----------------------------------------------------------------
@@ -147,7 +150,9 @@ def local_main(config):
                                 "skipping signature verification")
                     continue
                 sig_bool = sig_obj.verify_signature(
-                    response['result'], worker_obj.verification_key)
+                    response['result'],
+                    worker_obj.verification_key,
+                    requester_nonce)
                 try:
                     if sig_bool > 0:
                         LOGGER.info("Signature Verified")
@@ -183,6 +188,7 @@ def parse_command_line(config, args):
     global private_key
     global encrypted_session_key
     global session_iv
+    global requester_nonce
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--logfile", help="Name of the log file. " +


### PR DESCRIPTION
If the verification key is present in the work order response, its signature is verified in two steps
1. The response signature is verified using the verification key in the response
2. The verification key signature from the response is verified using worker’s public verification key
(aka KME’s verification key)

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>