### PR TITLE
Introduce inheritance to Graphene python worker class

### DIFF
--- a/tc/graphene/python_worker/Makefile
+++ b/tc/graphene/python_worker/Makefile
@@ -13,18 +13,19 @@
 # limitations under the License.
 
 PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/' | cut -b 1}
+WORKER_TYPE?=singleton
 
-WHEEL_FILE=dist/avalon_python_worker-0.6-py${PY_VERSION}-none-any.whl
+WHEEL_FILE=dist/${WORKER_TYPE}_avalon_python_worker-0.6-py${PY_VERSION}-none-any.whl
 
 all : $(WHEEL_FILE)
 
 $(WHEEL_FILE) : build_ext
 	@echo Build Distribution
-	python3 setup.py bdist_wheel
+	python3 setup_${WORKER_TYPE}.py bdist_wheel
 
 build_ext :
 	@echo Build build_ext
-	python3 setup.py build_ext
+	python3 setup_${WORKER_TYPE}.py build_ext
 
 build :
 	mkdir $@

--- a/tc/graphene/python_worker/avalon_worker/singleton_work_order_processor.py
+++ b/tc/graphene/python_worker/avalon_worker/singleton_work_order_processor.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import logging
+import argparse
+import json
+import avalon_worker.receive_request as receive_request
+import avalon_worker.crypto.worker_hash as worker_hash
+from avalon_worker.base_work_order_processor import BaseWorkOrderProcessor
+from avalon_worker.error_code import WorkerError
+import avalon_worker.utility.jrpc_utility as jrpc_utility
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+# -------------------------------------------------------------------------
+
+
+def main(args=None):
+    """
+    Graphene worker main function.
+    """
+    # Parse command line parameters.
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--bind', help='URI to listen for requests ', type=str)
+    parser.add_argument(
+        '--workload', help='JSON file which has workload module details',
+        type=str)
+    (options, remainder) = parser.parse_known_args(args)
+    # Get the workload JSON file name passed in command line.
+    if options.workload:
+        workload_json_file = options.workload
+    else:
+        # Default file name.
+        workload_json_file = "workloads.json"
+    # Create work order processor object.
+    wo_processor = SingletonWorkOrderProcessor(workload_json_file)
+    # Setup ZMQ channel to receive work order.
+    if options.bind:
+        zmq_bind_url = options.bind
+    else:
+        # default url. "*" means bind on all available interfaces.
+        zmq_bind_url = "tcp://*:7777"
+    zmq_socket = receive_request.ZmqSocket(zmq_bind_url, wo_processor)
+    logger.info("Listening for requests at url {}".format(zmq_bind_url))
+    # Start listener and wait for new request.
+    zmq_socket.start_zmq_listener()
+
+# -------------------------------------------------------------------------
+
+
+class SingletonWorkOrderProcessor(BaseWorkOrderProcessor):
+    """
+    Graphene work order processing class.
+    """
+
+# -------------------------------------------------------------------------
+
+    def __init__(self, workload_json_file):
+        super().__init__(workload_json_file)
+
+# -------------------------------------------------------------------------
+
+    def _process_work_order(self, input_json_str):
+        """
+        Process Avalon work order and returns JSON RPC response
+
+        Parameters :
+            input_json_str: JSON formatted work order request string.
+                            work order JSON is formatted as per
+                            TC spec ver 1.1 section 6.
+        Returns :
+            JSON RPC response containing result or error.
+        """
+        try:
+            input_json = json.loads(input_json_str)
+        except Exception as ex:
+            err_code = WorkerError.INVALID_PARAMETER_FORMAT_OR_VALUE
+            err_msg = "Error loading JSON: " + str(ex)
+            error_json = jrpc_utility.create_error_response(err_code,
+                                                            0,
+                                                            err_msg)
+            return json.dumps(error_json)
+        # Decrypt session key
+        encrypted_session_key_hex = \
+            input_json["params"]["encryptedSessionKey"]
+        encrypted_session_key = bytes.fromhex(encrypted_session_key_hex)
+        session_key = \
+            self.encrypt.decrypt_session_key(encrypted_session_key)
+        session_key_iv = None
+        if "sessionKeyIv" in input_json["params"]:
+            session_key_iv_hex = input_json["params"]["sessionKeyIv"]
+            session_key_iv = bytes.fromhex(session_key_iv_hex)
+        # Verify work order integrity
+        res = self._verify_work_order_request(input_json, session_key,
+                                              session_key_iv)
+        if res is False:
+            err_code = WorkerError.INVALID_PARAMETER_FORMAT_OR_VALUE
+            err_msg = "Work order integrity check failed"
+            logger.error(err_msg)
+            jrpc_id = input_json["id"]
+            error_json = jrpc_utility.create_error_response(err_code,
+                                                            jrpc_id,
+                                                            err_msg)
+            return json.dumps(error_json)
+        else:
+            logger.info("Verify work order request success")
+        # Decrypt work order inData
+        in_data_array = input_json["params"]["inData"]
+        self.encrypt.decrypt_work_order_data_json(in_data_array,
+                                                  session_key,
+                                                  session_key_iv)
+        # Process workload
+        workload_id_hex = input_json["params"]["workloadId"]
+        workload_id = bytes.fromhex(workload_id_hex).decode("UTF-8")
+        in_data_array = input_json["params"]["inData"]
+        result, out_data = self.wl_processor.execute_workload(workload_id,
+                                                              in_data_array)
+        # Generate work order response
+        if result is True:
+            output_json = self._create_work_order_response(input_json,
+                                                           out_data,
+                                                           session_key,
+                                                           session_key_iv)
+        else:
+            jrpc_id = input_json["id"]
+            err_code = WorkerError.INVALID_PARAMETER_FORMAT_OR_VALUE
+            err_msg = "Error processing work load"
+            output_json = jrpc_utility.create_error_response(err_code,
+                                                             jrpc_id,
+                                                             err_msg)
+        # return json str
+        output_json_str = json.dumps(output_json)
+        return output_json_str
+
+# -------------------------------------------------------------------------
+
+    def _encrypt_and_sign_response(self, session_key,
+                                   session_key_iv, output_json):
+        """
+        Encrypt outdata and compute worker signature.
+
+        Parameters :
+            session_key: Session key of the client which submitted
+                        this work order
+            session_key_iv: iv corresponding to teh session key
+            output_json: Pre-populated response json
+        Returns :
+            JSON RPC response with worker signature
+
+        """
+        # Encrypt outData
+        self.encrypt.encrypt_work_order_data_json(
+            output_json["result"]["outData"],
+            session_key,
+            session_key_iv)
+        # Compute worker signature
+        res_hash = worker_hash.WorkerHash().calculate_response_hash(
+            output_json["result"])
+        res_hash_sign = self.sign.sign_message(res_hash)
+        res_hash_sign_b64 = self.encrypt.byte_array_to_base64(res_hash_sign)
+        output_json["result"]["workerSignature"] = res_hash_sign_b64
+
+        return output_json
+
+# -------------------------------------------------------------------------
+
+
+main()

--- a/tc/graphene/python_worker/avalon_worker/wpe_work_order_processor.py
+++ b/tc/graphene/python_worker/avalon_worker/wpe_work_order_processor.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from avalon_worker.base_work_order_processor import BaseWorkOrderProcessor
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+# -------------------------------------------------------------------------
+
+
+class WPEWorkOrderProcessor(BaseWorkOrderProcessor):
+    """
+    Graphene work order processing class.
+    """
+
+# -------------------------------------------------------------------------
+
+    def __init__(self, workload_json_file):
+        super().__init__(workload_json_file)
+
+# -------------------------------------------------------------------------
+
+    def _process_work_order(self, input_json_str):
+        """
+        Process Avalon work order and returns JSON RPC response
+
+        Parameters :
+            input_json_str: JSON formatted work order request string.
+                            work order JSON is formatted as per
+                            TC spec ver 1.1 section 6.
+        Returns :
+            JSON RPC response containing result or error.
+        """
+        pass
+
+# -------------------------------------------------------------------------
+
+    def _encrypt_and_sign_response(self, session_key,
+                                   session_key_iv, output_json):
+        """
+        Encrypt outdata and compute worker signature.
+
+        Parameters :
+            session_key: Session key of the client which submitted
+                        this work order
+            session_key_iv: iv corresponding to teh session key
+            output_json: Pre-populated response json
+        Returns :
+            JSON RPC response with worker signature
+
+        """
+        pass
+
+# -------------------------------------------------------------------------
+
+
+main()

--- a/tc/graphene/python_worker/setup_singleton.py
+++ b/tc/graphene/python_worker/setup_singleton.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from setuptools import setup, find_packages
 import sys
 
 # This should only be run with python3
@@ -21,17 +22,16 @@ if sys.version_info[0] < 3:
     print('ERROR: must run with python3')
     sys.exit(1)
 
-from setuptools import setup, find_packages
 
-setup(name='avalon_python_worker',
+setup(name='singleton_avalon_python_worker',
       version=0.6,
-      description='Avalon python worker for Graphene ',
+      description='Avalon singleton python worker for Graphene ',
       author='Hyperledger Avalon',
       url='https://github.com/hyperledger/avalon',
       packages=find_packages(),
       data_files=[],
       entry_points={
           'console_scripts':
-          ['wo-processor = avalon_worker.work_order_processor:main']
+          ['wo-processor = avalon_worker.singleton_work_order_processor:main']
       }
       )


### PR DESCRIPTION
- Create a base python worker
- Make existing worker to derive from base and rename it as SingletonPythonWorker
- Create a new class WPEPythonWorker deriving from base worker
- Update Makefile to handle both types of workers

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>