### PR TITLE
Fix 'RuntimeError: This event loop is already running' bug of asyncio in ethereum-ganache model

### DIFF
--- a/blockchain_connector/docker/Dockerfile-ethereum
+++ b/blockchain_connector/docker/Dockerfile-ethereum
@@ -122,6 +122,9 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+# Required to create nested asyncio loop
+RUN pip3 install nest_asyncio
+
 # Installing web3 for ethereum
 RUN pip3 install --upgrade setuptools json-rpc web3 py-solc-x nose2
 

--- a/blockchain_connector/ethereum/ethereum_connector/ethereum_connector.py
+++ b/blockchain_connector/ethereum/ethereum_connector/ethereum_connector.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import asyncio
+import nest_asyncio
 
 from avalon_sdk.connector.blockchains.ethereum.ethereum_listener \
     import BlockchainInterface, EventProcessor
@@ -92,6 +93,7 @@ class EthereumConnector(BaseConnector):
         # Listening only for workOrderSubmitted event now
         listener = w3.newListener(contract, "workOrderSubmitted")
 
+        nest_asyncio.apply()
         try:
             daemon = EventProcessor(self._config)
             asyncio.get_event_loop().run_until_complete(daemon.start(


### PR DESCRIPTION
fix 'RuntimeError: This event loop is already running' bug of asyncio in ethereum-ganache model

Signed-off-by: PlyTools <qianren1024@gmail.com>