### PR TITLE
Remove command line workload configuration

### DIFF
--- a/config/singleton_enclave_config.toml
+++ b/config/singleton_enclave_config.toml
@@ -76,11 +76,7 @@ enclave_library_path = "tc/sgx/trusted_worker_manager/enclave/build/lib/"
 # Id of worker in plain text. This can be overridden by passing values in command line for
 # enclave manager using --worker_id option.
 worker_id = "singleton-worker-1"
-# Supported workloads for this worker. The work orders matching these workload ids
-# will be processed by the enclave manager. The enclaves should be built with matching
-# workloads. This can be overridden by passing values in command line for enclave manager
-# using --workloads option.
-workloads = "echo-result,heart-disease-eval,inside-out-eval,simple-wallet"
+
 ProofDataType = "TEE-SGX-IAS"
 
 # The Following URIs are used in direct model to submit work orders in

--- a/config/wpe_config.toml
+++ b/config/wpe_config.toml
@@ -84,8 +84,3 @@ connection_retry = 3
 # Id of worker in plain text. This can be overridden by passing values in command line for
 # enclave manager using --worker_id option.
 worker_id = "kme-worker-1"
-# Supported workloads for this worker. The work orders matching these workload ids
-# will be processed by the enclave manager. The enclaves should be built with matching
-# workloads. This can be overridden by passing values in command line for enclave manager
-# using --workloads option.
-workloads = "echo-result,heart-disease-eval,inside-out-eval,simple-wallet"

--- a/enclave_manager/avalon_enclave_manager/singleton/singleton_enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/singleton/singleton_enclave_manager.py
@@ -116,9 +116,6 @@ def main(args=None):
     parser.add_argument("--config-dir", help="configuration folder", nargs="+")
     parser.add_argument("--worker_id",
                         help="Id of worker in plain text", type=str)
-    parser.add_argument("--workloads",
-                        help="Comma-separated list of workloads supported",
-                        type=str)
 
     (options, remainder) = parser.parse_known_args(args)
 
@@ -135,8 +132,6 @@ def main(args=None):
         logger.error(str(e))
         sys.exit(-1)
 
-    if options.workloads:
-        config["WorkerConfig"]["workloads"] = options.workloads
     if options.worker_id:
         config["WorkerConfig"]["worker_id"] = options.worker_id
 

--- a/enclave_manager/avalon_enclave_manager/work_order_processor_manager.py
+++ b/enclave_manager/avalon_enclave_manager/work_order_processor_manager.py
@@ -35,12 +35,6 @@ class WOProcessorManager(EnclaveManager):
 
     def __init__(self, config):
         super().__init__(config)
-
-        workloads_str = config.get("WorkerConfig")["workloads"]
-        workloads = workloads_str.split(',')
-        self._workloads = []
-        for workload in workloads:
-            self._workloads.append(workload.encode("UTF-8").hex())
         self._identity = None
 
 # -------------------------------------------------------------------------
@@ -243,22 +237,6 @@ class WOProcessorManager(EnclaveManager):
         """
         try:
             json_obj = json.loads(wo_request)
-
-            # Check if wo can be processed by this worker
-            if "params" in json_obj and "workloadId" in json_obj["params"]:
-                workload_id_in_req = json_obj["params"]["workloadId"]
-                if workload_id_in_req not in self._workloads:
-                    logger.error("Workload cannot be processed by this worker")
-                    self._persist_wo_response_to_db(
-                        wo_id, WorkOrderStatus.FAILED, None,
-                        "Workload cannot be processed by this worker")
-                    return False
-            else:
-                logger.error("Work order request not well-formed")
-                self._persist_wo_response_to_db(
-                    wo_id, WorkOrderStatus.FAILED, None,
-                    "Workorder request is not well-formed")
-                return False
         except ValueError as e:
             logger.error("Invalid JSON format found for workorder - %s", e)
             logger.error(

--- a/enclave_manager/avalon_enclave_manager/wpe/wpe_enclave_manager.py
+++ b/enclave_manager/avalon_enclave_manager/wpe/wpe_enclave_manager.py
@@ -164,9 +164,7 @@ def main(args=None):
                         type=str)
     parser.add_argument(
         "--worker_id", help="Id of worker in plain text", type=str)
-    parser.add_argument("--workloads",
-                        help="Comma-separated list of workloads supported",
-                        type=str)
+
     (options, remainder) = parser.parse_known_args(args)
 
     if options.config:
@@ -184,8 +182,6 @@ def main(args=None):
 
     if options.kme_listener_url:
         config["KMEListener"]["kme_listener_url"] = options.kme_listener_url
-    if options.workloads:
-        config["WorkerConfig"]["workloads"] = options.workloads
     if options.worker_id:
         config["WorkerConfig"]["worker_id"] = options.worker_id
 

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor.cpp
@@ -290,7 +290,8 @@ namespace tcf {
             WorkloadProcessor *processor = \
                 WorkloadProcessor::CreateWorkloadProcessor(workload_type);
             tcf::error::ThrowIf<tcf::error::WorkloadError>(
-                processor == nullptr, "Invalid workload id");
+                processor == nullptr,
+                "This Worker does not support the workload in the request");
             processor->ProcessWorkOrder(
                     workload_type,
                     StrToByteArray(requester_id),


### PR DESCRIPTION
- Since build time configuration is added to configure workloads,
  command line opion is no longer needed.

Signed-off-by: manju956 <manjunath.a.c@intel.com>