### PR TITLE
Option to cleanup sealed data at startup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,7 @@ services:
       - http_proxy
       - https_proxy
       - no_proxy
+      - CLEAN_SEALED_DATA
     expose:
       # ZMQ socket port.
       - 5555
@@ -66,6 +67,7 @@ services:
       - ./.sealed:/project/avalon/.sealed
     command: |
       bash -c "
+        if [ -v CLEAN_SEALED_DATA ] && [ $CLEAN_SEALED_DATA = 1 ]; then rm -f /project/avalon/.sealed/.sealed.data*; fi;
         enclave_manager --lmdb_url http://avalon-lmdb:9090
         tail -f /dev/null
       "

--- a/docker/compose/avalon-pool-combo.yaml
+++ b/docker/compose/avalon-pool-combo.yaml
@@ -40,6 +40,7 @@ services:
       - http_proxy
       - https_proxy
       - no_proxy
+      - CLEAN_SEALED_DATA
     volumes:
       - pool-1:/shared-pool-1
       # Persistent volume to store sealed data across restarts
@@ -49,6 +50,7 @@ services:
       - 1948
     command: |
       bash -c "
+        if [ -v CLEAN_SEALED_DATA ] && [ $CLEAN_SEALED_DATA = 1 ]; then rm -f /project/avalon/.sealed/.sealed.data*; fi;
         while true;
           do
             if [ -e /shared-pool-1/wpe_mr_enclave.txt ];
@@ -109,6 +111,7 @@ services:
       - http_proxy
       - https_proxy
       - no_proxy
+      - CLEAN_SEALED_DATA
     volumes:
       - pool-2:/shared-pool-2
       # Persistent volume to store sealed data across restarts
@@ -118,6 +121,7 @@ services:
       - 1948
     command: |
       bash -c "
+        if [ -v CLEAN_SEALED_DATA ] && [ $CLEAN_SEALED_DATA = 1 ]; then rm -f /project/avalon/.sealed/.sealed.data*; fi;
         while true;
           do
             if [ -e /shared-pool-2/wpe_mr_enclave.txt ];

--- a/docker/compose/avalon-pool.yaml
+++ b/docker/compose/avalon-pool.yaml
@@ -38,6 +38,7 @@ services:
       - http_proxy
       - https_proxy
       - no_proxy
+      - CLEAN_SEALED_DATA
     volumes:
       - pool-1:/shared-pool-1
       # Persistent volume to store sealed data across restarts
@@ -47,6 +48,7 @@ services:
       - 1948
     command: |
       bash -c "
+        if [ -v CLEAN_SEALED_DATA ] && [ $CLEAN_SEALED_DATA = 1 ]; then rm -f /project/avalon/.sealed/.sealed.data*; fi;
         while true;
           do
             if [ -e /shared-pool-1/wpe_mr_enclave.txt ];


### PR DESCRIPTION
Read environment variable to check if sealed sata should be cleaned
up at start of KME/enclave-manager in case of SIngleton. If not cleaned
up, it might lead to errors if the enclave itself has changed. Primarily
targetted for development phase.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>