### PR TITLE
Fixed replacement of <workload_id> and <workload_lib_name> in README.md

### DIFF
--- a/docs/workload-tutorial/README.md
+++ b/docs/workload-tutorial/README.md
@@ -161,7 +161,7 @@ will be created next in [Phase 2](#phase2).
     MACRO(CREATE_SUPPORTED_WORKLOADS_LIST)
         ...
         ...
-        # LIST(SUPPORTED_WORKLOADS_LIST "hello-world")
+        LIST(SUPPORTED_WORKLOADS_LIST "hello-world")
     ENDMACRO()
   ```
 
@@ -170,7 +170,7 @@ will be created next in [Phase 2](#phase2).
     MACRO(CREATE_SUPPORTED_WORKLOAD_LIBRARY_LIST)
         ...
         ...
-        LIST(APPEND SUPPORTED_WORKLOAD_LIBRARY_LIST "<workload_lib_name>")
+        # LIST(APPEND SUPPORTED_WORKLOAD_LIBRARY_LIST "<workload_lib_name>")
     ENDMACRO()
   ```
 
@@ -179,7 +179,7 @@ will be created next in [Phase 2](#phase2).
     MACRO(CREATE_SUPPORTED_WORKLOADS_LIST)
         ...
         ...
-        # LIST(SUPPORTED_WORKLOADS_LIST "hello_world")
+        LIST(SUPPORTED_WORKLOADS_LIST "hello_world")
     ENDMACRO()
   ```
 


### PR DESCRIPTION
Fixed replacement of <workload_id> and <workload_lib_name> in README.md
This notation should be commented out for before and uncommented out for after.

Signed-off-by: ikegawa-koshi <koshi.ikegawa.mf@hitachi.com>