### PR TITLE
Handle cleanup of work order at startup

### DIFF
--- a/common/python/database/lmdb_helper_proxy.py
+++ b/common/python/database/lmdb_helper_proxy.py
@@ -154,7 +154,7 @@ class LMDBHelperProxy():
            @param value - The value that needs to be appended to the existing
                           value(comma-separated) corresponding to the key.
         """
-        # Csv_append, table, key, value
+        # csv_append, table, key, value
         # CA corresponding to Csv Append
         request = "CA\n" + self.__escape(table) + "\n" + self.__escape(key) + \
             "\n" + self.__escape(value)
@@ -175,7 +175,7 @@ class LMDBHelperProxy():
            @param value - The value that needs to be prepended to the existing
                           value(comma-separated) corresponding to the key.
         """
-        # Csv_prepend, table, key, value
+        # csv_prepend, table, key, value
         # CP corresponding to Csv Prepend
         request = "CP\n" + self.__escape(table) + "\n" + self.__escape(key) + \
             "\n" + self.__escape(value)
@@ -199,7 +199,7 @@ class LMDBHelperProxy():
            @returns value - First element from comma-separated value for key
                             passed in.
         """
-        # Csv_pop, table, key
+        # csv_pop, table, key
         # CR corresponding to Csv Pop where the 1st element from the csv is
         # retrieved and the rest left intact.
         request = "CR\n" + self.__escape(table) + "\n" + self.__escape(key)
@@ -225,13 +225,35 @@ class LMDBHelperProxy():
            @returns value - value if the first string of the comma-separated
                             strings matches. None, otherwise.
         """
-        # Csv_pop, table, key, value
+        # csv_pop, table, key, value
         # CM corresponding to Csv match and pop where the 1st element from the
         # csv is conditionally(if matches) retrieved and the rest left intact.
         request = "CM\n" + self.__escape(table) + "\n" + self.__escape(key) + \
             "\n" + self.__escape(value)
 
         return self.__get_update(request)
+
+# ------------------------------------------------------------------------------
+    def csv_search_delete(self, table, key, value):
+        """
+        Function to conditionally update a key-value pair in a lmdb table
+        that holds comma-separated strings as value. This function reads
+        each of the comma-separated strings and then compares it with the
+        value passed in. If there is a match, the passed value is deleted.
+        If this is the lone string, the key-value pair altogether is removed.
+
+        Parameters:
+           @param table - Name of the lmdb table from which key-value pair
+                          needs to be read and updated.
+           @param key - The primary key of the table.
+           @param value - Value to be compared against and deleted.
+        """
+        # csv_search_delete, table, key, value
+        # CD corresponding to Csv Search Delete
+        request = "CD\n" + self.__escape(table) + "\n" + self.__escape(key) + \
+            "\n" + self.__escape(value)
+
+        return self.__set_update(request)
 
 # ------------------------------------------------------------------------------
     def __set_update(self, request):

--- a/common/python/database/test_lmdb_app.py
+++ b/common/python/database/test_lmdb_app.py
@@ -176,6 +176,97 @@ class TestRemoteLMDB(unittest.TestCase):
                                               self.key3, "notFound")
         self.assertEqual(pop_result, None, "Incorrect match pop result")
 
+    def test_csv_search_delete_first(self):
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value1")
+        self.assertTrue(append_result)
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value2")
+        self.assertTrue(append_result)
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("Before delete value : %s", get_value_result)
+        delete_value_result = self.proxy.csv_search_delete(
+            self.table, "key5", "value1")
+        self.assertTrue(delete_value_result)
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("After delete value : %s", get_value_result)
+        self.assertEqual(get_value_result, "value2",
+                         "csv_search_delete failed to delete value")
+        self.proxy.remove(self.table, "key5")
+
+    def test_csv_search_delete_last(self):
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value1")
+        self.assertTrue(append_result)
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value2")
+        self.assertTrue(append_result)
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("Before delete value : %s", get_value_result)
+        delete_value_result = self.proxy.csv_search_delete(
+            self.table, "key5", "value2")
+        self.assertTrue(delete_value_result)
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("After delete value : %s", get_value_result)
+        self.assertEqual(get_value_result, "value1",
+                         "csv_search_delete failed to delete value")
+        self.proxy.remove(self.table, "key5")
+
+    def test_csv_search_delete_notfound(self):
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value1")
+        self.assertTrue(append_result)
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value2")
+        self.assertTrue(append_result)
+
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("Before delete value : %s", get_value_result)
+        delete_value_result = self.proxy.csv_search_delete(
+            self.table, "key5", "value3")
+        self.assertTrue(not delete_value_result)
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("After delete value : %s", get_value_result)
+        self.assertEqual(get_value_result, "value1,value2",
+                         "csv_search_delete failed to delete value")
+        self.proxy.remove(self.table, "key5")
+
+    def test_csv_search_delete_inbetween(self):
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value1")
+        self.assertTrue(append_result)
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value2")
+        self.assertTrue(append_result)
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value3")
+        self.assertTrue(append_result)
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("Before delete value : %s", get_value_result)
+        delete_value_result = self.proxy.csv_search_delete(
+            self.table, "key5", "value2")
+        self.assertTrue(delete_value_result)
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("After delete value : %s", get_value_result)
+        self.assertEqual(get_value_result, "value1,value3",
+                         "csv_search_delete failed to delete value")
+        self.proxy.remove(self.table, "key5")
+
+    def test_csv_search_delete_only(self):
+        append_result = self.proxy.csv_append(
+            self.table, "key5", "value1")
+        self.assertTrue(append_result)
+
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("Before delete value : %s", get_value_result)
+        delete_value_result = self.proxy.csv_search_delete(
+            self.table, "key5", "value1")
+        self.assertTrue(delete_value_result)
+        get_value_result = self.proxy.get(self.table, "key5")
+        logger.info("After delete value : %s", get_value_result)
+        self.assertEqual(get_value_result, None,
+                         "csv_search_delete failed to delete value")
+
     def test_remove(self):
         remove_result = self.proxy.remove(self.table, self.key)
         logger.info(remove_result)
@@ -221,6 +312,11 @@ def local_main():
     test.test_csv_match_pop_last()
     test.test_csv_pop_empty()
     test.test_csv_match_pop_empty()
+    test.test_csv_search_delete_first()
+    test.test_csv_search_delete_last()
+    test.test_csv_search_delete_notfound()
+    test.test_csv_search_delete_inbetween()
+    test.test_csv_search_delete_only()
     test.test_remove()
     test.test_get_none()
     test.test_remove2()

--- a/enclave_manager/avalon_enclave_manager/singleton/singleton_enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/singleton/singleton_enclave_manager.py
@@ -58,11 +58,9 @@ class SingletonEnclaveManager(WOProcessorManager):
         self._worker_kv_delegate.update_worker_map(
             worker_id, self._identity)
 
-        # Cleanup wo-worker-processing" table
-        wo_to_cleanup = []
-        if "cleanup_work_orders" in self._config["KvStorage"]:
-            wo_to_cleanup = self._config["KvStorage"]["cleanup_work_orders"]
-        self._wo_kv_delegate.cleanup_work_orders(wo_to_cleanup)
+        # Cleanup all stale work orders for this worker which
+        # used old worker keys
+        self._wo_kv_delegate.cleanup_work_orders()
 
 # -------------------------------------------------------------------------
 
@@ -117,9 +115,7 @@ def main(args=None):
     parser.add_argument("--workloads",
                         help="Comma-separated list of workloads supported",
                         type=str)
-    parser.add_argument("--cleanup_work_orders",
-                        help="Comma-separated list of work orders to recover",
-                        type=str)
+
     (options, remainder) = parser.parse_known_args(args)
 
     if options.config:
@@ -139,9 +135,6 @@ def main(args=None):
         config["WorkerConfig"]["workloads"] = options.workloads
     if options.worker_id:
         config["WorkerConfig"]["worker_id"] = options.worker_id
-    if options.cleanup_work_orders:
-        config["KvStorage"]["cleanup_work_orders"] = \
-            options.cleanup_work_orders
 
     plogger.setup_loggers(config.get("Logging", {}))
     sys.stdout = plogger.stream_to_logger(

--- a/enclave_manager/avalon_enclave_manager/work_order_processor_manager.py
+++ b/enclave_manager/avalon_enclave_manager/work_order_processor_manager.py
@@ -221,11 +221,14 @@ class WOProcessorManager(EnclaveManager):
                 WorkOrderStatus.FAILED, "0", msg)
             wo_response = json.dumps(err_response)
 
-        logger.info("Update response in wo-responses for workorder %s", wo_id)
+        logger.info("Update response in wo-responses for workorder %s.", wo_id)
         self._kv_helper.set("wo-responses", wo_id, wo_response)
 
-        logger.info("Persist status for workorder %s in wo-processed", wo_id)
-        self._kv_helper.set("wo-processed", wo_id, status.name)
+        logger.info(
+            "Persist work order id %s in wo-worker-processed map.", wo_id)
+        # Append wo_id to the list of work orders processed by this worker
+        self._kv_helper.csv_append("wo-worker-processed",
+                                   self._worker_id, wo_id)
 
     # -----------------------------------------------------------------
 

--- a/enclave_manager/avalon_enclave_manager/worker_kv_delegate.py
+++ b/enclave_manager/avalon_enclave_manager/worker_kv_delegate.py
@@ -58,6 +58,17 @@ class WorkerKVDelegate:
                 result &= self._kv_helper.remove("workers", worker)
         return result
 
+    def cleanup_pool(self, worker_id):
+        """
+        Remove worker pool mapping from datastore. All workers need to
+        register afresh to be a part of the pool.
+
+        Parameters:
+            @param worker_id - Id of worker representing the pool.
+        """
+        logger.info("Clearing worker pool mapping for %s", worker_id)
+        return self._kv_helper.remove("worker-pool", worker_id)
+
     def add_new_worker(self, worker_id, worker_info):
         """
         Add a new worker to the KV Store
@@ -97,3 +108,18 @@ class WorkerKVDelegate:
         worker_obj.load_worker(json_dict['details'])
 
         return worker_obj
+
+    def update_worker_map(self, worker_id, identity):
+        """
+        Function to register a worker in database. It effectively adds a
+        new entry in the mapping of worker_id to workers in that pool.
+        For a Singleton worker, this mapping is worker_id->worker_id. On
+        the other hand, it is worker_id->enclave_id1,enclave_id2... (A
+        list of enclave_id representing each WPE in the pool represented
+        by worker_id).
+
+        Parameters:
+            @param worker_id - Worker id of the pool/singleton
+            @param identity - worker_id of Singleton or enclave_id of a WPE
+        """
+        self._kv_helper.csv_append("worker-pool", worker_id, identity)

--- a/enclave_manager/avalon_enclave_manager/wpe/wpe_enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/wpe/wpe_enclave_manager.py
@@ -95,6 +95,7 @@ class WorkOrderProcessorEnclaveManager(WOProcessorManager):
         """
         Executes Boot flow of enclave manager
         """
+
         if self._wpe_requester\
             .register_wo_processor(self._unique_verification_key,
                                    self.encryption_key,

--- a/listener/avalon_listener/tcs_work_order_handler_sync.py
+++ b/listener/avalon_listener/tcs_work_order_handler_sync.py
@@ -126,12 +126,17 @@ class TCSWorkOrderHandlerSync(TCSWorkOrderHandler):
             )
         if((self.workorder_count + 1) > self.max_workorder_count):
 
+            # wo_ids is a csv of work order ids retrieved from database
+            wo_ids = self.kv_helper.get("wo-worker-processed", worker_id)
+            processed_wo_ids = [] if wo_ids is None else wo_ids.split(",")
+
             # if max count reached clear a processed entry
             work_orders = self.kv_helper.lookup("wo-timestamps")
             for id in work_orders:
                 # If work order is processed then remove from table
-                if(self.kv_helper.get("wo-processed", id) is not None):
-                    self.kv_helper.remove("wo-processed", id)
+                if id in processed_wo_ids:
+                    self.kv_helper.csv_search_delete(
+                        "wo-worker-processed", worker_id, id)
                     self.kv_helper.remove("wo-requests", id)
                     self.kv_helper.remove("wo-responses", id)
                     self.kv_helper.remove("wo-receipts", id)

--- a/listener/avalon_listener/tcs_work_order_handler_sync.py
+++ b/listener/avalon_listener/tcs_work_order_handler_sync.py
@@ -153,15 +153,15 @@ class TCSWorkOrderHandlerSync(TCSWorkOrderHandler):
             # Don't change the order of table updates.
             # The order is important for clean up if the TCS is restarted in
             # the middle.
-            # Add entry to wo-worker-pending which holds all the work order id
-            # separated by comma(csv) to be processed by corresponding worker.
-            # i.e. - <worker_id> -> <wo_id>,<wo_id>,<wo_id>...
+            # Add entry to wo-worker-scheduled which holds all the work order
+            # id separated by comma(csv) to be processed by corresponding
+            # worker. i.e. - <worker_id> -> <wo_id>,<wo_id>,<wo_id>...
             epoch_time = str(time.time())
 
             # Update the tables
             self.kv_helper.set("wo-timestamps", wo_id, epoch_time)
             self.kv_helper.set("wo-requests", wo_id, input_json_str)
-            self.kv_helper.csv_append("wo-worker-pending", worker_id, wo_id)
+            self.kv_helper.csv_append("wo-worker-scheduled", worker_id, wo_id)
             # Add to the internal FIFO
             self.workorder_list.append(wo_id)
             self.workorder_count += 1

--- a/shared_kv_storage/db_store/db_store_csv.cpp
+++ b/shared_kv_storage/db_store/db_store_csv.cpp
@@ -78,5 +78,14 @@ std::string DbStoreCsv::db_store_csv_match_pop(
 
     return value_b64;
 }
-
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+void DbStoreCsv::db_store_csv_search_delete(
+    const std::string& table_b64,
+    const std::string& key_b64,
+    const std::string& value_b64){
+    ByteArray raw_key(key_b64.begin(), key_b64.end());
+    ByteArray raw_value(value_b64.begin(), value_b64.end());
+    tcf_err_t presult = db_store::db_store_csv_search_delete(table_b64, raw_key, raw_value);
+    db_error::ThrowIf<db_error::RuntimeError>(presult, "db store update(search_delete) failed");
+}
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/shared_kv_storage/db_store/db_store_csv.h
+++ b/shared_kv_storage/db_store/db_store_csv.h
@@ -104,4 +104,25 @@ class DbStoreCsv : public DbStore {
             const std::string& value_b64);
 
         // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        /**
+         * Updates a key->value pair in the database store conditionally.
+         * Reads each of the comma-separated strings and then compares it
+         * with the value passed in. If there is a match, the passed value
+         * is deleted. If this is the lone string, the key-value pair
+         * altogether is removed.
+         *
+         * @param table_b64     base64 encoded table name
+         * @param key_b64       base64 encoded key string
+         * @param value_b64     base64 encoded value string to search and delete
+         *
+         * @return
+         *  Success: void/no return
+         *  Failure: throws exception
+         */
+        void db_store_csv_search_delete(
+            const std::string& table_b64,
+            const std::string& key_b64,
+            const std::string& value_b64);
+
+        // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 };

--- a/shared_kv_storage/db_store/packages/db_store_wrapper.h
+++ b/shared_kv_storage/db_store/packages/db_store_wrapper.h
@@ -255,6 +255,26 @@ namespace db_store {
         ByteArray& outValue,
         const bool isMatch);
 
-    }  /* namespace db_store */
+    // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    /**
+     * Updates a key->value pair in the database store. Reads each of the
+     * comma-separated strings and then compares it with the value passed
+     * in. If there is a match, the passed value is deleted. If this is the
+     * lone string, the key-value pair altogether is removed.
+     * Primary expected use: python / untrusted side
+     *
+     * @param table     table name
+     * @param inId      id byte array
+     * @param inValue   data to be deleted
+     *
+     * @return
+     *  TCF_SUCCESS  id->value updated/deleted
+     *  else         failed, data store unchanged
+     */
+    tcf_err_t db_store_csv_search_delete(
+        const std::string& table,
+        const ByteArray& inId,
+        const ByteArray& inValue);
 
+}  /* namespace db_store */
 

--- a/shared_kv_storage/kv_storage/interface/kv_csv_interface.py
+++ b/shared_kv_storage/kv_storage/interface/kv_csv_interface.py
@@ -92,3 +92,21 @@ class KvCsvStorage(ABC):
                             strings matches. None, otherwise.
         """
         pass
+
+# ---------------------------------------------------------------------------------------------------
+    @abstractmethod
+    def csv_search_delete(self, table, key, value):
+        """
+        Function to conditionally update a key-value pair in a lmdb table
+        that holds comma-separated strings as value. This function reads
+        each of the comma-separated strings and then compares it with the
+        value passed in. If there is a match, the passed value is deleted.
+        If this is the lone string, the key-value pair altogether is removed.
+
+        Parameters:
+           @param table - Name of the lmdb table from which key-value pair
+                          needs to be read and updated.
+           @param key - The primary key of the table.
+           @param value - Value to be compared against and deleted.
+        """
+        pass

--- a/shared_kv_storage/kv_storage/remote_lmdb/lmdb_request_handler.py
+++ b/shared_kv_storage/kv_storage/remote_lmdb/lmdb_request_handler.py
@@ -195,6 +195,22 @@ class LMDBRequestHandler(resource.Resource):
                 logger.error("Invalid args for cmd csv_match_pop")
                 response = "e\nInvalid args for cmd csv_match_pop"
 
+        # Delete from CSV if a match is found
+        elif (cmd == "CD"):
+            if len(args) == 4:
+                result = self.kv_helper.csv_search_delete(
+                    args[1], args[2], args[3])
+                # Value found
+                if result:
+                    response = "t"
+                # Value not found
+                else:
+                    response = "f"
+            # Error
+            else:
+                logger.error("Invalid args for cmd csv_search_delete")
+                response = "e\nInvalid args for cmd csv_search_delete"
+
         # Error
         else:
             logger.error("Unknown cmd")

--- a/shared_kv_storage/kv_storage/remote_lmdb/shared_kv_dbstore.py
+++ b/shared_kv_storage/kv_storage/remote_lmdb/shared_kv_dbstore.py
@@ -85,7 +85,7 @@ class KvDBStore(KvStorage, KvCsvStorage):
         except Exception:
             # @TODO : Instead of suppressing exception here, pass it back
             # and let the caller decide how to react to the exception.
-            logger.warn("Could not set key-value in database.")
+            logger.debug("Could not set key-value in database.")
             return False
 
 # ---------------------------------------------------------------------------------------------------
@@ -105,7 +105,7 @@ class KvDBStore(KvStorage, KvCsvStorage):
         except Exception:
             # @TODO : Instead of suppressing exception here, pass it back
             # and let the caller decide how to react to the exception.
-            logger.warn("Could not retrieve value from database.")
+            logger.debug("Could not retrieve value from database.")
             value = None
 
         if not value:
@@ -137,7 +137,7 @@ class KvDBStore(KvStorage, KvCsvStorage):
         except Exception:
             # @TODO : Instead of suppressing exception here, pass it back
             # and let the caller decide how to react to the exception.
-            logger.warn("Could not delete key-value from database.")
+            logger.debug("Could not delete key-value from database.")
             return False
 
 # ---------------------------------------------------------------------------------------------------
@@ -158,7 +158,7 @@ class KvDBStore(KvStorage, KvCsvStorage):
         except Exception:
             # @TODO : Instead of suppressing exception here, pass it back
             # and let the caller decide how to react to the exception.
-            logger.warn("Could not lookup keys in database.")
+            logger.debug("Could not lookup keys in database.")
             result = []
 
         return result
@@ -183,7 +183,7 @@ class KvDBStore(KvStorage, KvCsvStorage):
         except Exception:
             # @TODO : Instead of suppressing exception here, pass it back
             # and let the caller decide how to react to the exception.
-            logger.warn("Could not append value to csv in database.")
+            logger.debug("Could not append value to csv in database.")
             return False
 
 # ---------------------------------------------------------------------------------------------------
@@ -206,7 +206,7 @@ class KvDBStore(KvStorage, KvCsvStorage):
         except Exception:
             # @TODO : Instead of suppressing exception here, pass it back
             # and let the caller decide how to react to the exception.
-            logger.warn("Could not prepend value to csv in database.")
+            logger.debug("Could not prepend value to csv in database.")
             return False
 
 # ---------------------------------------------------------------------------------------------------
@@ -234,7 +234,7 @@ class KvDBStore(KvStorage, KvCsvStorage):
         except Exception:
             # @TODO : Instead of suppressing exception here, pass it back
             # and let the caller decide how to react to the exception.
-            logger.warn("Could not pop value from csv in database.")
+            logger.debug("Could not pop value from csv in database.")
             value = None
 
         if not value:
@@ -270,11 +270,37 @@ class KvDBStore(KvStorage, KvCsvStorage):
         except Exception:
             # @TODO : Instead of suppressing exception here, pass it back
             # and let the caller decide how to react to the exception.
-            logger.warn("Could not match pop value from csv in database.")
+            logger.debug("Could not match pop value from csv in database.")
             value = None
         if not value:
             value = None
 
         return value
+
+# ---------------------------------------------------------------------------------------------------
+
+    def csv_search_delete(self, table, key, value):
+        """
+        Function to conditionally update a key-value pair in a lmdb table
+        that holds comma-separated strings as value. This function reads
+        each of the comma-separated strings and then compares it with the
+        value passed in. If there is a match, the passed value is deleted.
+        If this is the lone string, the key-value pair altogether is removed.
+
+        Parameters:
+           @param table - Name of the lmdb table from which key-value pair
+                          needs to be read and updated.
+           @param key - The primary key of the table.
+           @param value - Value to be compared against and deleted.
+        """
+        try:
+            value = self._db_store.db_store_csv_search_delete(
+                table, key, value)
+            return True
+        except Exception:
+            # @TODO : Instead of suppressing exception here, pass it back
+            # and let the caller decide how to react to the exception.
+            logger.debug("Could not search/delete value from csv in database.")
+            return False
 
 # ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Replace wo-processing wo-worker-processing to hold list
   of work orders being actively processed
- Update wo-worker-pending to wo-worker-scheduled
- Rename wo-processed to wo-worker-processed
- Add table worker-pool to hold map of wokers in a pool
- Add calls to add entries to worker-pool mapping
- Add method to handle boot time cleanup for KME/Singleton
- Add LMDB API for search and delete


Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>