### PR TITLE
Updating rebuild.sh and clean.sh as per new path of kme_workload.

### DIFF
--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -38,7 +38,7 @@ cd $SRCDIR/shared_kv_storage
 make clean
 
 #--------------- KME WORKLOAD ---------------
-cd $SRCDIR/tc/sgx/trusted_worker_manager/enclave/kme_workload
+cd $SRCDIR/tc/sgx/trusted_worker_manager/enclave/kme/workload
 rm -rf build
 
 # --------------- COMMON CPP ---------------

--- a/tools/rebuild.sh
+++ b/tools/rebuild.sh
@@ -155,7 +155,7 @@ try cmake ..
 try make "-j$NUM_CORES"
 
 yell --------------- KME WORKLOAD ---------------
-cd $TCF_HOME/tc/sgx/trusted_worker_manager/enclave/kme_workload || error_exit "Failed to change to the directory"
+cd $TCF_HOME/tc/sgx/trusted_worker_manager/enclave/kme/workload || error_exit "Failed to change to the directory"
 
 mkdir -p build
 cd build


### PR DESCRIPTION
Without this change standalone build would fail

Signed-off-by: Karthika Murthy <karthika.murthy@intel.com>