### PR TITLE
Optimize Python worker Graphene Manifest.

### DIFF
--- a/examples/graphene_apps/python_worker/graphene/build_gsc_python_worker.sh
+++ b/examples/graphene_apps/python_worker/graphene/build_gsc_python_worker.sh
@@ -38,7 +38,7 @@ if [ "$GSC_IMAGE_EXISTS" = "yes" ]; then
 fi
 
 # Manifest files
-MANIFEST_FILE_DIR="${TCF_HOME}/examples/graphene_apps/python_worker/graphene"
+MANIFEST_FILE_DIR="${TCF_HOME}/examples/graphene_apps/python_worker/graphene/manifest"
 MANIFEST_FILES="python.manifest
 sh.manifest
 gcc.manifest

--- a/examples/graphene_apps/python_worker/graphene/collect2.manifest
+++ b/examples/graphene_apps/python_worker/graphene/collect2.manifest
@@ -1,2 +1,0 @@
-sgx.enclave_size = 1G
-sgx.file_check_policy = allow_all_but_log

--- a/examples/graphene_apps/python_worker/graphene/gcc.manifest
+++ b/examples/graphene_apps/python_worker/graphene/gcc.manifest
@@ -1,2 +1,0 @@
-sgx.enclave_size = 1G
-sgx.file_check_policy = allow_all_but_log

--- a/examples/graphene_apps/python_worker/graphene/ld.manifest
+++ b/examples/graphene_apps/python_worker/graphene/ld.manifest
@@ -1,2 +1,0 @@
-sgx.enclave_size = 1G
-sgx.file_check_policy = allow_all_but_log

--- a/examples/graphene_apps/python_worker/graphene/manifest/collect2.manifest
+++ b/examples/graphene_apps/python_worker/graphene/manifest/collect2.manifest
@@ -1,0 +1,3 @@
+sgx.enclave_size = 512M
+# Uses tmp directory
+sgx.allowed_files.tmp = file:/tmp

--- a/examples/graphene_apps/python_worker/graphene/manifest/gcc.manifest
+++ b/examples/graphene_apps/python_worker/graphene/manifest/gcc.manifest
@@ -1,0 +1,3 @@
+sgx.enclave_size = 512M
+# Uses tmp directory
+sgx.allowed_files.tmp = file:/tmp

--- a/examples/graphene_apps/python_worker/graphene/manifest/ld.manifest
+++ b/examples/graphene_apps/python_worker/graphene/manifest/ld.manifest
@@ -1,0 +1,3 @@
+sgx.enclave_size = 512M
+# Uses tmp directory
+sgx.allowed_files.tmp = file:/tmp

--- a/examples/graphene_apps/python_worker/graphene/manifest/python.manifest
+++ b/examples/graphene_apps/python_worker/graphene/manifest/python.manifest
@@ -1,5 +1,9 @@
 sgx.allow_file_creation = 1
-sgx.enclave_size = 1G
+# Set the virtual memory size of the SGX enclave. For SGX v1, the enclave
+# size must be specified upfront. If Python worker needs more
+# virtual memory than the enclave size, Graphene will not be able to
+# allocate it.
+sgx.enclave_size = 512M
 sgx.thread_num = 8
 sgx.file_check_policy = allow_all_but_log
 

--- a/examples/graphene_apps/python_worker/graphene/manifest/sh.manifest
+++ b/examples/graphene_apps/python_worker/graphene/manifest/sh.manifest
@@ -1,0 +1,1 @@
+sgx.enclave_size = 512M

--- a/examples/graphene_apps/python_worker/graphene/sh.manifest
+++ b/examples/graphene_apps/python_worker/graphene/sh.manifest
@@ -1,2 +1,0 @@
-sgx.enclave_size = 1G
-sgx.file_check_policy = allow_all_but_log


### PR DESCRIPTION
- Move manifest files to manifest directory and update build script.
- Reduce enclave size to improve startup time of python worker
  in Graphene-SGX.
- Allow only tmp directory in gcc,ld and collect2 manifest files.
  These are child manifest files used by pycryptodomex and
  these programs uses tmp directory.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>