### PR TITLE
Fix Ethereum connector asyncio loop

### DIFF
--- a/blockchain_connector/ethereum/ethereum_connector/ethereum_connector.py
+++ b/blockchain_connector/ethereum/ethereum_connector/ethereum_connector.py
@@ -94,7 +94,7 @@ class EthereumConnector(BaseConnector):
 
         try:
             daemon = EventProcessor(self._config)
-            asyncio.get_event_loop().run_until_complete(daemon.start(
+            asyncio.get_event_loop().create_task(daemon.start(
                 listener,
                 workorder_event_handler_func,
                 account=None,


### PR DESCRIPTION
Replace nested run_until_complete() with create_task() in Ethereum
connector. The evet loop once started cannot be started again from
within a coroutine.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>