### PR TITLE
Cleanup from all workers if processing limit hit

### DIFF
--- a/listener/listener_config.toml
+++ b/listener/listener_config.toml
@@ -25,7 +25,11 @@ LogFile  = "__screen__"
 
 [Listener]
 bind = "http://localhost:1947"
-max_work_order_count = 10
+# Maximum number of work order requests the kv store is expected to hold
+# context for in a deployment. If the number of entries exceed this limit,
+# there will be purging of work order requests throughout the storage on
+# FCFS basis i.e.-The oldest request will be cleaned first.
+max_work_order_count = 1000
 # ZMQ configurations the listener would connect to
 # Same as the url and port of enclave manager socket
 zmq_url = "tcp://avalon-enclave-manager:5555"


### PR DESCRIPTION
 - Cleanup work orders from all workers in the system if
   the max_work_order limit is hit
 - Boost max_work_order limit to 1000 in listener config.
   10 is way too low.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>