### PR TITLE
Allow worker_id in cmdline arg

### DIFF
--- a/config/kme_config.toml
+++ b/config/kme_config.toml
@@ -67,7 +67,8 @@ remote_url = "http://localhost:9090"
 # -------------------------------------------------------------
 
 [WorkerConfig]
-# Id of worker in plain text
+# Id of worker in plain text. This can be overridden by passing values in command line for
+# enclave manager using --worker_id option.
 worker_id = "kme-worker-1"
 ProofDataType = "TEE-SGX-IAS"
 

--- a/config/singleton_enclave_config.toml
+++ b/config/singleton_enclave_config.toml
@@ -76,7 +76,8 @@ enclave_type = "SWE"
 # -------------------------------------------------------------
 
 [WorkerConfig]
-# Id of worker in plain text
+# Id of worker in plain text. This can be overridden by passing values in command line for
+# enclave manager using --worker_id option.
 worker_id = "singleton-worker-1"
 # Supported workloads for this worker. The work orders matching these workload ids
 # will be processed by the enclave manager. The enclaves should be built with matching

--- a/config/wpe_config.toml
+++ b/config/wpe_config.toml
@@ -84,7 +84,8 @@ kme_listener_url = "http://localhost:1948"
 connection_retry = 3
 
 [WorkerConfig]
-# Id of worker in plain text
+# Id of worker in plain text. This can be overridden by passing values in command line for
+# enclave manager using --worker_id option.
 worker_id = "kme-worker-1"
 # Supported workloads for this worker. The work orders matching these workload ids
 # will be processed by the enclave manager. The enclaves should be built with matching

--- a/enclave_manager/avalon_enclave_manager/kme/kme_enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/kme/kme_enclave_manager.py
@@ -239,6 +239,8 @@ def main(args=None):
     parser.add_argument("--config-dir", help="configuration folder", nargs="+")
     parser.add_argument("--bind", help="KME listener url for requests to KME",
                         type=str)
+    parser.add_argument(
+        "--worker_id", help="Id of worker in plain text", type=str)
     (options, remainder) = parser.parse_known_args(args)
 
     if options.config:
@@ -256,6 +258,8 @@ def main(args=None):
 
     if options.bind:
         config["KMEListener"]["bind"] = options.bind
+    if options.worker_id:
+        config["WorkerConfig"]["worker_id"] = options.worker_id
 
     plogger.setup_loggers(config.get("Logging", {}))
     sys.stdout = plogger.stream_to_logger(

--- a/enclave_manager/avalon_enclave_manager/singleton/singleton_enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/singleton/singleton_enclave_manager.py
@@ -108,6 +108,8 @@ def main(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", help="configuration file", nargs="+")
     parser.add_argument("--config-dir", help="configuration folder", nargs="+")
+    parser.add_argument(
+        "--worker_id", help="Id of worker in plain text", type=str)
     parser.add_argument("--workloads",
                         help="Comma-separated list of workloads supported",
                         type=str)
@@ -128,6 +130,8 @@ def main(args=None):
 
     if options.workloads:
         config["WorkerConfig"]["workloads"] = options.workloads
+    if options.worker_id:
+        config["WorkerConfig"]["worker_id"] = options.worker_id
 
     plogger.setup_loggers(config.get("Logging", {}))
     sys.stdout = plogger.stream_to_logger(

--- a/enclave_manager/avalon_enclave_manager/wpe/wpe_enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/wpe/wpe_enclave_manager.py
@@ -133,6 +133,8 @@ def main(args=None):
     parser.add_argument("--kme_listener_url",
                         help="KME listener url for requests to KME",
                         type=str)
+    parser.add_argument(
+        "--worker_id", help="Id of worker in plain text", type=str)
     parser.add_argument("--workloads",
                         help="Comma-separated list of workloads supported",
                         type=str)
@@ -155,6 +157,8 @@ def main(args=None):
         config["KMEListener"]["kme_listener_url"] = options.kme_listener_url
     if options.workloads:
         config["WorkerConfig"]["workloads"] = options.workloads
+    if options.worker_id:
+        config["WorkerConfig"]["worker_id"] = options.worker_id
 
     plogger.setup_loggers(config.get("Logging", {}))
     sys.stdout = plogger.stream_to_logger(


### PR DESCRIPTION
 - Allow worker_id config to be passed via command line
   argument for Singleton/KME/WPE. This would override the
   default in respective config files
 - Add retry to lookup worker for a WPE

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>