### PR TITLE
Fix for the bug TCFH-1065

### DIFF
--- a/sdk/avalon_sdk/connector/blockchains/fabric/fabric_wrapper.py
+++ b/sdk/avalon_sdk/connector/blockchains/fabric/fabric_wrapper.py
@@ -37,6 +37,18 @@ class FabricWrapper():
     It provides wrapper functions to invoke and query chain code.
     """
 
+    # Class variable
+    network_config = None
+
+    @classmethod
+    def init_network_config(cls, net_config_file):
+        # Read network file path from fabric toml file.
+        # Initalize the class variable network_config
+        if FabricWrapper.network_config is None:
+            logging.info("INITIALIZING network_config")
+            with open(net_config_file, 'r') as profile:
+                FabricWrapper.network_config = json.load(profile)
+
     def __init__(self, config):
         """
         Constructor to initialize wrapper with required parameter.
@@ -46,15 +58,13 @@ class FabricWrapper():
                   These parameters are read from a .toml file
         """
         if self.__validate(config):
-            # Read network file path from fabric toml file.
-            with open(self.__network_conf_file, 'r') as profile:
-                self.__network_config = json.load(profile)
+            FabricWrapper.init_network_config(self.__network_conf_file)
             self.__channel_name = config["fabric"]["channel_name"]
-            self.__orgname = base.get_net_info(self.__network_config,
+            self.__orgname = base.get_net_info(FabricWrapper.network_config,
                                                'client', 'organization')
             logging.debug("Org name choose: {}".format(self.__orgname))
             self.__peername = random.choice(base.get_net_info(
-                self.__network_config, 'organizations', self.__orgname,
+                FabricWrapper.network_config, 'organizations', self.__orgname,
                 'peers'))
             # Get a txn committer
             self.__txn_committer = tx_committer.TxCommitter(


### PR DESCRIPTION
1. Fix error AttributeError: 'NoneType' object has no attribute 'encode' in fabric python sdk.
It is because of wrong value None is passed to contract. Checks are added in fabric sdk.
2. EOFError: Ran out of input due to multiple sdk instances are opening the file blockchain network config file.
Created a class instance variable to initialize network config.

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>