### PR TITLE
Fix server error issue when unencrypted input data is sent to worker …

### DIFF
--- a/common/sgx_workload/workload/ext_work_order_info_kme.cpp
+++ b/common/sgx_workload/workload/ext_work_order_info_kme.cpp
@@ -281,6 +281,16 @@ int ExtWorkOrderInfoKME::CreateWorkOrderKeyInfo(
         int count = this->in_work_order_keys.size();
         wo_key_info.in_data_keys.resize(count);
         for (int i=0; i<count; i++) {
+            std::string in_data_enc_key = \
+                ByteArrayToStr(wo_key_info.in_data_keys[i].decrypted_data);
+            // skip encrypting input data encryption key if
+            // its value is equivalent to empty or null or "-"
+            // these checks are performed again while decrypting data
+            // during work order processing at WPE
+            if (in_data_enc_key.empty() || "null" == in_data_enc_key ||
+                "-" == in_data_enc_key ) {
+                continue;
+            }
             wo_key_info.in_data_keys[i].decrypted_data = \
                 tcf::crypto::skenc::EncryptMessage(wo_key_info.sym_key,
                     wo_key_info.in_data_keys[i].decrypted_data);
@@ -289,6 +299,16 @@ int ExtWorkOrderInfoKME::CreateWorkOrderKeyInfo(
         count = this->out_work_order_keys.size();
         wo_key_info.out_data_keys.resize(count);
         for (int i=0; i<count; i++) {
+            std::string out_data_enc_key = \
+                ByteArrayToStr(wo_key_info.out_data_keys[i].decrypted_data);
+            // skip encrypting output data encryption key if
+            // its value is equivalent to empty or null or "-"
+            // these checks are performed again while decrypting data
+            // during work order processing at WPE
+            if (out_data_enc_key.empty() || "null" == out_data_enc_key ||
+                "-" == out_data_enc_key) {
+                continue;
+            }
             wo_key_info.out_data_keys[i].decrypted_data = \
                 tcf::crypto::skenc::EncryptMessage(wo_key_info.sym_key,
                     wo_key_info.out_data_keys[i].decrypted_data);

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_preprocessed_keys_wpe.cpp
@@ -37,6 +37,14 @@ void WorkOrderPreProcessedKeys::Unpack(const JSON_Object* keys_object,
 
     data_keys.index = GetJsonNumber(keys_object, "index");
     encrypted_data_key = GetJsonStr(keys_object, "encrypted-data-key");
+
+    // skip decrypting data encryption key if its value is
+    // equivalent to empty or null or "-"
+    if (encrypted_data_key.empty() ||  "null" == encrypted_data_key ||
+        "-" == encrypted_data_key) {
+        return;
+    }
+
     // Decrypt base64 encoded data key using symmetric key(after decryption)
     // from work_order_key_info json
     data_keys.decrypted_data = DecryptKey(this->sym_key,


### PR DESCRIPTION
…pool

- Skip encryption of inData or outData encryption keys during preprocess
  when "-" is passed as data encryption key.
- Skip decryption of inData or outData encryption keys at WPE during work order processing.
- This fixes https://jira.devtools.intel.com/browse/TCFH-980

Signed-off-by: manju956 <manjunath.a.c@intel.com>