### PR TITLE
Refactor transaction build/execute in Ethereum

### DIFF
--- a/docs/dev-environments/ethereum/besu/besu/node1/genesis.json
+++ b/docs/dev-environments/ethereum/besu/besu/node1/genesis.json
@@ -16,7 +16,7 @@
     "byzantiumBlock": 0,
     "constantinoplefixblock": 0,
     "clique": {
-      "blockperiodseconds": 5,
+      "blockperiodseconds": 2,
       "epochlength": 30000
     },
     "chainId": 12345

--- a/docs/dev-environments/ethereum/besu/besu/node2/genesis.json
+++ b/docs/dev-environments/ethereum/besu/besu/node2/genesis.json
@@ -16,7 +16,7 @@
     "byzantiumBlock": 0,
     "constantinoplefixblock": 0,
     "clique": {
-      "blockperiodseconds": 5,
+      "blockperiodseconds": 2,
       "epochlength": 30000
     },
     "chainId": 12345

--- a/sdk/avalon_sdk/connector/blockchains/ethereum/ethereum_work_order.py
+++ b/sdk/avalon_sdk/connector/blockchains/ethereum/ethereum_work_order.py
@@ -121,12 +121,11 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
                 return ContractResponse.ERROR
 
             try:
-                txn_dict = self.__contract_instance.functions.workOrderSubmit(
-                    work_order_id, worker_id, requester_id, work_order_request
-                ).buildTransaction(
-                    self.__eth_client.get_transaction_params()
-                )
-                txn_receipt = self.__eth_client.execute_transaction(txn_dict)
+                contract_func = \
+                    self.__contract_instance.functions.workOrderSubmit(
+                        work_order_id, worker_id,
+                        requester_id, work_order_request)
+                txn_receipt = self.__eth_client.build_exec_txn(contract_func)
                 if txn_receipt['status'] == 1:
                     return ContractResponse.SUCCESS
                 else:
@@ -156,12 +155,10 @@ class EthereumWorkOrderProxyImpl(WorkOrderProxy):
         """
         if (self.__contract_instance is not None):
             try:
-                txn_dict = \
+                contract_func = \
                     self.__contract_instance.functions.workOrderComplete(
-                        work_order_id, work_order_response).buildTransaction(
-                        self.__eth_client.get_transaction_params()
-                    )
-                txn_receipt = self.__eth_client.execute_transaction(txn_dict)
+                        work_order_id, work_order_response)
+                txn_receipt = self.__eth_client.build_exec_txn(contract_func)
                 if txn_receipt['status'] == 1:
                     return ContractResponse.SUCCESS
                 else:

--- a/sdk/avalon_sdk/connector/blockchains/ethereum/ethereum_worker_registry.py
+++ b/sdk/avalon_sdk/connector/blockchains/ethereum/ethereum_worker_registry.py
@@ -241,13 +241,11 @@ class EthereumWorkerRegistryImpl(WorkerRegistry):
                         "Worker details not valid : {}".format(is_valid))
                     return None
             """
-            txn_dict = self.__contract_instance.functions.workerRegister(
-                worker_id, worker_type.value, organization_id,
-                application_type_ids, details)\
-                .buildTransaction(
-                self.__eth_client.get_transaction_params())
-            txn_receipt = self.__eth_client.execute_transaction(
-                txn_dict)
+            contract_func = \
+                self.__contract_instance.functions.workerRegister(
+                    worker_id, worker_type.value, organization_id,
+                    application_type_ids, details)
+            txn_receipt = self.__eth_client.build_exec_txn(contract_func)
             if txn_receipt['status'] == 1:
                 return ContractResponse.SUCCESS
             else:
@@ -286,10 +284,10 @@ class EthereumWorkerRegistryImpl(WorkerRegistry):
                         "Worker details not valid : {}".format(is_valid))
                     return None
             """
-            txn_dict = self.__contract_instance.functions.workerUpdate(
-                worker_id, details)\
-                .buildTransaction(self.__eth_client.get_transaction_params())
-            txn_receipt = self.__eth_client.execute_transaction(txn_dict)
+            contract_func = \
+                self.__contract_instance.functions.workerUpdate(
+                    worker_id, details)
+            txn_receipt = self.__eth_client.build_exec_txn(contract_func)
             if txn_receipt['status'] == 1:
                 return ContractResponse.SUCCESS
             else:
@@ -325,10 +323,10 @@ class EthereumWorkerRegistryImpl(WorkerRegistry):
                 logging.error("Invalid workerStatus {}".format(status))
                 return None
 
-            txn_dict = self.__contract_instance.functions.workerSetStatus(
-                worker_id, status.value)\
-                .buildTransaction(self.__eth_client.get_transaction_params())
-            txn_receipt = self.__eth_client.execute_transaction(txn_dict)
+            contract_func = \
+                self.__contract_instance.functions.workerSetStatus(
+                    worker_id, status.value)
+            txn_receipt = self.__eth_client.build_exec_txn(contract_func)
             if txn_receipt['status'] == 1:
                 return ContractResponse.SUCCESS
             else:

--- a/sdk/avalon_sdk/connector/blockchains/ethereum/ethereum_worker_registry_list.py
+++ b/sdk/avalon_sdk/connector/blockchains/ethereum/ethereum_worker_registry_list.py
@@ -188,7 +188,7 @@ class EthereumWorkerRegistryListImpl(WorkerRegistryList):
             config["ethereum"]["direct_registry_contract_file"]
         contract_address = \
             config["ethereum"]["direct_registry_contract_address"]
-        self.__contract_instance = self.__eth_client.get_contract_instance(
+        self.__contract_instance, _ = self.__eth_client.get_contract_instance(
             contract_file_name, contract_address
         )
 
@@ -230,13 +230,10 @@ class EthereumWorkerRegistryListImpl(WorkerRegistryList):
                         is False):
                     logging.info("Invalid application id {}".format(aid))
                     return None
-
-            txn_dict = self.__contract_instance.functions.registryAdd(
-                org_id, uri, org_id, app_type_ids).buildTransaction(
-                    self.__eth_client.get_transaction_params()
-            )
-            txn_receipt = self.__eth_client.execute_transaction(
-                txn_dict)
+            contract_func = \
+                self.__contract_instance.functions.registryAdd(
+                    org_id, uri, org_id, app_type_ids)
+            txn_receipt = self.__eth_client.build_exec_txn(contract_func)
             return txn_receipt
         else:
             logging.error(
@@ -282,15 +279,10 @@ class EthereumWorkerRegistryListImpl(WorkerRegistryList):
                         is False):
                     logging.error("Invalid application id {}".format(aid))
                     return None
-
-            txn_dict = \
+            contract_func = \
                 self.__contract_instance.functions.registryUpdate(
-                    org_id, uri, sc_addr,
-                    app_type_ids).buildTransaction(
-                        self.__eth_client.get_transaction_params()
-                        )
-            txn_receipt = self.__eth_client.execute_transaction(
-                txn_dict)
+                    org_id, uri, sc_addr, app_type_ids)
+            txn_receipt = self.__eth_client.build_exec_txn(contract_func)
             return txn_receipt
         else:
             logging.error(
@@ -321,14 +313,10 @@ class EthereumWorkerRegistryListImpl(WorkerRegistryList):
             if not isinstance(status, RegistryStatus):
                 logging.info("Invalid registry status {}".format(status))
                 return None
-            txn_dict = \
+            contract_func = \
                 self.__contract_instance.functions.registrySetStatus(
-                    org_id,
-                    status.value).buildTransaction(
-                        self.__eth_client.get_transaction_params()
-                        )
-            txn_receipt = self.__eth_client.execute_transaction(
-                txn_dict)
+                    org_id, status.value)
+            txn_receipt = self.__eth_client.build_exec_txn(contract_func)
             return txn_receipt
         else:
             logging.error(


### PR DESCRIPTION
 - Create a common method to build and execute transaction
 - Retry if an error is encountered in trnsaction commit as
   these error are many a times indiative of a transaction
   not being mined within the timeout period. Then one of
   the most recurrent reason for not being mined is a clash
   in the nonce for transactions. This clash is being taken
   care now by introducing a random sleep.
 - Transaction timeout decreased from default 120s to 10s.
   This being a private network with minimum gas required
   being 0, there should not be such huge delay in mining.
 - Poll latency for ethereum transactions updated to 0.2s
   to cut down excessive traffic when load is higher.
 - Decreasing blockperiod for default Besu network
