### PR TITLE
Cleanup to ethereum work order connector APIs

### DIFF
--- a/examples/apps/generic_client/eth_generic_client.py
+++ b/examples/apps/generic_client/eth_generic_client.py
@@ -572,6 +572,11 @@ def Main(args=None):
                 res
             ))
             sys.exit(1)
+    else:
+        logger.error("\n Work order get result failed {}\n".format(
+            res
+        ))
+        sys.exit(1)
 
     if show_receipt and wo_receipt:
         # Retrieve receipt

--- a/sdk/avalon_sdk/connector/blockchains/ethereum/ethereum_work_order.py
+++ b/sdk/avalon_sdk/connector/blockchains/ethereum/ethereum_work_order.py
@@ -31,9 +31,6 @@ from avalon_sdk.connector.interfaces.work_order_proxy \
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO)
 
-# Return codes
-SUCCESS = 0
-ERROR = 1
 
 # Event Listener sleep duration
 LISTENER_SLEEP_DURATION = 5
@@ -48,6 +45,7 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
     """
 
     def __init__(self, config):
+        self.WORK_ORDER_GET_RESULT_TIMEOUT = 30
         if self.__validate(config) is True:
             self.__initialize(config)
         else:
@@ -74,7 +72,7 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
                 logging.error("Missing Ethereum provider url!!")
                 return False
         except KeyError as ex:
-            logging.error("Required configs not present".format(ex))
+            logging.error("Required configs not present: {}".format(ex))
             return False
         return True
 
@@ -120,14 +118,14 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
                                              requester_id, work_order_request):
                 logging.error("Invalid request string {}"
                               .format(work_order_request))
-                return ERROR
+                return ContractResponse.ERROR
 
-            txn_dict = self.__contract_instance.functions.workOrderSubmit(
-                work_order_id, worker_id, requester_id, work_order_request
-            ).buildTransaction(
-                self.__eth_client.get_transaction_params()
-            )
             try:
+                txn_dict = self.__contract_instance.functions.workOrderSubmit(
+                    work_order_id, worker_id, requester_id, work_order_request
+                ).buildTransaction(
+                    self.__eth_client.get_transaction_params()
+                )
                 txn_receipt = self.__eth_client.execute_transaction(txn_dict)
                 if txn_receipt['status'] == 1:
                     return ContractResponse.SUCCESS
@@ -136,8 +134,8 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
             except Exception as e:
                 logging.error(
                     "Exception occurred when trying to execute "
-                    + "workOrderSubmit transaction on chain "+str(e))
-                return ERROR
+                    + "workOrderSubmit transaction on chain {}".format(e))
+                return ContractResponse.ERROR
         else:
             logging.error(
                 "Work order contract instance is not initialized")
@@ -157,12 +155,12 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
         errorCode           0 on success or non-zero on error.
         """
         if (self.__contract_instance is not None):
-
-            txn_dict = self.__contract_instance.functions.workOrderComplete(
-                work_order_id, work_order_response).buildTransaction(
-                    self.__eth_client.get_transaction_params()
-            )
             try:
+                txn_dict = \
+                    self.__contract_instance.functions.workOrderComplete(
+                        work_order_id, work_order_response).buildTransaction(
+                        self.__eth_client.get_transaction_params()
+                    )
                 txn_receipt = self.__eth_client.execute_transaction(txn_dict)
                 if txn_receipt['status'] == 1:
                     return ContractResponse.SUCCESS
@@ -171,12 +169,12 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
             except Exception as e:
                 logging.error(
                     "Exception occurred when trying to execute "
-                    + "workOrderComplete transaction on chain "+str(e))
+                    + "workOrderComplete transaction on chain {}".format(e))
                 return ContractResponse.ERROR
         else:
             logging.error(
                 "Work order contract instance is not initialized")
-            return ERROR
+            return ContractResponse.ERROR
 
     def work_order_get_result(self, work_order_id, id=None):
         """
@@ -194,7 +192,30 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
         work order response, and error code.
         None on error.
         """
-        logging.info("About to start Ethereum event handler")
+        # Call the contract to get the result from blockchain
+        # If we get the result from chain then return
+        # Otherwise start the event listener to get work order
+        # completed event.
+        if (self.__contract_instance is not None):
+            try:
+                # workOrderGet returns tuple containing work order
+                # result params as defined in EEA spec 6.10.5
+                _, _, _, work_order_res, _ = \
+                    self.__contract_instance.functions.workOrderGet(
+                        work_order_id).call()
+                if len(work_order_res) > 0:
+                    return json.loads(work_order_res)
+                else:
+                    logging.warn("Work order seems to be not computed yet, "
+                                 "going to listen for workOrderCompleted "
+                                 "event")
+            except Exception as e:
+                logging.error("Failed to call contract {}".format(e))
+                return None
+        else:
+            logging.error(
+                "Work order contract instance is not initialized")
+            return None
 
         # Start an event listener that listens for events from the proxy
         # blockchain, extracts response payload from there and passes it
@@ -206,21 +227,31 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
         # Listening only for workOrderCompleted event now
         listener = w3.newListener(contract, "workOrderCompleted")
 
+        daemon = EventProcessor(self._config)
+        # Wait for the workOrderCompleted event after starting the
+        # listener and handler
         try:
-            daemon = EventProcessor(self._config)
-            # Wait for the workOrderCompleted event after starting the
-            # listener and handler
-            event = asyncio.get_event_loop()\
-                .run_until_complete(daemon.get_event_synchronously(
-                    listener, is_wo_id_in_event, wo_id=work_order_id))
-
+            event = asyncio.get_event_loop().run_until_complete(
+                asyncio.wait_for(daemon.get_event_synchronously(
+                    listener, is_wo_id_in_event, wo_id=work_order_id),
+                    timeout=self.WORK_ORDER_GET_RESULT_TIMEOUT,
+                )
+            )
             # Get the first element as this is a list of one event
             # obtained from gather() in ethereum_listener
             work_order_response = event[0]["args"]["workOrderResponse"]
 
             return json.loads(work_order_response)
-        except KeyboardInterrupt:
+        except asyncio.TimeoutError:
+            logging.error("Work order get result timed out."
+                          " Either work order id is invalid or"
+                          " Work order execution not completed yet")
+        except Exception as e:
+            logging.error("Exception occurred while listening"
+                          " to an event: {}".format(e))
+        finally:
             asyncio.get_event_loop().run_until_complete(daemon.stop())
+        return None
 
     def encryption_key_retrieve(self, worker_id, last_used_key_nonce, tag,
                                 requester_id, signature_nonce=None,


### PR DESCRIPTION
1. Call contract api workOrderGet in ethereum connnector
2. Add timeout in event listener for workOrderCompleted event in connector
3. Handle error cases all apis in ethereum work order APIs

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>