### PR TITLE
Remove worker_id calculation worker details

### DIFF
--- a/sdk/avalon_sdk/worker/worker_details.py
+++ b/sdk/avalon_sdk/worker/worker_details.py
@@ -198,7 +198,6 @@ class SGXWorkerDetails(WorkerDetails):
         self.encryption_key_nonce = ""
         self.encryption_key_signature = ""
         self.enclave_certificate = ""
-        self.worker_id = ""
 
 # -----------------------------------------------------------------------------
     def load_worker(self, worker_data):
@@ -225,14 +224,6 @@ class SGXWorkerDetails(WorkerDetails):
             self.proof_data = json.loads(
                 worker_data['workerTypeData']['proofData'])
 
-        w_id = crypto_utility.strip_begin_end_public_key(
-            worker_data['workerTypeData']['verificationKey']) \
-            .encode("UTF-8")
-        # Calculate sha256 of worker id to get 32 bytes. The TC spec proxy
-        # model contracts expect byte32. Then take a hexdigest for hex str.
-        self.worker_id = hashlib.sha256(w_id).hexdigest()
-        ''' worker_id - newline, BEGIN PUB KEY and END PUB KEY are removed
-                        from worker's verification key and converted to hex '''
         logger.info("Hashing Algorithm : %s", self.hashing_algorithm)
         logger.info("Signing Algorithm : %s", self.signing_algorithm)
 

--- a/tests/Demo.py
+++ b/tests/Demo.py
@@ -70,7 +70,7 @@ def local_main(config):
                 input_json_obj = json.loads(input_json_str1)
                 wo_id = hex(random.randint(1, 2**64 - 1))
                 input_json_obj["params"]["workOrderId"] = wo_id
-                input_json_obj["params"]["workerId"] = worker_obj.worker_id
+                input_json_obj["params"]["workerId"] = worker_id
 
                 # Convert workloadId to a hex string and update the request
                 workload_id = input_json_obj["params"]["workloadId"]
@@ -186,6 +186,7 @@ def parse_command_line(config, args):
     global consensus_file_name
     global sig_obj
     global worker_obj
+    global worker_id
     global private_key
     global encrypted_session_key
     global session_iv


### PR DESCRIPTION
Worker id is calculated from enclave manager

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>