### PR TITLE
Reduce enclave size in graphene python worker manifest files

### DIFF
--- a/tc/graphene/python_worker/graphene_sgx/manifest/collect2.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/collect2.manifest
@@ -1,3 +1,3 @@
-sgx.enclave_size = 512M
+sgx.enclave_size = 256M
 # Uses tmp directory
 sgx.allowed_files.tmp = file:/tmp

--- a/tc/graphene/python_worker/graphene_sgx/manifest/gcc.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/gcc.manifest
@@ -1,3 +1,3 @@
-sgx.enclave_size = 512M
+sgx.enclave_size = 256M
 # Uses tmp directory
 sgx.allowed_files.tmp = file:/tmp

--- a/tc/graphene/python_worker/graphene_sgx/manifest/ld.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/ld.manifest
@@ -1,3 +1,3 @@
-sgx.enclave_size = 512M
+sgx.enclave_size = 256M
 # Uses tmp directory
 sgx.allowed_files.tmp = file:/tmp

--- a/tc/graphene/python_worker/graphene_sgx/manifest/python.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/python.manifest
@@ -3,7 +3,7 @@ sgx.allow_file_creation = 1
 # size must be specified upfront. If Python worker needs more
 # virtual memory than the enclave size, Graphene will not be able to
 # allocate it.
-sgx.enclave_size = 512M
+sgx.enclave_size = 256M
 sgx.thread_num = 8
 sgx.file_check_policy = allow_all_but_log
 

--- a/tc/graphene/python_worker/graphene_sgx/manifest/sh.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/sh.manifest
@@ -1,1 +1,1 @@
-sgx.enclave_size = 512M
+sgx.enclave_size = 256M


### PR DESCRIPTION
- sgx enclave size in graphene python worker is reduced from 512M to 256M as higher enclave size results in 
  Out-Of-Memory issue leading to crash python worker container and crashing docker daemon.

Signed-off-by: manju956 <manjunath.a.c@intel.com>