### PR TITLE
Copy mrenclave.txt rather than move in kme service

### DIFF
--- a/docker-compose-pool.yaml
+++ b/docker-compose-pool.yaml
@@ -48,7 +48,7 @@ services:
         while true;
           do
             if [ -e /shared-pool-1/wpe_mr_enclave.txt ];
-              then mv /shared-pool-1/wpe_mr_enclave.txt /project/avalon/wpe_mr_enclave.txt;
+              then cp /shared-pool-1/wpe_mr_enclave.txt /project/avalon/wpe_mr_enclave.txt;
               break;
             fi;
             sleep 1;


### PR DESCRIPTION
 - Copy mrenclave file instead of moving as future start
   stop might be impeded if an older container is being
   recovered.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>