### PR TITLE
Fix underfined error in EPID attestation

### DIFF
--- a/enclave_manager/avalon_enclave_manager/attestation/epid_attestation.py
+++ b/enclave_manager/avalon_enclave_manager/attestation/epid_attestation.py
@@ -18,6 +18,8 @@ import random
 import json
 import importlib
 
+from ssl import SSLError
+from requests.exceptions import HTTPError, Timeout
 import avalon_enclave_manager.ias_client as ias_client
 from avalon_enclave_manager.attestation.attestation import Attestation
 from avalon_enclave_manager.enclave_type import EnclaveType


### PR DESCRIPTION
- Added missing imports needed for SSLError, HTTPError, Timeout

Signed-off-by: manju956 <manjunath.a.c@intel.com>