### PR TITLE
Fixing issue with updating work order receipt

### DIFF
--- a/sdk/avalon_sdk/work_order_receipt/work_order_receipt.py
+++ b/sdk/avalon_sdk/work_order_receipt/work_order_receipt.py
@@ -135,7 +135,7 @@ class WorkOrderReceiptRequest():
         Returns:
         JSON RPC work order update receipt request of type dictionary
         """
-        data = update_data
+        data = json.dumps(update_data)
         if update_type in [ReceiptCreateStatus.PROCESSED.value,
                            ReceiptCreateStatus.COMPLETED.value]:
             # Work Order Receipt status is set to be completed or processed,


### PR DESCRIPTION
Pushing the fix for the issue #693 .

In the file work_order_receipt.py, in line 163, while creating the update receipt - we concatenate the update data to the work order receipt string. The issue is that if the receipt create status has the value FAILED, the update data will be a dictionary, and hence, concatenating it to the string will cause the enclave manager to crash. 

Have pushed code to convert this update data into a string so that it can be concatenated. 

Signed-off-by: Sourabh Natesh sourabh.natesh@intel.com
