### PR TITLE
Fix verification key encoding format

### DIFF
--- a/common/sgx_workload/workload/ext_work_order_info_kme.cpp
+++ b/common/sgx_workload/workload/ext_work_order_info_kme.cpp
@@ -249,8 +249,8 @@ int ExtWorkOrderInfoKME::CreateWorkOrderKeyInfo(
         public_sig_key = private_sig_key.GetPublicKey();
 
         ByteArray signing_key = StrToByteArray(private_sig_key.Serialize());
-        wo_key_info.verification_key = StrToByteArray(
-            public_sig_key.Serialize());
+        // verification_key is PEM encoded public key string
+        wo_key_info.verification_key = public_sig_key.Serialize();
 
         // Generate signature on verification key and nonce
         std::string concat_str = \

--- a/common/sgx_workload/workload/work_order_key_info.h
+++ b/common/sgx_workload/workload/work_order_key_info.h
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include "types.h"
 #include "work_order_data.h"
 
 class WorkOrderKeyInfo {
@@ -26,7 +27,7 @@ public:
         encrypted_sym_key = {};
         encrypted_wo_key = {};
         encrypted_signing_key = {};
-        verification_key = {};
+        verification_key = "";
         verification_key_signature = {};
         signature = {};
         in_data_keys = {};
@@ -46,7 +47,7 @@ public:
     }
 
     std::string GetVerificationKey() {
-        return ByteArrayToBase64EncodedString(verification_key);
+        return this->verification_key;
     }
 
     std::string GetVerificationKeySignature() {
@@ -61,7 +62,7 @@ public:
     ByteArray encrypted_sym_key;
     ByteArray encrypted_wo_key;
     ByteArray encrypted_signing_key;
-    ByteArray verification_key;
+    Base64EncodedString verification_key;
     ByteArray verification_key_signature;
     ByteArray signature;
     std::vector<tcf::WorkOrderData> in_data_keys;

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.cpp
@@ -98,12 +98,10 @@ tcf_err_t WorkOrderPreProcessedKeys::ParsePreProcessingJson(
     this->signing_key = DecryptKey(this->sym_key,
         Base64EncodedStringToByteArray(encrypted_signing_key));
 
-    std::string wo_verification_key = GetJsonStr(wo_keys_obj,
+    this->verification_key = GetJsonStr(wo_keys_obj,
         "wo-verification-key",
         "failed to retrieve work order verification key "
         "from preprocessed keys");
-    this->verification_key = \
-        Base64EncodedStringToByteArray(wo_verification_key);
 
     std::string wo_verification_key_sig = GetJsonStr(wo_keys_obj,
         "wo-verification-key-sig",

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.h
@@ -34,7 +34,7 @@ public:
         sym_key = {};
         work_order_session_key = {};
         signing_key = {};
-        verification_key = {};
+        verification_key = "";
         verification_key_signature = {};
         signature = {};
         in_data_keys = {};
@@ -52,7 +52,7 @@ public:
     ByteArray sym_key;
     ByteArray work_order_session_key;
     ByteArray signing_key;
-    ByteArray verification_key;
+    Base64EncodedString verification_key;
     ByteArray verification_key_signature;
     ByteArray signature;
     std::vector<tcf::WorkOrderData> in_data_keys;

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor_wpe.cpp
@@ -121,13 +121,12 @@ namespace tcf {
         // extVerificationKeySignature from preprocessed json used at client
         // to do 2 step signing verification.
         //
-        // extVerificationKey - needs to be used by client to verify signature
-        //                of the output
+        // extVerificationKey - PEM encoded public key which needs to be
+        //            used by client to verify signature of the output
         // extVerificationKeySignature - client needs to verify using
-        //                Worker's(KME) public verification key
+        //            Worker's(KME) public verification key
         JsonSetStr(result, "extVerificationKey",
-            ByteArrayToStr(
-                wo_pre_proc_keys.verification_key).c_str(),
+            (wo_pre_proc_keys.verification_key).c_str(),
             "failed to serialize verification key");
         JsonSetStr(result, "extVerificationKeySignature",
             ByteArrayToBase64EncodedString(


### PR DESCRIPTION
- Change verification_key type from ByteArray to Base64EncodedString(PEM format). This avoids 
   unnecessary data format conversions at multiple places.

Signed-off-by: manju956 <manjunath.a.c@intel.com>