### PR TITLE
Updated json param check in listener

### DIFF
--- a/common/python/listener/base_jrpc_listener.py
+++ b/common/python/listener/base_jrpc_listener.py
@@ -83,15 +83,14 @@ class BaseJRPCListener(resource.Resource):
 
         try:
             input_json = json.loads(input_json_str)
+            logger.info("Received request: %s", input_json['method'])
         except Exception as err:
-            logger.exception("exception loading Json: %s", str(err))
+            logger.error("exception loading Json: %s", str(err))
             response["error"]["message"] = "Improper Json request"
             return response
 
-        logger.info("Received request: %s", input_json['method'])
         # save the full json for WorkOrderSubmit
         input_json["params"]["raw"] = input_json_str
-
         data = json.dumps(input_json).encode('utf-8')
         response = JSONRPCResponseManager.handle(data, self.dispatcher)
         return response.data

--- a/sdk/avalon_sdk/work_order/work_order_request_validator.py
+++ b/sdk/avalon_sdk/work_order/work_order_request_validator.py
@@ -83,7 +83,7 @@ class WorkOrderRequestValidator():
         if type(params["responseTimeoutMSecs"]) != int:
             return False, "Invalid data format for responseTimeoutMSecs"
 
-        if params["payloadFormat"] != "JSON-RPC":
+        if params["payloadFormat"].upper() != "JSON-RPC":
             return False, "Invalid payload format"
 
         if not is_valid_hex_str(params["workerId"]):


### PR DESCRIPTION
Bug fix:
Operation failed with response: 500 error message received when wrong method name is passed
Pay load format is not checked in Direct SDK model

Resolved
Multiple issues noticed while setting up and running test on standalone avalon build.

Signed-off-by: Karthika Murthy <karthika.murthy@intel.com>