### PR TITLE
Minor refactor in base enclave manager

### DIFF
--- a/enclave_manager/avalon_enclave_manager/base_enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/base_enclave_manager.py
@@ -45,20 +45,20 @@ class EnclaveManager(ABC):
         self._worker_kv_delegate = WorkerKVDelegate(self._kv_helper)
         self._wo_kv_delegate = WorkOrderKVDelegate(
             self._kv_helper, self._worker_id)
-        signup_data, measurements = self._setup_enclave()
+        signup_data = self._setup_enclave()
         self.enclave_data = signup_data
-        self.sealed_data = signup_data.sealed_data
-        self.verifying_key = signup_data.verifying_key
-        self.encryption_key = signup_data.encryption_key
+        self.sealed_data = signup_data["sealed_data"]
+        self.verifying_key = signup_data["verifying_key"]
+        self.encryption_key = signup_data["encryption_key"]
+        self.encryption_key_signature = signup_data["encryption_key_signature"]
+        self.enclave_id = signup_data["enclave_id"]
+        self.proof_data = signup_data["proof_data"]
+        self.extended_measurements = signup_data["measurements"]
 
         # TODO: encryption_key_nonce is hardcoded to an empty str
         # Need to come up with a scheme to generate it for every unique
         # encryption key.
         self.encryption_key_nonce = ""
-        self.encryption_key_signature = signup_data.encryption_key_signature
-        self.enclave_id = signup_data.enclave_id
-        self.extended_measurements = measurements
-        self.proof_data = signup_data.proof_data
 
 # -------------------------------------------------------------------------
 
@@ -134,16 +134,14 @@ class EnclaveManager(ABC):
         Returns :
             signup_data - Relevant signup data to be used for requests to the
                           enclave
-            extended_measurements - A tuple of enclave basename & measurements
         """
         try:
             logger.info("Initialize enclave and create signup data")
             signup_data = self._create_signup_data()
-            extended_measurements = signup_data.get_extended_measurements()
         except Exception as e:
             logger.exception("failed to initialize/signup enclave; %s", str(e))
             sys.exit(-1)
-        return signup_data, extended_measurements
+        return self._get_JSON_from_signup_object(signup_data)
 
     # -----------------------------------------------------------------
 
@@ -158,6 +156,32 @@ class EnclaveManager(ABC):
                           enclave
         """
         pass
+
+    # -----------------------------------------------------------------
+
+    def _get_JSON_from_signup_object(self, signup_data):
+        """
+        Create enclave specific signup data JSON from signup_data object.
+        This function is meant to be used by derived classes.
+
+        Parameters:
+            @param signup_data - An object carrying relevenat signup data
+        Returns:
+            @returns signup_data_json - Relevant signup data as a JSON to be
+                                        used for requests to the enclave
+        """
+        signup_data_json = {}
+        signup_data_json["enclave_data"] = signup_data
+        signup_data_json["sealed_data"] = signup_data.sealed_data
+        signup_data_json["verifying_key"] = signup_data.verifying_key
+        signup_data_json["encryption_key"] = signup_data.encryption_key
+        signup_data_json["encryption_key_signature"] = \
+            signup_data.encryption_key_signature
+        signup_data_json["enclave_id"] = signup_data.enclave_id
+        signup_data_json["proof_data"] = signup_data.proof_data
+        signup_data_json["measurements"] = signup_data.extended_measurements
+
+        return signup_data_json
 
     # -----------------------------------------------------------------
 

--- a/enclave_manager/avalon_enclave_manager/kme/kme_enclave_info.py
+++ b/enclave_manager/avalon_enclave_manager/kme/kme_enclave_info.py
@@ -57,6 +57,7 @@ class KeyManagementEnclaveInfo(BaseEnclaveInfo):
                 enclave_info['encryption_key_signature']
             self.proof_data = enclave_info['proof_data']
             self.enclave_id = enclave_info['enclave_id']
+            self.extended_measurements = self.get_extended_measurements()
         except KeyError as ke:
             raise Exception("missing enclave initialization parameter; {}"
                             .format(str(ke)))

--- a/enclave_manager/avalon_enclave_manager/singleton/singleton_enclave_info.py
+++ b/enclave_manager/avalon_enclave_manager/singleton/singleton_enclave_info.py
@@ -53,6 +53,7 @@ class SingletonEnclaveInfo(BaseEnclaveInfo):
                 enclave_info['encryption_key_signature']
             self.proof_data = enclave_info['proof_data']
             self.enclave_id = enclave_info['enclave_id']
+            self.extended_measurements = self.get_extended_measurements()
         except KeyError as ke:
             raise Exception("missing enclave initialization parameter; {}"
                             .format(str(ke)))

--- a/enclave_manager/avalon_enclave_manager/wpe/wpe_enclave_info.py
+++ b/enclave_manager/avalon_enclave_manager/wpe/wpe_enclave_info.py
@@ -76,6 +76,7 @@ class WorkOrderProcessorEnclaveInfo(BaseEnclaveInfo):
                 self.proof_data = enclave_data.proof_data
             self.enclave_keys = \
                 keys.EnclaveKeys(self.verifying_key, self.encryption_key)
+            self.extended_measurements = self.get_extended_measurements()
             # No sealed data is present for WPE
             self.sealed_data = None
         except AttributeError as attr:


### PR DESCRIPTION
 - Do not expose SignupInfo object to enclave manager constructor
 - Retrieve data members to create a JSON instead

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>