### PR TITLE
Add new lmdb tables for work order processing

### DIFF
--- a/config/singleton_enclave_config.toml
+++ b/config/singleton_enclave_config.toml
@@ -28,7 +28,7 @@ LogFile  = "__screen__"
 # ------------------------------------------------------------------
 [WorkloadExecution]
 # Set this flag to 1 for sync workorder execution.Else set it to 0
-sync_workload_execution = 1
+sync_workload_execution = 0
 
 # -------------------------------------------------------------------
 # EnclaveManager -- configuration of Intel SGX Enclave EnclaveManager

--- a/config/wpe_config.toml
+++ b/config/wpe_config.toml
@@ -28,7 +28,7 @@ LogFile  = "__screen__"
 # ------------------------------------------------------------------
 [WorkloadExecution]
 # Set this flag to 1 for sync workorder execution.Else set it to 0
-sync_workload_execution = 1
+sync_workload_execution = 0
 
 # -------------------------------------------------------------------
 # EnclaveManager -- configuration of Intel SGX Enclave EnclaveManager

--- a/listener/avalon_listener/tcs_work_order_handler_sync.py
+++ b/listener/avalon_listener/tcs_work_order_handler_sync.py
@@ -89,6 +89,8 @@ class TCSWorkOrderHandlerSync(TCSWorkOrderHandler):
                 data
             )
 
+        worker_id = input_value_json["params"]["workerId"]
+
         if "inData" in input_value_json["params"]:
             valid, err_msg = req_validator.validate_data_format(
                 input_value_json["params"]["inData"])
@@ -151,12 +153,15 @@ class TCSWorkOrderHandlerSync(TCSWorkOrderHandler):
             # Don't change the order of table updates.
             # The order is important for clean up if the TCS is restarted in
             # the middle.
+            # Add entry to wo-worker-pending which holds all the work order id
+            # separated by comma(csv) to be processed by corresponding worker.
+            # i.e. - <worker_id> -> <wo_id>,<wo_id>,<wo_id>...
             epoch_time = str(time.time())
 
             # Update the tables
             self.kv_helper.set("wo-timestamps", wo_id, epoch_time)
             self.kv_helper.set("wo-requests", wo_id, input_json_str)
-            self.kv_helper.set("wo-scheduled", wo_id, input_json_str)
+            self.kv_helper.csv_append("wo-worker-pending", worker_id, wo_id)
             # Add to the internal FIFO
             self.workorder_list.append(wo_id)
             self.workorder_count += 1

--- a/listener/listener_config.toml
+++ b/listener/listener_config.toml
@@ -35,7 +35,7 @@ zmq_url = "tcp://avalon-enclave-manager:5555"
 # ------------------------------------------------------------------
 [WorkloadExecution]
 # Set this flag to 1 for sync workorder execution.Else set it to 0
-sync_workload_execution = 1
+sync_workload_execution = 0
 
 [KvStorage]
 remote_storage_url = "http://localhost:9090"

--- a/shared_kv_storage/db_store/packages/lmdb_store.cpp
+++ b/shared_kv_storage/db_store/packages/lmdb_store.cpp
@@ -168,7 +168,13 @@ tcf_err_t db_store::db_store_get_value_size(
     }
 
     ret = mdb_dbi_open(stxn.txn, table.c_str(), 0, &dbi);
-    if (ret != 0) {
+    if (ret == MDB_NOTFOUND) {
+        // Set outIsPresent to false if database not found and return SUCCESS
+        // for the db_store_get_value_size operation
+        *outIsPresent = false;
+        return TCF_SUCCESS;
+    }
+    else if (ret != 0) {
         // SAFE_LOG(TCF_LOG_ERROR, "Failed to open LMDB transaction : %d", ret);
         *outIsPresent = false;
         return TCF_ERR_SYSTEM;

--- a/shared_kv_storage/kv_storage/remote_lmdb/shared_kv_dbstore.py
+++ b/shared_kv_storage/kv_storage/remote_lmdb/shared_kv_dbstore.py
@@ -82,7 +82,9 @@ class KvDBStore(KvStorage, KvCsvStorage):
         try:
             self._db_store.db_store_put(table, key, value)
             return True
-        except Exception:
+        except Exception as ex:
+            logger.error("Exception occurred in set - {}".
+                         format(ex))
             return False
 
 # ---------------------------------------------------------------------------------------------------
@@ -99,7 +101,9 @@ class KvDBStore(KvStorage, KvCsvStorage):
                 value = self._db_store.db_store_get(table, key)
             else:
                 value = None
-        except Exception:
+        except Exception as ex:
+            logger.error("Exception occurred in get - {}".
+                         format(ex))
             value = None
 
         if not value:
@@ -128,7 +132,9 @@ class KvDBStore(KvStorage, KvCsvStorage):
             else:
                 self._db_store.db_store_del(table, key, value)
             return True
-        except Exception:
+        except Exception as ex:
+            logger.error("Exception occurred in remove - {}".
+                         format(ex))
             return False
 
 # ---------------------------------------------------------------------------------------------------
@@ -146,7 +152,9 @@ class KvDBStore(KvStorage, KvCsvStorage):
             table_keys = table_keys.split(",")
             for i in table_keys:
                 result.append(i)
-        except Exception:
+        except Exception as ex:
+            logger.error("Exception occurred in lookup - {}".
+                         format(ex))
             result = []
 
         return result
@@ -168,7 +176,9 @@ class KvDBStore(KvStorage, KvCsvStorage):
         try:
             self._db_store.db_store_csv_append(table, key, value)
             return True
-        except Exception:
+        except Exception as ex:
+            logger.error("Exception occurred in csv_append - {}".
+                         format(ex))
             return False
 
 # ---------------------------------------------------------------------------------------------------
@@ -188,7 +198,9 @@ class KvDBStore(KvStorage, KvCsvStorage):
         try:
             self._db_store.db_store_csv_prepend(table, key, value)
             return True
-        except Exception:
+        except Exception as ex:
+            logger.error("Exception occurred in csv_prepend - {}".
+                         format(ex))
             return False
 
 # ---------------------------------------------------------------------------------------------------
@@ -213,7 +225,9 @@ class KvDBStore(KvStorage, KvCsvStorage):
                 value = self._db_store.db_store_csv_pop(table, key)
             else:
                 value = None
-        except Exception:
+        except Exception as ex:
+            logger.error("Exception occurred in csv_pop - {}".
+                         format(ex))
             value = None
 
         if not value:


### PR DESCRIPTION
- Add MDB_NOTFOUND check in db_store_get_value_size and return Success
       if databse itself not found.
- Log instead of suppressing exception at shared_kv_db_store
- Toggle sync mode to use polling
- Add tables wo-worker-pending and wo-worker-processing
- Update usage of these tables in in enclave_manager
- Update generic client to pick up workers randomly
