### PR TITLE
ECDSA Signing and Verification Fixes

### DIFF
--- a/common/cpp/crypto/sig.h
+++ b/common/cpp/crypto/sig.h
@@ -28,7 +28,14 @@ namespace crypto {
           * ECDSA Secp256k1 signature size, in bytes:
           * 64 bytes (512b) + 8 byte DER prefix
           */
-        const int MAX_SIG_SIZE = 72;
+        const unsigned int MAX_SIG_SIZE = 72;
+        /**
+          * Length of binary EC point, in bytes.
+          * The printable hexadecimal character length is 2 times this value.
+          * A uncompressed EC point in binary contains a 1 byte prefix (0x04),
+          * followed by two 32 byte (256 bit) (X,Y) coordinates.
+          */
+        const unsigned int EC_POINT_BYTE_LEN = 1 + 32 + 32;
     }  // namespace constants
 }  // namespace crypto
 }  // namespace tcf

--- a/common/cpp/tests/Makefile
+++ b/common/cpp/tests/Makefile
@@ -84,10 +84,11 @@ build/pktest: build build/pktest.o \
 
 build/signtest: build build/signtest.o \
 		build/sig_private_key.o build/sig_private_key_common.o \
-		build/sig_public_key.o build/sig_public_key_common.o
+		build/sig_public_key.o build/sig_public_key_common.o \
+		$(UTILTESTOBJS)
 	g++ -o $@ $@.o build/sig_private_key.o build/sig_private_key_common.o \
 		build/sig_public_key.o build/sig_public_key_common.o \
-		$(LDFLAGS)
+		$(UTILTESTOBJS) $(LDFLAGS)
 
 build/secrettest: build build/secrettest.o $(UTILTESTOBJS)
 	g++ -o $@ $@.o $(UTILTESTOBJS) $(LDFLAGS)


### PR DESCRIPTION
signtest.cpp
- Fix ECDSA test to pass hash of message, not message itself
  (to test SignMessage() and VerifyMessage())
- Add messages

sig_public_key.cpp
- Verify point (X,Y) hex digit length
- Verify PEM strings are not empty

sig_private_key.cpp
- Verify hash length

sig*.cpp
- Use == and != to compare non-Boolean pointers and integers
- Add compile-time test that CRYPTOLIB_OPENSSL is defined

Signed-off-by: danintel <daniel.anderson@intel.com>