### PR TITLE
Add retry to http client

### DIFF
--- a/config/wpe_config.toml
+++ b/config/wpe_config.toml
@@ -79,6 +79,9 @@ enclave_type = "WPE"
 # URL of KMEListener where a Work order processor can send requests meant for
 # the Key Management Enclave(KME)  
 kme_listener_url = "http://localhost:1948"
+# Number of times the WPE will attempt to send a request to a KME if a timeout
+# or connection error occurs
+connection_retry = 3
 
 [WorkerConfig]
 # Id of worker in plain text

--- a/docker-compose-pool.yaml
+++ b/docker-compose-pool.yaml
@@ -63,11 +63,8 @@ services:
     expose:
       # ZMQ socket port.
       - 5555
-      # sleep is required to wait WPE until KME starts and register worker.
-      # This is temporary work around.
     command: |
       bash -c "
-        sleep 5s
         enclave_manager --lmdb_url http://avalon-lmdb:9090 --kme_listener_url http://avalon-kme:1948
         tail -f /dev/null
       "


### PR DESCRIPTION
 - Add retry mechanism to HttpJrpcClient
 - Default to no retries
 - Pass config in WPE to retry in case of failures to connect

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>