### PR TITLE
Change behavior of work get result for fabric

### DIFF
--- a/examples/apps/generic_client/fabric_generic_client.py
+++ b/examples/apps/generic_client/fabric_generic_client.py
@@ -593,7 +593,7 @@ def Main(args=None):
         jrpc_req_id+1)
 
     # Check if result field is present in work order response
-    if "result" in res:
+    if res and "result" in res:
         # Verify work order response signature
         if generic_client.verify_wo_res_signature(
                 res['result'],

--- a/sdk/avalon_sdk/connector/blockchains/fabric/fabric_wrapper.py
+++ b/sdk/avalon_sdk/connector/blockchains/fabric/fabric_wrapper.py
@@ -50,7 +50,7 @@ class FabricWrapper():
             self.__channel_name = config["fabric"]["channel_name"]
             self.__orgname = base.get_net_info(self.__network_config,
                                                'client', 'organization')
-            logging.info("Org name choose: {}".format(self.__orgname))
+            logging.debug("Org name choose: {}".format(self.__orgname))
             self.__peername = random.choice(base.get_net_info(
                 self.__network_config, 'organizations', self.__orgname,
                 'peers'))
@@ -111,19 +111,19 @@ class FabricWrapper():
         """
         cc_methods = self.__valid_calls[chaincode_name]
         if cc_methods is None:
-            logging.info("Invalid chain code name")
+            logging.error("Invalid chain code name")
             return False
         the_call = cc_methods[method_name]
         if the_call is None:
-            logging.info("Please specify a valid method name. \
+            logging.error("Please specify a valid method name. \
                 Valid ones for chaincode " +
-                         chaincode_name + " are " +
-                         ",".join(cc_methods.keys()))
+                          chaincode_name + " are " +
+                          ",".join(cc_methods.keys()))
             return False
         resp = self.__txn_committer.cc_invoke(params, chaincode_name,
                                               method_name, '',
                                               queryonly=the_call['isQuery'])
-        logging.info("Response of chain code {} call: {}".format(
+        logging.debug("Response of chain code {} call: {}".format(
             method_name, resp
         ))
 
@@ -135,7 +135,7 @@ class FabricWrapper():
                 result = []
                 for v in resp.values():
                     result.append(v)
-                logging.info(
+                logging.debug(
                     "\nThe tuple created: %s\n ", result)
                 return result
             else:

--- a/sdk/avalon_sdk/connector/blockchains/fabric/tx_committer.py
+++ b/sdk/avalon_sdk/connector/blockchains/fabric/tx_committer.py
@@ -104,7 +104,7 @@ class TxCommitter(base.ClientBase):
         responses = loop.run_until_complete(base.get_stream_result(
             send_transaction(self.client.orderers, tran_req, tx_context_tx)))
 
-        logger.info('Tx response: {}'.format(responses))
+        logger.debug('Tx response: {}'.format(responses))
         return responses
 
     def cc_query(self, args, cc_name, fcn):
@@ -122,8 +122,10 @@ class TxCommitter(base.ClientBase):
             responses = loop.run_until_complete(self.client.chaincode_query(
                 requestor=self.user, channel_name=self.channel_name,
                 peers=[self.peer_name], args=args, cc_name=cc_name, fcn=fcn))
-            logger.info('Tx response: {0}'.format(responses))
+            logger.debug('Tx response: {0}'.format(responses))
             return json.loads(responses)
         except Exception as ex:
-            logger.error('Query error: {0}'.format(ex))
+            # In case of invalid input catch exception
+            # return empty dict.
+            logger.debug('Query response: {0}'.format(ex))
             return {}


### PR DESCRIPTION
First make a call to chaincode query function to get
the work order result. If result not found in blockchain
then wait for workOrderCompleted event

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>