### PR TITLE
Python worker manifest changes for TOML parsing

### DIFF
--- a/examples/graphene_apps/cppopenvino/graphene/openvinowl.manifest
+++ b/examples/graphene_apps/cppopenvino/graphene/openvinowl.manifest
@@ -1,7 +1,7 @@
 sgx.allow_file_creation = 1
-sgx.enclave_size = 2G
+sgx.enclave_size = "2G"
 sgx.thread_num = 16 
-sgx.file_check_policy = allow_all_but_log
+sgx.file_check_policy = "allow_all_but_log"
 
 # eventfd used by C++ ZMQ library.
 sys.insecure__allow_eventfd = 1

--- a/tc/graphene/python_worker/graphene_sgx/manifest/collect2.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/collect2.manifest
@@ -1,3 +1,3 @@
-sgx.enclave_size = 256M
+sgx.enclave_size = "256M"
 # Uses tmp directory
-sgx.allowed_files.tmp = file:/tmp
+sgx.allowed_files.tmp = "file:/tmp"

--- a/tc/graphene/python_worker/graphene_sgx/manifest/gcc.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/gcc.manifest
@@ -1,3 +1,3 @@
-sgx.enclave_size = 256M
+sgx.enclave_size = "256M"
 # Uses tmp directory
-sgx.allowed_files.tmp = file:/tmp
+sgx.allowed_files.tmp = "file:/tmp"

--- a/tc/graphene/python_worker/graphene_sgx/manifest/ld.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/ld.manifest
@@ -1,3 +1,3 @@
-sgx.enclave_size = 256M
+sgx.enclave_size = "256M"
 # Uses tmp directory
-sgx.allowed_files.tmp = file:/tmp
+sgx.allowed_files.tmp = "file:/tmp"

--- a/tc/graphene/python_worker/graphene_sgx/manifest/python.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/python.manifest
@@ -3,13 +3,17 @@ sgx.allow_file_creation = 1
 # size must be specified upfront. If Python worker needs more
 # virtual memory than the enclave size, Graphene will not be able to
 # allocate it.
-sgx.enclave_size = 256M
+sgx.enclave_size = "256M"
 sgx.thread_num = 8
-sgx.file_check_policy = allow_all_but_log
+sgx.file_check_policy = "allow_all_but_log"
 
 # Request remote attestation functionality from Graphene
-sgx.remote_attestation = 1
+# For EPID based remote attestaion, ra_client_spid and ra_client_linkable
+# configs must be filled with proper values.
+# For DCAP/ECDSA based attestation, ``ra_client_spid`` must be an empty string.
+# All the below configs need to be enabled to request remote attestation
+#sgx.remote_attestation = 1
 
 # Specify your SPID and linkable/unlinkable attestation policy
-#sgx.ra_client_spid =
+#sgx.ra_client_spid = ""
 #sgx.ra_client_linkable =

--- a/tc/graphene/python_worker/graphene_sgx/manifest/sh.manifest
+++ b/tc/graphene/python_worker/graphene_sgx/manifest/sh.manifest
@@ -1,1 +1,1 @@
-sgx.enclave_size = 256M
+sgx.enclave_size = "256M"


### PR DESCRIPTION
- the values corresponding to keys in manifest files are
  enclosed in quotes to enable toml parsing in grapene

Signed-off-by: manju956 <manjunath.a.c@intel.com>