### PR TITLE
Fix stand alone mode test failure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,6 @@ services:
       "
     depends_on:
       - avalon-lmdb
-      - avalon-listener
 
   avalon-lmdb:
     container_name: avalon-lmdb

--- a/listener/avalon_listener/tcs_listener.py
+++ b/listener/avalon_listener/tcs_listener.py
@@ -27,6 +27,7 @@
 import sys
 import logging
 import argparse
+from urllib.parse import urlparse
 
 from avalon_listener.tcs_work_order_handler import TCSWorkOrderHandler
 from avalon_listener.tcs_work_order_handler_sync import TCSWorkOrderHandlerSync
@@ -72,8 +73,7 @@ class TCSListener(BaseJRPCListener):
             self.workorder_handler = TCSWorkOrderHandlerSync(
                 self.kv_helper,
                 config["Listener"]["max_work_order_count"],
-                config["Listener"]["zmq_url"],
-                config["Listener"]["zmq_port"])
+                config["Listener"]["zmq_url"])
         else:
             self.workorder_handler = TCSWorkOrderHandler(
                 self.kv_helper,
@@ -121,6 +121,12 @@ def parse_command_line(config, args):
         '--bind', help='URI to listen for requests ', type=str)
     parser.add_argument(
         '--lmdb_url', help='DB url to connect to LMDB ', type=str)
+    parser.add_argument(
+        '--sync_mode', help='Work order execution in synchronous mode',
+        type=bool, default=False)
+    parser.add_argument(
+        '--zmq_url',
+        help='ZMQ url to connect to enclave manager ', type=str)
 
     options = parser.parse_args(args)
 
@@ -150,6 +156,26 @@ def parse_command_line(config, args):
             logger.error("Quit : remote_storage_url is not \
                             present in config for Listener")
             sys.exit(-1)
+    # Check if listener is running in sync work order
+    if options.sync_mode:
+        is_sync = True
+    else:
+        is_sync = config["WorkloadExecution"]["sync_workload_execution"]
+
+    if options.zmq_url:
+        if not is_sync:
+            logger.warn("Option zmq_url has no effect!"
+                        "It is be supported "
+                        "in work order sync mode ON")
+        if config.get("Listener") is None or \
+                config["Listener"].get("zmq_url") is None:
+            logger.error("Quit : no zmq_url config found for Listener")
+            sys.exit(-1)
+        parse_res = urlparse(options.zmq_url)
+        if parse_res.scheme != "tcp" or parse_res.port == "":
+            logger.error("Invalid zmq url. It should be tcp://<host>:<port>")
+            sys.exit(-1)
+        config["Listener"]["zmq_url"] = options.zmq_url
 
     return host_name, port
 

--- a/listener/avalon_listener/tcs_work_order_handler_sync.py
+++ b/listener/avalon_listener/tcs_work_order_handler_sync.py
@@ -52,14 +52,13 @@ class TCSWorkOrderHandlerSync(TCSWorkOrderHandler):
     """
 # ------------------------------------------------------------------------------------------------
 
-    def __init__(self, kv_helper, max_wo_count, zmq_url, zmq_port):
+    def __init__(self, kv_helper, max_wo_count, zmq_url):
         """
         Function to perform init activity
         Parameters:
             - kv_helper is a object of lmdb database
         """
         self.zmq_url = zmq_url
-        self.zmq_port_number = zmq_port
         super(TCSWorkOrderHandlerSync, self).__init__(kv_helper, max_wo_count)
 
 # ---------------------------------------------------------------------------------------------
@@ -145,11 +144,11 @@ class TCSWorkOrderHandlerSync(TCSWorkOrderHandler):
             # ZeroMQ for sync workorder processing
             try:
                 socket = context.socket(zmq.REQ)
-                socket.connect(self.zmq_url + self.zmq_port_number)
+                socket.connect(self.zmq_url)
                 socket.send_string(wo_id, flags=0, encoding='utf-8')
                 replymessage = socket.recv()
                 logger.info(replymessage)
-                socket.disconnect(self.zmq_url + self.zmq_port_number)
+                socket.disconnect(self.zmq_url)
             except Exception as er:
                 raise JSONRPCDispatchException(
                     WorkOrderStatus.UNKNOWN_ERROR,

--- a/listener/listener_config.toml
+++ b/listener/listener_config.toml
@@ -28,8 +28,7 @@ bind = "http://localhost:1947"
 max_work_order_count = 10
 # ZMQ configurations the listener would connect to
 # Same as the url and port of enclave manager socket
-zmq_url = "tcp://avalon-enclave-manager:"
-zmq_port = '5555'
+zmq_url = "tcp://avalon-enclave-manager:5555"
 
 # ------------------------------------------------------------------
 # Work load execution-settings for workload execution(synchronous/asynchronous)


### PR DESCRIPTION
Since listener config is hard-coded with container service name
and it is failing in standlone mode.
Added command line option to listener to read zmq_url and default value
in config file is localhost and command line argument takes precedence.

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>